### PR TITLE
First pass at basic /registry/<package>.rss route.

### DIFF
--- a/facets/registry/index.js
+++ b/facets/registry/index.js
@@ -1,0 +1,88 @@
+var path = require('path');
+var internals = {};
+
+exports.register = function Regsitry (facet, options, next) {
+
+  facet.views({
+    engines: { hbs: require('handlebars') },
+    path: path.resolve(__dirname, 'templates')
+  });
+
+  facet.route({
+    path: "/package/{package}/{version?}",
+    method: "GET",
+    handler: require('./show-package')
+  });
+
+  facet.route({
+    path: "/package/{package}.rss",
+    method: "GET",
+    handler: require('./show-feed')
+  });
+
+  facet.route({
+    path: "/browse/{p*}",
+    method: "GET",
+    handler: require('./show-browse')
+  })
+
+  facet.route({
+    path: "/keyword/{kw}",
+    method: "GET",
+    handler: function (request, reply) {
+      return reply.redirect('/browse/keyword/' + request.params.kw).code(301);
+    }
+  });
+
+  facet.route({
+    path: "/recent-authors/{since?}",
+    method: "GET",
+    handler: require('./show-recent-authors')
+  });
+
+  facet.route({
+    path: "/star",
+    method: "POST",
+    config: {
+      handler: require('./show-star'),
+      plugins: {
+        crumb: {
+          source: 'payload',
+          restful: true
+        }
+      }
+    }
+  });
+
+  facet.route({
+    path: "/star",
+    method: "GET",
+    config: {
+      handler: require('./show-star'),
+      auth: {
+        mode: 'required'
+      },
+      plugins: { 'hapi-auth-cookie': {
+        redirectTo: '/login'
+      }}
+    }
+  });
+
+  facet.route({
+    path: "/search",
+    method: "GET",
+    handler: require('./show-search')(options)
+  });
+
+  facet.route({
+    method: '*',
+    path: '/{p*}',
+    handler: require('./show-fallback')
+  });
+
+  next();
+};
+
+exports.register.attributes = {
+  pkg: require('./package.json')
+};

--- a/facets/registry/show-feed.js
+++ b/facets/registry/show-feed.js
@@ -1,0 +1,117 @@
+var Hapi = require('hapi'),
+    presentPackage = require('./presenters/package'),
+    log = require('bole')('registry-package'),
+    commaIt = require('number-grouper'),
+    uuid = require('node-uuid'),
+    metrics = require('../../adapters/metrics')();
+
+module.exports = function (request, reply) {
+  var getPackage = request.server.methods.registry.getPackage,
+      getBrowseData = request.server.methods.registry.getBrowseData,
+      addMetric = metrics.addMetric,
+      addLatencyMetric = metrics.addPageLatencyMetric;
+
+  var timer = { start: Date.now() };
+
+  if (request.params.version) {
+    reply.redirect('/package/' + request.params.package)
+  }
+
+  var opts = {
+    user: request.auth.credentials
+  }
+
+  opts.name = request.params.package
+
+  if (opts.name !== encodeURIComponent(opts.name)) {
+    opts.errorType = 'invalid';
+    opts.errId = uuid.v1();
+
+    log.error(opts.errId + ' ' + Hapi.error.badRequest('Invalid Package Name'), opts.name);
+
+    return reply.view('error', opts).code(400)
+  }
+
+  getPackage(opts.name, function (er, pkg) {
+
+    if (er || pkg.error) {
+      opts.errorType = 'notFound';
+      opts.errId = uuid.v1();
+
+      log.error(opts.errId + ' ' + Hapi.error.notFound('Package Not Found ' + opts.name), er || pkg.error);
+
+      return reply.view('error', opts).code(404)
+    }
+
+    if (pkg.time && pkg.time.unpublished) {
+      // reply with unpublished package page
+      var t = pkg.time.unpublished.time
+      pkg.unpubFromNow = require('moment')(t).format('ddd MMM DD YYYY HH:mm:ss Z');
+
+      opts.package = pkg;
+
+      timer.end = Date.now();
+      addLatencyMetric(timer, 'showUnpublishedPackage');
+
+      addMetric({ name: 'showPackageFeed', package: request.params.package });
+      return reply.view('unpublished-package-page', opts);
+    }
+
+    timer.start = Date.now();
+    getBrowseData('depended', opts.name, 0, 1000, function (er, dependents) {
+      timer.end = Date.now();
+      addMetric({
+        name: 'latency',
+        value: timer.end - timer.start,
+        type: 'couchdb',
+        browse: ['depended', opts.name, 0, 1000].join(', ')
+      });
+
+      if (er) {
+        opts.errId = uuid.v1();
+        opts.errorType = 'internal';
+        log.error(opts.errId + ' ' + Hapi.error.internal('Unable to get depended data from couch for ' + opts.name), er);
+
+        return reply.view('error', opts).code(500);
+      }
+
+      pkg.dependents = dependents;
+
+      presentPackage(pkg, function (er, pkg) {
+        if (er) {
+          opts.errId = uuid.v1();
+          opts.errorType = 'internal';
+          log.error(opts.errId + ' ' + Hapi.error.internal('An error occurred with presenting package ' + opts.name), er);
+          return reply.view('error', opts).code(500);
+        }
+
+        opts.package = pkg;
+        opts.title = pkg.name;
+
+        buildRss();
+
+        function buildRss(){
+          var RSS = require('rss');
+          var feed = new RSS({
+            title: opts.package.name,
+            description: opts.package.description,
+            feed_url: '/package/' + opts.package.name + '/feed',
+            site_url: '/',
+            author: opts.package._npmUser.name
+          });
+
+          Object.keys(opts.package.versions).forEach(function(semver){
+            var version = opts.package.versions[semver];
+            feed.item({
+              title: version.name + "@" + semver,
+              guid: version.name + "@" + semver,
+              date: opts.package.time[semver]
+            });
+          });
+
+          return reply(feed.xml('\t')).type('application/rss+xml');
+        }
+      })
+    })
+  })
+}

