### PR TITLE
Fixes line-height for h1 in readme, instead of overflow 'hack'.

### DIFF
--- a/assets/styles/readme.styl
+++ b/assets/styles/readme.styl
@@ -5,9 +5,8 @@
     margin 0
     padding 0
     text-align left
-    line-height 1.2
+    line-height 1.25
     @extend .ellipsis
-    overflow-y hidden
 
   hgroup
     margin 20px 0


### PR DESCRIPTION
> Removes scrolling due to to small line-height. This is an alternative solution
to #350 and #352, as adding overflow hidden doesn't solve the problem, but
potentially cuts the lower part of the font.

I added this PR as I feel `overflow-y: hidden` ( #352 ) is not the correct solution to the problems described in #350 and #378. Adding `overflow-y: hidden` will potentially just cut the lower part of the font. The real issue here is the line-height. The line height is too small in contrast to the font-size. You could also potentially remove the line-height, but as the font is loaded lazily, you would get a "temporary moment of ugliness" and a site jump when the font is loaded.