### PR TITLE
Adds support for anchor links and adds heading anchor links

### DIFF
--- a/assets/styles/readme.styl
+++ b/assets/styles/readme.styl
@@ -47,6 +47,20 @@
   pre
     overflow-x auto
 
+  h2,h3,h4,h5
+    position relative
+    &:hover .package-header-link
+      visibility visible
+
+  .package-header-link
+    position absolute
+    padding 0 10px
+    left -30px
+    text-decoration none
+    visibility hidden
+    i
+      font-size 0.7em
+
   .superfluous
     display none
 

--- a/facets/registry/presenters/package.js
+++ b/facets/registry/presenters/package.js
@@ -10,6 +10,17 @@ var marked = require('marked'),
     cheerio = require('cheerio'),
     log = require('bole')('registry-package-presenter');
 
+var renderer = new marked.Renderer();
+var heading = renderer.heading;
+renderer.heading = function(text, level, raw) {
+  var slug = raw.toLowerCase().replace(/[^\w]+/g, '-'),
+      h = heading.call(this, text, level, raw),
+      closingTag = '</h' + level + '>',
+      link = '<a href="#' + slug + '" class="package-header-link"><i class="icon-website"></i></a>';
+
+  return h.replace(closingTag, link + closingTag);
+};
+
 module.exports = function package (data, cb) {
 
   if (data.time && data['dist-tags']) {
@@ -158,7 +169,7 @@ function parseReadme (data, cb) {
       (data.readmeFilename.match(/\.(m?a?r?k?d?o?w?n?)$/i) &&
        !data.readmeFilename.match(/\.$/))) {
     try {
-      p = marked.parse(data.readme);
+      p = marked.parse(data.readme, {renderer: renderer});
     } catch (er) {
       return cb(new Error('error parsing readme'));
     }

--- a/facets/registry/presenters/package.js
+++ b/facets/registry/presenters/package.js
@@ -110,7 +110,9 @@ module.exports = function package (data, cb) {
 function urlPolicy (pkgData) {
   var gh = pkgData && pkgData.repository ? ghurl(pkgData.repository.url) : null
   return function (u, effect, ltype, hints) {
-    if (u.scheme_ === null && u.domain_ === null) {
+    if (u.scheme_ === null && u.domain_ === null && u.path_ === null) {
+      u = { hash: u.fragment_ }
+    } else if (u.scheme_ === null && u.domain_ === null) {
       if (!gh) return null
       // temporary fix for relative links in github readmes, until a more general fix is needed
       var v = url.parse(gh)

--- a/facets/registry/presenters/package.js
+++ b/facets/registry/presenters/package.js
@@ -11,14 +11,12 @@ var marked = require('marked'),
     log = require('bole')('registry-package-presenter');
 
 var renderer = new marked.Renderer();
-var heading = renderer.heading;
 renderer.heading = function(text, level, raw) {
   var slug = raw.toLowerCase().replace(/[^\w]+/g, '-'),
-      h = heading.call(this, text, level, raw),
-      closingTag = '</h' + level + '>',
       link = '<a href="#' + slug + '" class="package-header-link"><i class="icon-website"></i></a>';
 
-  return h.replace(closingTag, link + closingTag);
+  return '<h' + level + ' id="' + this.options.headerPrefix + slug + '">' +
+                text + link + '</h' + level + '>\n';
 };
 
 module.exports = function package (data, cb) {

--- a/test/fixtures/fake.json
+++ b/test/fixtures/fake.json
@@ -88,7 +88,7 @@
     "fake",
     "omg so fake"
   ],
-  "readme": "# fake\n\nNot actually a package. In fact, it's not even real. [Here's a link](http://somelink.com/somwhere).\n\n[And here's a relative link](somewhere.md#bugs)\nAnd here comes some prose\n\n# Another H1\n\n<p><a href=\"https://travis-ci.org/senchalabs/connect\"><img src=\"https://img.shields.io/travis/senchalabs/connect.svg?style=flat\" alt=\"Build Status\"></a></p>\n\n<a href=\"https://nodei.co/npm/request/\"><img src=\"https://nodei.co/npm/request.png?downloads=true&amp;downloadRank=true&amp;stars=true\" alt=\"NPM\"></a>",
+  "readme": "# fake\n\nNot actually a package. In fact, it's not even real. [Here's a link](http://somelink.com/somwhere).\n\n[And here's a relative link](somewhere.md#bugs)\nAnd here is a [internal link](#hash-link)\nAnd here comes some prose\n\n# Another H1\n\n<p><a href=\"https://travis-ci.org/senchalabs/connect\"><img src=\"https://img.shields.io/travis/senchalabs/connect.svg?style=flat\" alt=\"Build Status\"></a></p>\n\n<a href=\"https://nodei.co/npm/request/\"><img src=\"https://nodei.co/npm/request.png?downloads=true&amp;downloadRank=true&amp;stars=true\" alt=\"NPM\"></a>",
   "readmeFilename": "README.md",
   "homepage": "https://github.com/boom/fake",
   "bugs": {

--- a/test/registry/package.js
+++ b/test/registry/package.js
@@ -98,6 +98,11 @@ describe('Modifying the package before sending to the template', function () {
     done()
   });
 
+  it('allows internal anchor links', function (done) {
+    expect(p.readme).to.include('href="#hash-link"')
+    done();
+  });
+
   it('turns relative URLs into real URLs', function (done) {
     expect(p.readme).to.include('/blob/master')
     done();

--- a/test/registry/package.js
+++ b/test/registry/package.js
@@ -108,6 +108,11 @@ describe('Modifying the package before sending to the template', function () {
     done();
   });
 
+  it('adds anchor links to headings', function (done) {
+    expect(p.readme).to.include('class="package-header-link"')
+    done();
+  });
+
   it('includes the dependencies', function (done) {
     expect(p.dependencies).to.exist
     done();


### PR DESCRIPTION
_Congratulations on the new site, by the way!_

Anchor links (#some-slug) didn't seem to pass the sanitation step, so I added a conditional to support it.

This PR also adds "Github style" heading anchor links. This way people can refer to specific part of the README (a anchor-icon is visible on heading hover). See image below.

I don't know if you are interested in this feature, but it's something I've been missing in the readmes, so I thought I'd give it a try.

![anchorlinks](https://cloud.githubusercontent.com/assets/606374/5381331/6e63c412-80a0-11e4-858a-208babcc590d.png)
