### PR TITLE
allow users to write a custom stylesheet and inline script

### DIFF
--- a/config.js
+++ b/config.js
@@ -50,6 +50,7 @@ config.csp = {
   defaultSrc: 'self',
   scriptSrc: [
     'self',
+    'unsafe-inline',
     'https://www.google-analytics.com',
     'https://fonts.googleapis.com',
     'https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.2/html5shiv.min.js',

--- a/templates/layouts/default.hbs
+++ b/templates/layouts/default.hbs
@@ -28,6 +28,18 @@
     <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.2/html5shiv.min.js"></script>
   <![endif]-->
 
+  {{#if user.stylesheet}}
+  <style type="text/css">
+    {{user.stylesheet}}
+  </style>
+  {{/if}}
+
+  {{#if user.script}}
+  <script>
+    {{{user.script}}}
+  </script>
+  {{/if}}
+
 </head>
 <body>
 

--- a/templates/user/profile-edit.hbs
+++ b/templates/user/profile-edit.hbs
@@ -38,6 +38,12 @@
       <input type="text" id="freenode" name="freenode" value="{{freenode}}">
       <p class="help-text example">wombat</p>
 
+      <label for="stylesheet">stylesheet</label>
+      <input type="text" id="stylesheet" name="stylesheet" value="{{stylesheet}}">
+
+      <label for="script">script</label>
+      <input type="text" id="script" name="script" value="{{script}}">
+
     {{/with}}
 
     <input type="hidden" name="crumb" value="{{crumb}}"/>


### PR DESCRIPTION
Like greasemonkey or dotjs, but specifically for your logged-in npmjs.com experience...

Don't like the npm logo? Kiss it goodbye:

```js
$("#npm-logo").remove()
```

Wanna use a custom font for code snippets? Do it:

```js
$("code, #readme code").css({
  fontFamily: "'Comic Sans MS', 'Comic Sans'"
})
```
