### PR TITLE
Fix lab aliases

### DIFF
--- a/services/downloads/test/index.js
+++ b/services/downloads/test/index.js
@@ -1,9 +1,8 @@
 var Lab = require('lab'),
-    lab = exports.lab = Lab.script(),
-    describe = lab.experiment,
-    before = lab.before,
-    after = lab.after,
-    it = lab.test,
+    describe = Lab.experiment,
+    before = Lab.before,
+    after = Lab.after,
+    it = Lab.test,
     expect = Lab.expect;
 
 var Hapi = require('hapi'),

--- a/services/registry/test/index.js
+++ b/services/registry/test/index.js
@@ -1,9 +1,8 @@
 var Lab = require('lab'),
-    lab = exports.lab = Lab.script(),
-    describe = lab.experiment,
-    before = lab.before,
-    after = lab.after,
-    it = lab.test,
+    describe = Lab.experiment,
+    before = Lab.before,
+    after = Lab.after,
+    it = Lab.test,
     expect = Lab.expect;
 
 var Hapi = require('hapi'),

--- a/services/user/test/index.js
+++ b/services/user/test/index.js
@@ -1,9 +1,8 @@
 var Lab = require('lab'),
-    lab = exports.lab = Lab.script(),
-    describe = lab.experiment,
-    before = lab.before,
-    after = lab.after,
-    it = lab.test,
+    describe = Lab.experiment,
+    before = Lab.before,
+    after = Lab.after,
+    it = Lab.test,
     expect = Lab.expect;
 
 var Hapi = require('hapi'),


### PR DESCRIPTION
This is a quick fix to get the test suite passing. It updates some of the "services" tests to use old-school (3.x.x) lab API syntax for things like `Lab.before`, `Lab.experiment`, etc

The longer term fix is to only have one package.json file in newww, and hence one version of lab. Right now we have a bunch:

![screen shot 2014-12-28 at 10 43 13 pm](https://cloud.githubusercontent.com/assets/2289/5566697/98df87f0-8ee5-11e4-9d8a-40af56729158.png)