### PR TITLE
Adds style for tables in readme section

### DIFF
--- a/assets/styles/readme.styl
+++ b/assets/styles/readme.styl
@@ -31,6 +31,13 @@
   p, li
     font-size 16px
 
+  th
+    font-weight bold
+
+  td, th
+    padding 0 5px
+    background #F5F5F5
+
   p
     margin 15px 0
 


### PR DESCRIPTION
The tables in the READMEs looked a bit off without any styling. I tried to add a style similar to the code block styles, with a #f5f5f5 background and some padding.

I don't know what kind of style you are going for here. Do you think the background looks OK, or should it simply have borders or no background at all?

---

### Before
![tablebefore](https://cloud.githubusercontent.com/assets/606374/5377278/81e7763e-8080-11e4-9915-28951d1edb82.png)
---
### After
![tableafter](https://cloud.githubusercontent.com/assets/606374/5377280/8b820998-8080-11e4-97d9-bffab276f142.png)
