### PR TITLE
Fixed issue #499: handle mixed-case package names

### DIFF
--- a/assets/styles/readme.styl
+++ b/assets/styles/readme.styl
@@ -8,6 +8,7 @@
     line-height 1.2
     @extend .ellipsis
     overflow-y hidden
+    text-transform none
 
   hgroup
     margin 20px 0

--- a/dev/replicate.js
+++ b/dev/replicate.js
@@ -49,7 +49,7 @@ var packagesByRockbot = ["couch-login", "googalytics", "newww",
 
 var crazyPackages = [
   'ifyouwanttogetthesumoftwonumberswherethosetwonumbersarechosenbyfindingthelargestoftwooutofthreenumbersandsquaringthemwhichismultiplyingthembyitselfthenyoushouldinputthreenumbersintothisfunctionanditwilldothatforyou',
-  'dezalgo'
+  'dezalgo', 'JSONStream'
 ]
 
 function filterPackage (id, rev) {

--- a/facets/registry/show-package.js
+++ b/facets/registry/show-package.js
@@ -18,12 +18,6 @@ function showPackage(request, reply) {
 
   opts.name = request.params.package;
 
-  if (!validatePackageName(opts.name).valid) {
-    request.logger.info('request for invalid package name: ' + opts.name);
-    reply.view('errors/not-found', opts).code(404);
-    return;
-  }
-
   getPackage(opts.name, function (er, pkg) {
 
     opts.package = { name: opts.name };
@@ -33,6 +27,13 @@ function showPackage(request, reply) {
     }
 
     if (!pkg) {
+      if (!validatePackageName(opts.name).valid) {
+        delete opts.package; // to suppress the encouraging message
+        request.logger.info('request for invalid package name: ' + opts.name);
+        reply.view('errors/not-found', opts).code(404);
+        return;
+      }
+
       return reply.view('errors/not-found', opts).code(404);
     }
 


### PR DESCRIPTION
Don't attempt to validate package names before fetching, because the rules have changed along the way. Only validate if a package is not found, so we can vary the message shown to the viewer. (Now-invalid names do not get any encouragement to publish with that name.)

Added `JSONStream` to the list of replicated packages for verification.