### PR TITLE
Fixes broken caching due to getBrowseData arg types

### DIFF
--- a/facets/registry/show-package.js
+++ b/facets/registry/show-package.js
@@ -92,7 +92,7 @@ function fetchDependents(request, name, callback) {
   var results = [];
   request.timing.browse_start = Date.now();
 
-  getBrowseData({type: 'depended', noPackageData: true}, name, 0, 1000, function (er, dependents) {
+  getBrowseData('depended', name, 0, 1000, true, function (er, dependents) {
 
     request.metrics.metric({
       name:   'latency',

--- a/services/registry/browseUtils.js
+++ b/services/registry/browseUtils.js
@@ -121,13 +121,7 @@ function packageDisplay (key) {
 }
 
 
-exports.transform = function transform (type, arg, data, skip, limit, opts, next) {
-
-  // opts is an optional parameter.
-  if (typeof opts === 'function') {
-    next = opts;
-    opts = {};
-  }
+exports.transform = function transform (type, arg, data, skip, limit, noPackageData, next) {
 
   log.info('transforming ', type, arg, skip, limit);
   if (!data.rows) {
@@ -152,9 +146,9 @@ exports.transform = function transform (type, arg, data, skip, limit, opts, next
     }).slice(skip, skip + limit);
   }
 
-  // don't lookup dependent package if opts.noPackageData is truthy.
+  // don't lookup dependent package if noPackageData is truthy.
   if (type.match(/all|updated|depended|^star/) && !arg ||
-      type.match(/keyword|author|depended|userstar/) && arg && !opts.noPackageData) {
+      type.match(/keyword|author|depended|userstar/) && arg && !noPackageData) {
     log.info('getting package data for ' + type + ' with arg ' + arg);
     return getPackageData(data, function (er, data) {
       return next(null, data);

--- a/services/registry/methods/getBrowseData.js
+++ b/services/registry/methods/getBrowseData.js
@@ -1,5 +1,4 @@
 var Boom = require('boom'),
-    Hapi = require('hapi'),
     CouchDB = require('../../../adapters/couchDB'),
     qs = require('querystring'),
     browseUtils = require('../browseUtils'),
@@ -7,8 +6,7 @@ var Boom = require('boom'),
     uuid = require('node-uuid'),
     metrics = require('../../../adapters/metrics')();
 
-module.exports = function (type, arg, skip, limit, next) {
-  var opts = {};
+module.exports = function (type, arg, skip, limit, noPackageData, next) {
   var anonCouch = CouchDB.anonCouch;
   var key = [type, arg, skip, limit].join(',');
 
@@ -16,9 +14,9 @@ module.exports = function (type, arg, skip, limit, next) {
   // string, assume that it is an options object.
   // this allows us to vary behavior, as an example,
   // only looking up dependent packages in some cases.
-  if (typeof type === 'object') {
-    opts = type;
-    type = opts.type;
+  if (typeof noPackageData === 'function') {
+    next = noPackageData;
+    noPackageData = false;
   }
 
   var start = Date.now();
@@ -69,7 +67,7 @@ module.exports = function (type, arg, skip, limit, next) {
     }
 
     start = Date.now();
-    browseUtils.transform(type, arg, data, skip, limit, opts, function (er, transformedData) {
+    browseUtils.transform(type, arg, data, skip, limit, noPackageData, function (er, transformedData) {
 
       metrics.metric({
         name:   'latency',

--- a/test/fixtures/mock-server-methods.js
+++ b/test/fixtures/mock-server-methods.js
@@ -140,13 +140,11 @@ module.exports = function (server) {
     },
 
     registry: {
-      getBrowseData: function (type, arg, skip, limit, next) {
-        var opts = {};
+      getBrowseData: function (type, arg, skip, limit, noPackageData, next) {
 
-        // type can optionally pass along opts.
-        if (typeof type === 'object') {
-          opts = type;
-          type = opts.type;
+        if (typeof noPackageData === 'function') {
+          next = noPackageData;
+          noPackageData = false;
         }
 
         return next(null, browse[type]);


### PR DESCRIPTION
When hapi caches a method call, i.e. `getBrowseData('depended', 'underscore', 0, 1000, cb)`, it stores the generated object in redis with a key that looks something like `getBrowseData:depended:underscore:0:1000`. However, we recently made a change that allows the first argument to be an object, i.e. `getBrowseData({type: 'depended', noPackageData: true}, 'underscore', 0, 1000, cb)`. Since Hapi doesn't know what to do with objects as parameters when storing items in the cache, it
simply never caches.