### PR TITLE
Make vagrant box start from base ubuntu.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,11 +10,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "npm-www-20140617"
-
-  # The url from where the 'config.vm.box' box will be fetched if it
-  # doesn't already exist on the user's system.
-  config.vm.box_url = "https://s3-us-west-2.amazonaws.com/public-vagrant-boxes/npm-www-20140623.box"
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.provision :shell, :path => "dev/bootstrap.sh"
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine.

--- a/dev/bootstrap.sh
+++ b/dev/bootstrap.sh
@@ -1,0 +1,35 @@
+apt-get update
+# Make it possible to add PPA sources.
+apt-get install python-software-properties -y
+
+# Add sources for what we want to install
+wget -q -O - http://packages.elasticsearch.org/GPG-KEY-elasticsearch | apt-key add -
+echo "deb http://packages.elasticsearch.org/elasticsearch/1.1/debian stable main" | tee -a /etc/apt/sources.list
+add-apt-repository ppa:rwky/redis -y
+sudo add-apt-repository ppa:couchdb/stable -y
+curl -sL https://deb.nodesource.com/setup | bash -
+
+# Install stuff we need. And some stuff that might come in handy.
+apt-get install openjdk-7-jre redis-server nodejs couchdb elasticsearch g++ git -y
+
+# Fix a couple of potential permission problems. Not really production values, these...
+sudo chmod o+w /var/run/couchdb/couch.uri
+sudo chmod o+r /etc/couchdb/local.ini
+
+# Create swapfile of 1GB with block size 1MB
+/bin/dd if=/dev/zero of=/swapfile bs=1024 count=1048576
+
+# Set up the swap file
+/sbin/mkswap /swapfile
+
+# Enable swap file immediately
+/sbin/swapon /swapfile
+
+# Enable swap file on every boot
+/bin/echo '/swapfile          swap            swap    defaults        0 0' >> /etc/fstab
+
+# Make elasticsearch available in PATH
+echo 'PATH="/usr/share/elasticsearch/bin/:$PATH"' | tee -a /home/vagrant/.bashrc
+
+# Make vagrant user start in /vagrant
+echo 'cd /vagrant' | tee -a /home/vagrant/.bashrc


### PR DESCRIPTION
This is the PR generated from discussion over at #476

Discussion points I can think of:
- Ubuntu has been upgraded to 14.04. Good/bad?
- Couchdb has been upgraded to 1.6. As suggested. Good?
- Elasticsearch is not upgraded (still 1.1). Good/bad?
- Redis is a slightly different version, but follows my go-to ppa for it. Good/bad?

Instructions from README still applies with this setup, should not change anything as far I as I know.

So, up for discussion is the keyword here :)

And have a nice weekend!