### PR TITLE
remove unused dependency

### DIFF
--- a/facets/company/show-homepage.js
+++ b/facets/company/show-homepage.js
@@ -3,7 +3,6 @@ var TWO_WEEKS = 1000 * 60 * 60 * 24 * 14; // in milliseconds
 var async = require('async'),
     browse = require('../../services/registry/methods/getBrowseData'),
     Hapi = require('hapi'),
-    parseLanguageHeader = require('accept-language-parser').parse,
     fmt = require('util').format,
     moment = require('moment'),
     once = require('once');

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     ]
   },
   "dependencies": {
-    "accept-language-parser": "^1.0.2",
     "async": "^0.9.0",
     "async-cache": "^0.1.5",
     "blankie": "^0.1.2",


### PR DESCRIPTION
https://www.npmjs.com/package/accept-language-parser was being used to figure out the user's language and preferred big-number delimiter, but now we're using the browser's built-in `toLocaleString()` function instead. Yay!