--- a/facets/registry/test/feed.js
+++ b/facets/registry/test/feed.js
@@ -1,0 +1,47 @@
+var Lab = require('lab'),
+    describe = Lab.experiment,
+    before = Lab.before,
+    it = Lab.test,
+    expect = Lab.expect;
+
+var server, p, source, cookieCrumb;
+
+// prepare the server
+before(function (done) {
+  server = require('./fixtures/setupServer')(done);
+
+  server.ext('onPreResponse', function (request, next) {
+    source = request.response.source;
+    next();
+  });
+});
+
+describe('Retreiving package feed from the registry', function () {
+  it('gets an rss feed for package', function (done) {
+    var pkgName = 'fake';
+
+    var options = {
+      url: '/package/' + pkgName + '.rss'
+    }
+    server.inject(options, function (resp) {
+      var header = resp.headers['set-cookie'];
+      expect(header.length).to.equal(1);
+
+      expect(resp.statusCode).to.equal(200);
+
+      var titleString = '<title><![CDATA[fake]]></title>';
+      var titleStringIndex = source.indexOf(titleString);
+      expect(titleStringIndex).to.be.greaterThan(-1);
+
+      var itemTitleString = '<title><![CDATA[fake@0.0.1]]></title>';
+      var itemTitleStringIndex = source.indexOf(itemTitleString)
+      expect(itemTitleStringIndex).to.be.greaterThan(titleStringIndex);
+
+      var guidString = '<guid isPermaLink="false">fake@0.0.1</guid>';
+      var guidStringIndex = source.indexOf(guidString);
+      expect(guidStringIndex).to.be.greaterThan(itemTitleStringIndex);
+
+      done();
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "repl-client": "~0.3.0",
     "replify": "~1.2.0",
     "request": "^2.51.0",
+    "rss": "^1.1.1",
     "sanitizer": "^0.1.1",
     "schemeless": "^1.0.0",
     "scooter": "^2.0.1",

--- a/test/registry.js
+++ b/test/registry.js
@@ -1,0 +1,53 @@
+var Lab = require('lab')
+  , describe = Lab.experiment
+  , before = Lab.before
+  , it = Lab.test
+  , expect = Lab.expect;
+
+var Hapi = require('hapi'),
+    registry = require('../facets/registry'),
+    metricsConfig = require('../config').metrics,
+    MetricsClient = require('../adapters/metrics');
+
+var server;
+
+before(function (done) {
+  var metrics = new MetricsClient(metricsConfig);
+
+  server = Hapi.createServer();
+  server.pack.register(require('hapi-auth-cookie'), function (err) {
+    if (err) throw err;
+
+    server.auth.strategy('session', 'cookie', 'try', {
+      password: '12345'
+    });
+
+    server.pack.register(registry, done);
+  });
+});
+
+describe('Registry is routing properly', function () {
+  it('calls all the right routes', function (done) {
+    var table = server.table();
+    expect(table).to.have.length(9);
+
+    var paths = table.map(function (route) {
+      var obj = {
+        path: route.path,
+        method: route.method
+      }
+      return obj;
+    });
+
+    expect(paths).to.include({ path: '/search', method: 'get' });
+    expect(paths).to.include({ path: '/keyword/{kw}', method: 'get' });
+    expect(paths).to.include({ path: '/package/{package}/{version?}', method: 'get' });
+    expect(paths).to.include({ path: '/browse/{p*}', method: 'get' });
+    expect(paths).to.include({ path: '/recent-authors/{since?}', method: 'get' });
+    expect(paths).to.include({ path: '/star', method: 'get' });
+    expect(paths).to.include({ path: '/star', method: 'post' });
+    expect(paths).to.include({ path: '/{p*}', method: '*' });
+
+    done();
+  })
+})


### PR DESCRIPTION
Solution for #121 

This is a first pass, mostly to try playing with newww. It's a feature I think would be really useful. Not sure long term support or issues with it, but here's a first blush.

The registry facet gets a new route, `/registry/{package}.rss`, that returns an rss xml with reach release as an `<item>`. Long term, I'd like to see options for "deep" notifications, generating items for each dependency update as well. This way, you could subscribe to the "master" rss feed for your package, and know when your deps are updated to run tests or re-release or whatever.