### PR TITLE
Added border-radius to the ad class

### DIFF
--- a/assets/styles/layout.styl
+++ b/assets/styles/layout.styl
@@ -243,6 +243,7 @@ ul.humans
 .ad
   padding 10px
   border 1px solid greigh7
+  border-radius 2px
   background greigh8
   a
     font-weight 400


### PR DESCRIPTION
The only other elements that don't have border-radii on the packages page are the code blocks; I've added a border-radius as a further way of differentiating the ad, in addition to the current border.