### PR TITLE
Ensuring license URL is valid, adding CC0 url. Fixes #440

### DIFF
--- a/facets/registry/presenters/package.js
+++ b/facets/registry/presenters/package.js
@@ -8,7 +8,8 @@ var marked = require('marked'),
     similarity = require('similarity'),
     gh = require('github-url-to-object'),
     cheerio = require('cheerio'),
-    log = require('bole')('registry-package-presenter');
+    log = require('bole')('registry-package-presenter'),
+    osiLicenses = require('osi-licenses');
 
 module.exports = function package (data, cb) {
 
@@ -266,19 +267,11 @@ function getOssLicenseUrlFromName (name) {
     'lgplv2': 'LGPL-2.1'
   }
 
-  /**
-   * Generate this list by visiting http://opensource.org/licenses/alphabetical and executing the
-   * following in your browser's console:
-   *
-   * jQuery.unique(jQuery('#block-system-main li a[href^=/licenses/]').map(function() {return jQuery(this).attr('href').substr(10);}))
-   */
-  var validOSSLicenses = ["MS-PL", "Zlib", "MS-RL", "AFL-3.0", "MIT", "APL-1.0", "Motosoto", "APSL-2.0", "MPL-2.0", "AAL", "Multics", "BSD-2-Clause", "NASA-1.3", "CECILL-2.1", "NTP", "CDDL-1.0", "Naumen", "CUA-OPL-1.0", "NGPL", "EPL-1.0", "Nokia", "EFL-2.0", "NPOSL-3.0", "EUPL-1.1", "OCLC-2.0", "Frameworx-1.0", "OFL-1.1", "GPL-2.0", "OGTSL", "LGPL-2.1", "OSL-3.0", "HPND", "PHP-3.0", "IPA", "PostgreSQL", "LPPL-1.3c", "Python-2.0", "MirOS", "CNRI-Python", "Apache-2.0", "QPL-1.0", "BSD-3-Clause", "RPSL-1.0", "CATOSL-1.1", "RPL-1.5", "EUDatagrid", "RSCPL", "Entessa", "SimPL-2.0", "AGPL-3.0", "Sleepycat", "LGPL-3.0", "SPL-1.0", "LPL-1.02", "Watcom-1.0", "Artistic-2.0", "NCSA", "CPAL-1.0", "VSL-1.0", "Fair", "IPL-1.0", "ZPL-2.0", "Xnet", "WXwindows", "W3C", "ISC", "GPL-3.0", "ECL-2.0", "BSL-1.0"];
-
   if (licenseMap[name.toLowerCase()]) {
     name = licenseMap[name.toLowerCase()];
   }
 
-  if (validOSSLicenses.indexOf(name) != -1) {
+  if (osiLicenses[name]) {
     return base + name;
   } else {
     return null;

--- a/facets/registry/presenters/package.js
+++ b/facets/registry/presenters/package.js
@@ -9,7 +9,9 @@ var marked = require('marked'),
     gh = require('github-url-to-object'),
     cheerio = require('cheerio'),
     log = require('bole')('registry-package-presenter'),
-    osiLicenses = require('osi-licenses');
+    osiLicenses = Object.keys(require('osi-licenses')).map(function(license) {
+      return license.toLowerCase();
+    });
 
 module.exports = function package (data, cb) {
 
@@ -271,7 +273,7 @@ function getOssLicenseUrlFromName (name) {
     name = licenseMap[name.toLowerCase()];
   }
 
-  if (osiLicenses[name]) {
+  if (osiLicenses[name.toLowerCase()]) {
     return base + name;
   } else {
     return null;

--- a/facets/registry/presenters/package.js
+++ b/facets/registry/presenters/package.js
@@ -273,7 +273,7 @@ function getOssLicenseUrlFromName (name) {
     name = licenseMap[name.toLowerCase()];
   }
 
-  if (osiLicenses[name.toLowerCase()]) {
+  if (osiLicenses.indexOf(name.toLowerCase()) != -1) {
     return base + name;
   } else {
     return null;

--- a/facets/registry/presenters/package.js
+++ b/facets/registry/presenters/package.js
@@ -237,7 +237,7 @@ function setLicense (data, v) {
     if (parsedLicense && parsedLicense.protocol && parsedLicense.protocol.match(/^https?:$/)) {
       data.license.url = data.license.type = parsedLicense.href
     } else {
-      data.license.url = getOssLicenseUrlFromName(license)
+      data.license.url = getOssLicenseUrlFromName(license) || getAlternativeLicenseUrlFromName(license)
       data.license.name = license
     }
   }
@@ -266,9 +266,35 @@ function getOssLicenseUrlFromName (name) {
     'lgplv2': 'LGPL-2.1'
   }
 
-  return licenseMap[name.toLowerCase()]
-         ? base + licenseMap[name.toLowerCase()]
-         : base + name
+  /**
+   * Generate this list by visiting http://opensource.org/licenses/alphabetical and executing the
+   * following in your browser's console:
+   *
+   * jQuery.unique(jQuery('#block-system-main li a[href^=/licenses/]').map(function() {return jQuery(this).attr('href').substr(10);}))
+   */
+  var validOSSLicenses = ["MS-PL", "Zlib", "MS-RL", "AFL-3.0", "MIT", "APL-1.0", "Motosoto", "APSL-2.0", "MPL-2.0", "AAL", "Multics", "BSD-2-Clause", "NASA-1.3", "CECILL-2.1", "NTP", "CDDL-1.0", "Naumen", "CUA-OPL-1.0", "NGPL", "EPL-1.0", "Nokia", "EFL-2.0", "NPOSL-3.0", "EUPL-1.1", "OCLC-2.0", "Frameworx-1.0", "OFL-1.1", "GPL-2.0", "OGTSL", "LGPL-2.1", "OSL-3.0", "HPND", "PHP-3.0", "IPA", "PostgreSQL", "LPPL-1.3c", "Python-2.0", "MirOS", "CNRI-Python", "Apache-2.0", "QPL-1.0", "BSD-3-Clause", "RPSL-1.0", "CATOSL-1.1", "RPL-1.5", "EUDatagrid", "RSCPL", "Entessa", "SimPL-2.0", "AGPL-3.0", "Sleepycat", "LGPL-3.0", "SPL-1.0", "LPL-1.02", "Watcom-1.0", "Artistic-2.0", "NCSA", "CPAL-1.0", "VSL-1.0", "Fair", "IPL-1.0", "ZPL-2.0", "Xnet", "WXwindows", "W3C", "ISC", "GPL-3.0", "ECL-2.0", "BSL-1.0"];
+
+  if (licenseMap[name.toLowerCase()]) {
+    name = licenseMap[name.toLowerCase()];
+  }
+
+  if (validOSSLicenses.indexOf(name) != -1) {
+    return base + name;
+  } else {
+    return null;
+  }
+}
+
+function getAlternativeLicenseUrlFromName (name) {
+
+  var alternativeLicenseMap = {
+    'cc0': 'http://creativecommons.org/publicdomain/zero/1.0/',
+    'cc0-1.0': 'http://creativecommons.org/publicdomain/zero/1.0/'
+  };
+
+  if (alternativeLicenseMap[name.toLowerCase()]) {
+    return alternativeLicenseMap[name.toLowerCase()];
+  }
 }
 
 function gravatarPerson (p) {

--- a/facets/registry/presenters/package.js
+++ b/facets/registry/presenters/package.js
@@ -294,6 +294,8 @@ function getAlternativeLicenseUrlFromName (name) {
 
   if (alternativeLicenseMap[name.toLowerCase()]) {
     return alternativeLicenseMap[name.toLowerCase()];
+  } else {
+    return null;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "npm2es": "git://github.com/npm/npm2es",
     "numbat-emitter": "^1.0.0",
     "number-grouper": "0.0.1",
+    "osi-licenses": "^0.1.0",
     "parse-link-header": "^0.2.0",
     "pkgs": "^1.1.0",
     "redis": "^0.12.1",

--- a/templates/registry/package-page.hbs
+++ b/templates/registry/package-page.hbs
@@ -56,7 +56,11 @@
 
     {{#if license}}
       <li>
-        <a href="{{license.url}}">{{license.name}}</a> <span> license</span>
+        {{#if license.url}}
+          <a href="{{license.url}}">{{license.name}}</a> <span> license</span>
+        {{else}}
+          {{license.name}} <span> license</span>
+        {{/if}}
       </li>
     {{/if}}
 


### PR DESCRIPTION
Sets the license url to null if the license isn't listed on opensource.org or in the alternative licenses list I added (currently just CC0).

Updated the template to just display the name of the license without a link if no URL is available.

On my laptop, 11 tests failed both before and after this commit, so no new failures. The VM is still downloading but I'm 80% sure that it will work ;)