### PR TITLE
Fixes :hover on links in the right sidebar.

### DIFF
--- a/assets/styles/layout.styl
+++ b/assets/styles/layout.styl
@@ -136,9 +136,9 @@ ul.columnar
   font-size 16px
   color greigh3
 
-  &:hover
-    a
-      color npmred !important
+  
+  a:hover
+    color npmred !important
 
   p
     padding 14px


### PR DESCRIPTION
This change makes it so that links inside of .box in the right sidebar on package's page turn "npmred" on `.box a:hover` and not on `.box:hover` which causes all links in the parent .box to be turned "npmred" which, imo is bad UX.