### PR TITLE
Fixes broken star issue

### DIFF
--- a/facets/registry/show-package.js
+++ b/facets/registry/show-package.js
@@ -74,7 +74,9 @@ function showPackage(request, reply) {
           return;
         }
 
-        cleanedPackage.isStarred = opts.user && cleanedPackage.users && cleanedPackage.users[opts.user.name] || false;
+        var loggedInUser = request.auth.credentials;
+
+        cleanedPackage.isStarred = loggedInUser && cleanedPackage.users && cleanedPackage.users[loggedInUser.name] || false;
         opts.package = cleanedPackage;
         opts.title = cleanedPackage.name;
         reply.view('registry/package-page', opts);

--- a/test/fixtures/fake.json
+++ b/test/fixtures/fake.json
@@ -82,7 +82,7 @@
     "url": "http://github.com/boom/fake"
   },
   "users": {
-    "rockbot": true
+    "fakeuser": true
   },
   "keywords": [
     "fake",

--- a/test/registry/package.js
+++ b/test/registry/package.js
@@ -274,3 +274,22 @@ describe('requesting invalid packages', function () {
     });
   });
 });
+
+describe('seeing stars', function () {
+  it('highlights the star if the user is logged in and has starred the package', function (done) {
+    var pkgName = 'fake';
+
+    var options = {
+      url: '/package/' + pkgName,
+      credentials: { name: 'fakeuser' }
+    };
+
+    server.inject(options, function (resp) {
+      expect(resp.statusCode).to.equal(200);
+      expect(source.context.package.name).to.equal(pkgName);
+      expect(source.context.package.isStarred).to.be.true;
+      expect(resp.result).to.include('<input id="star-input" type="checkbox" name="isStarred" value="true" checked>');
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Issue was that when a user was logged in, the packages that they have
already starred did not appear as such. Now it all works again yay!