### PR TITLE
Preserve query parameters in links when rendering README.

### DIFF
--- a/facets/registry/presenters/package.js
+++ b/facets/registry/presenters/package.js
@@ -123,7 +123,7 @@ function urlPolicy (pkgData) {
         protocol: v.protocol,
         host: v.host,
         pathname: v.pathname,
-        query: u.query_,
+        search: u.query_,
         hash: u.fragment_
       }
     } else {
@@ -131,7 +131,7 @@ function urlPolicy (pkgData) {
         protocol: u.scheme_ + ':',
         host: u.domain_ + (u.port_ ? ':' + u.port_ : ''),
         pathname: u.path_,
-        query: u.query_,
+        search: u.query_,
         hash: u.fragment_
       }
     }

--- a/test/fixtures/fake.json
+++ b/test/fixtures/fake.json
@@ -88,7 +88,7 @@
     "fake",
     "omg so fake"
   ],
-  "readme": "# fake\n\nNot actually a package. In fact, it's not even real. [Here's a link](http://somelink.com/somwhere).\n\n[And here's a relative link](somewhere.md#bugs)\nAnd here comes some prose\n\n# Another H1\n\n<p><a href=\"https://travis-ci.org/senchalabs/connect\"><img src=\"https://img.shields.io/travis/senchalabs/connect.svg?style=flat\" alt=\"Build Status\"></a></p>\n\n<a href=\"https://nodei.co/npm/request/\"><img src=\"https://nodei.co/npm/request.png?downloads=true&amp;downloadRank=true&amp;stars=true\" alt=\"NPM\"></a>",
+  "readme": "# fake\n\nNot actually a package. In fact, it's not even real. [Here's a link](http://somelink.com/somwhere).\n\n[And here's a relative link](somewhere.md#bugs)\n[And here's a link with a query parameter](https://www.youtube.com/watch?v=dQw4w9WgXcQ)\nAnd here comes some prose\n\n# Another H1\n\n<p><a href=\"https://travis-ci.org/senchalabs/connect\"><img src=\"https://img.shields.io/travis/senchalabs/connect.svg?style=flat\" alt=\"Build Status\"></a></p>\n\n<a href=\"https://nodei.co/npm/request/\"><img src=\"https://nodei.co/npm/request.png?downloads=true&amp;downloadRank=true&amp;stars=true\" alt=\"NPM\"></a>",
   "readmeFilename": "README.md",
   "homepage": "https://github.com/boom/fake",
   "bugs": {

--- a/test/registry/package.js
+++ b/test/registry/package.js
@@ -101,6 +101,13 @@ describe('Modifying the package before sending to the template', function () {
     done();
   });
 
+  it('preserves query parameters in URLs when making them into links', function (done) {
+    expect(p.readmeSrc).to.include("watch?v=dQw4w9WgXcQ");
+    var $ = cheerio.load(p.readme);
+    expect($("a[href*='youtube.com']").attr('href')).to.equal('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+    done();
+  });
+
   it('includes the dependencies', function (done) {
     expect(p.dependencies).to.exist;
     done();


### PR DESCRIPTION
Hey guys!

Great work on the new website!

Just noticed on a package I was browsing (karma at the time) that URLs with query parameters gets their parameters stripped. Not sure if you do it on purpose, but reading the code, it seems the query parameter is supposed to be preserved. So here is a PR fixing that, including a test (which will fail without the fix applied, to prove my point).

Basically, this is the problem:

```
$ node
> var u = { protocol: 'http:',
...   host: 'www.youtube.com',
...   pathname: '/watch',
...   search: 'v=dQw4w9WgXcQ',
...   hash: null }
undefined
> u
{ protocol: 'http:',
  host: 'www.youtube.com',
  pathname: '/watch',
  search: 'v=dQw4w9WgXcQ',
  hash: null }
> url.format(u)
'http://www.youtube.com/watch?v=dQw4w9WgXcQ'
> u.query = u.search
'v=dQw4w9WgXcQ'
> delete u.search
true
> url.format(u)
'http://www.youtube.com/watch'
>
```

Yup. So keep up the good work && <3 npm

Oh and a nice holiday and new years to npm and contributors!