### PR TITLE
clearer use of 'private npm' copy

### DIFF
--- a/routes.js
+++ b/routes.js
@@ -74,6 +74,12 @@ var unauthenticatedRoutes = [
     method: "GET",
     handler: require('./facets/company/show-homepage')
   },{
+    path: "/private-npm",
+    method: "GET",
+    handler: function(request, reply) {
+      return reply.redirect("/private-modules").code(301);
+    }
+  },{
     path: "/contact",
     method: "GET",
     handler: require('./facets/company/show-contact')

--- a/templates/enterprise/index.hbs
+++ b/templates/enterprise/index.hbs
@@ -26,7 +26,7 @@
   <h2>Features</h2>
 
   <ul>
-    <li><a href="#private">Private npm that just works</a></li>
+    <li><a href="#private">Private npm registry that just works</a></li>
     <li><a href="#scoped">Scoped modules give you private code, simply</a></li>
     <li><a href="#conflicts">Eliminate conflicts with public modules</a></li>
     <li><a href="#compatible">Works in concert with the public registry</a></li>
@@ -39,7 +39,7 @@
 
   <iframe width="100%" height="480" src="//www.youtube.com/embed/FJyVsD8xs14?rel=0" frameborder="0" allowfullscreen></iframe>
 
-  <h3><a name="private">npm Enterprise is private npm</a></h3>
+  <h3><a name="private">npm Enterprise is a private npm registry</a></h3>
 
   <p>npm Enterprise is an npm registry that works with the same standard npm client you
   already use, but provides the features needed by larger organizations who

--- a/templates/layouts/default.hbs
+++ b/templates/layouts/default.hbs
@@ -35,7 +35,7 @@
   <nav>
     <div class="container">
       <a href="#" id="npm-expansions">node package manager</a>
-      <a href="/private-npm">private npm</a>
+      <a href="/private-modules">npm private modules</a>
       <a href="/enterprise">npm Enterprise</a>
       <a href="https://docs.npmjs.com">documentation</a>
       <a href="http://blog.npmjs.org/">blog</a>
@@ -98,7 +98,7 @@
           <ul class="links">
             <li><a href="/about">About npm, Inc</a></li>
             <li><a href="/jobs">Jobs</a></li>
-            <li><a href="/private-npm">private npm</a></li>
+            <li><a href="/private-modules">npm private modules</a></li>
             <li><a href="http://blog.npmjs.org">Blog</a></li>
             <li><a href="https://twitter.com/npmjs">Twitter</a></li>
             <li><a href="https://github.com/npm">GitHub</a></li>

--- a/test/company/home.js
+++ b/test/company/home.js
@@ -58,3 +58,18 @@ describe('Getting to the home page', function () {
     });
   }*/);
 });
+
+describe('redirects', function () {
+  it('redirects /private-npm to /private-modules', function (done) {
+    var opts = {
+      url: '/private-npm'
+    };
+
+    server.inject(opts, function (resp) {
+      expect(resp.statusCode).to.equal(301);
+      expect(resp.headers.location).to.match(/\/private-modules$/);
+      done();
+    });
+  });
+
+});


### PR DESCRIPTION
We say "npm Enterprise is private npm" but then "private npm" links to the "npm Private Modules" page, and it's all confusing.

This clarifies a bit while hopefully not destroying our SEO goodness.