### PR TITLE
display deprecation notice on package page

### DIFF
--- a/dev/replicate.js
+++ b/dev/replicate.js
@@ -49,7 +49,9 @@ var packagesByRockbot = ["couch-login", "googalytics", "newww",
 
 var crazyPackages = [
   'ifyouwanttogetthesumoftwonumberswherethosetwonumbersarechosenbyfindingthelargestoftwooutofthreenumbersandsquaringthemwhichismultiplyingthembyitselfthenyoushouldinputthreenumbersintothisfunctionanditwilldothatforyou',
-  'dezalgo', 'JSONStream'
+  'dezalgo',
+  'JSONStream',
+  'grunt-compass'
 ]
 
 function filterPackage (id, rev) {

--- a/templates/registry/package-page.hbs
+++ b/templates/registry/package-page.hbs
@@ -23,6 +23,10 @@
 
 <div class="sidebar">
 
+  {{#if deprecated}}
+    <p class="notice">{{deprecated}}</p>
+  {{/if}}
+
   {{#if installCommand}}
     <div class="autoselect-wrapper npm-install icon-download">
       <input type="text" value="{{installCommand}}" readonly>


### PR DESCRIPTION
DO NOT MERGE. Needs tests.

A deprecated package, for reference: http://registry.npmjs.org/grunt-compass