### PR TITLE
Fix submit button style on the private-npm page

### DIFF
--- a/assets/scripts/private-npm-beta.js
+++ b/assets/scripts/private-npm-beta.js
@@ -4,7 +4,8 @@ module.exports = function() {
       hbspt.forms.create({
         portalId: '419727',
         formId: 'd9ba17d5-606e-456d-a703-733c67f5e708',
-        target: '#private-module-signup-form'
+        target: '#private-module-signup-form',
+        submitButtonClass: 'primary large'
       })
     }
   })


### PR DESCRIPTION
I think this is the issue mentioned in #296. What I did was override the submit button class to remove the `hs-button` class, which was making the button blue.