### PR TITLE
add npm weekly subscription opt-in to sign up

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
+MAILCHIMP_KEY=12345-us9
 SESSION_SALT=put something crazy here

--- a/facets/user/show-signup.js
+++ b/facets/user/show-signup.js
@@ -20,7 +20,8 @@ module.exports = function signup (request, reply) {
       name: Joi.string().required(),
       password: Joi.string().required(),
       verify: Joi.string().required(),
-      email: Joi.string().email().required()
+      email: Joi.string().email().required(),
+      npmweekly: Joi.string()
     });
 
     var joiOptions = {
@@ -62,7 +63,6 @@ module.exports = function signup (request, reply) {
           }
 
           signupUser(validatedUser, function (er, user) {
-
             if (er) {
               request.logger.warn('Failed to create account.');
               return reply.view('errors/internal', opts).code(403);

--- a/locales/en_US/user.js
+++ b/locales/en_US/user.js
@@ -10,6 +10,7 @@ module.exports = {
       verify: "Verify Password",
       email: "Email Address",
       emailHelp: "This <strong>will</strong> be public and shown on all the packages you publish. Accounts with invalid emails may be deleted without notice.",
+      npmWeekly: "Sign up for npm Weekly emails",
       submit: "Make it so"
     }
   },

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "joi": "^5.1.0",
     "jquery": "^2.1.1",
     "leven": "^1.0.1",
+    "mailchimp-api": "^2.0.7",
     "malarkey": "^1.1.0",
     "marked": "^0.3.2",
     "moment": "^2.6.0",

--- a/server.js
+++ b/server.js
@@ -1,3 +1,5 @@
+require("dotenv").load();
+
 var _       = require('lodash'),
     assert  = require('assert'),
     config  = require('./config.js'),

--- a/services/user/methods/signupUser.js
+++ b/services/user/methods/signupUser.js
@@ -2,12 +2,20 @@ var Boom = require('boom'),
     Hapi = require('hapi'),
     anonCouch = require('../../../adapters/couchDB').anonCouch,
     metrics = require('../../../adapters/metrics')(),
-    mailchimp = require('mailchimp-api');
+    mailchimp = require('mailchimp-api'),
+    log = require('bole')('user-signup');
 
 module.exports = function signupUser (acct, next) {
   if (acct.npmweekly === "on") {
     var mc = new mailchimp.Mailchimp(process.env.MAILCHIMP_KEY);
-    mc.lists.subscribe({id: 'e17fe5d778', email:{email:acct.email}});
+    mc.lists.subscribe({id: 'e17fe5d778', email:{email:acct.email}}, function(data) {
+      // do nothing on success
+    }, function(error) {
+      log.error('Could not register user for npm Weekly: ' + acct.email);
+      if (error.error) {
+        log.error(error.error);
+      }
+    });
   }
 
   var timer = { start: Date.now() };

--- a/services/user/methods/signupUser.js
+++ b/services/user/methods/signupUser.js
@@ -6,7 +6,7 @@ var Boom = require('boom'),
 
 module.exports = function signupUser (acct, next) {
   if (acct.npmweekly === "on") {
-    var mc = new mailchimp.Mailchimp('xxx');
+    var mc = new mailchimp.Mailchimp(process.env.MAILCHIMP_KEY);
     mc.lists.subscribe({id: 'e17fe5d778', email:{email:acct.email}});
   }
 

--- a/services/user/methods/signupUser.js
+++ b/services/user/methods/signupUser.js
@@ -5,9 +5,9 @@ var Boom = require('boom'),
     mailchimp = require('mailchimp-api'),
     log = require('bole')('user-signup');
 
-module.exports = function signupUser (acct, next) {
+function signupUser (acct, next) {
   if (acct.npmweekly === "on") {
-    var mc = new mailchimp.Mailchimp(process.env.MAILCHIMP_KEY);
+    var mc = signupUser.getMailchimp();
     mc.lists.subscribe({id: 'e17fe5d778', email:{email:acct.email}}, function(data) {
       // do nothing on success
     }, function(error) {
@@ -46,3 +46,9 @@ module.exports = function signupUser (acct, next) {
     return next(null, data);
   });
 }
+
+signupUser.getMailchimp = function getMailchimp () {
+  return new mailchimp.Mailchimp(process.env.MAILCHIMP_KEY);
+}
+
+module.exports = signupUser;

--- a/services/user/methods/signupUser.js
+++ b/services/user/methods/signupUser.js
@@ -1,9 +1,15 @@
 var Boom = require('boom'),
     Hapi = require('hapi'),
     anonCouch = require('../../../adapters/couchDB').anonCouch,
-    metrics = require('../../../adapters/metrics')();
+    metrics = require('../../../adapters/metrics')(),
+    mailchimp = require('mailchimp-api');
 
 module.exports = function signupUser (acct, next) {
+  if (acct.npmweekly === "on") {
+    var mc = new mailchimp.Mailchimp('xxx');
+    mc.lists.subscribe({id: 'e17fe5d778', email:{email:acct.email}});
+  }
+
   var timer = { start: Date.now() };
   anonCouch.signup(acct, function (er, cr, data) {
     timer.end = Date.now();

--- a/templates/user/signup-form.hbs
+++ b/templates/user/signup-form.hbs
@@ -22,10 +22,12 @@
     <input type="text" id="email" name="email" autocorrect="off" autocapitalize="off" />
     <p class="help-text">{{{t "user.signup.form.emailHelp"}}}</p>
 
-    <label for="npmweekly">
-      <input type="checkbox" id="npmweekly" name="npmweekly" autocorrect="off" autocapitalize="off" />
-      {{t "user.signup.form.npmWeekly"}}
-    </label>
+    <div class="radio-group">
+      <label for="npmweekly">
+        <input type="checkbox" id="npmweekly" name="npmweekly" autocorrect="off" autocapitalize="off" />
+        {{t "user.signup.form.npmWeekly"}}
+      </label>
+    </div>
 
     <input type="submit" class="full-width" value="{{t "user.signup.form.submit"}}" />
     {{> form_security}}

--- a/templates/user/signup-form.hbs
+++ b/templates/user/signup-form.hbs
@@ -22,6 +22,11 @@
     <input type="text" id="email" name="email" autocorrect="off" autocapitalize="off" />
     <p class="help-text">{{{t "user.signup.form.emailHelp"}}}</p>
 
+    <label for="npmweekly">
+      <input type="checkbox" id="npmweekly" name="npmweekly" autocorrect="off" autocapitalize="off" />
+      {{t "user.signup.form.npmWeekly"}}
+    </label>
+
     <input type="submit" class="full-width" value="{{t "user.signup.form.submit"}}" />
     {{> form_security}}
   </form>

--- a/test/fixtures/fake-couch.js
+++ b/test/fixtures/fake-couch.js
@@ -17,7 +17,7 @@ module.exports = function (config) {
                 .get('/_users/org.couchdb.user:blah')
                 .reply(200, require('./users').blah)
 
-                .get('/_users/org.couchdb.user:boom').thrice()
+                .get('/_users/org.couchdb.user:boom').times(5)
                 .reply(200, require('./users').boom)
 
                 .get('/_users/org.couchdb.user:boop')
@@ -30,7 +30,7 @@ module.exports = function (config) {
                 ]})
 
                 // --- modify user ---
-                .put('/_users/org.couchdb.user:boom')
+                .put('/_users/org.couchdb.user:boom').thrice()
                 .reply(201, require('./users').boom)
 
                 .put('/_users/org.couchdb.user:boom?rev=1-7adf7e546de1852cec39894c0d652fb4')
@@ -45,7 +45,7 @@ module.exports = function (config) {
                 .reply(201, { ok: 'updated email address' })
 
                 // --- log in ---
-                .post('/_session').twice()
+                .post('/_session').times(4)
                 .reply(200, require('./users').boom)
 
                 // --- log out ---

--- a/test/services/user.js
+++ b/test/services/user.js
@@ -1,3 +1,5 @@
+require('dotenv').load();
+
 var Code = require('code'),
     Lab = require('lab'),
     lab = exports.lab = Lab.script(),
@@ -65,6 +67,43 @@ describe('signing up a user', function () {
       expect(er).to.not.exist();
       expect(user).to.exist();
       expect(user.name).to.equal('boom');
+      done();
+    });
+  });
+});
+
+describe('the mailing list checkbox', function () {
+  var body = {"id":"e17fe5d778","email":{"email":"boom@boom.com"},"merge_vars":null,"email_type":"html","double_optin":true,"update_existing":false,"replace_interests":true,"send_welcome":false,"apikey":process.env.MAILCHIMP_KEY};
+
+  it('adds the user to the mailing list when checked', function (done) {
+    var mailchimp = nock('https://us9.api.mailchimp.com')
+      .post('/2.0/lists/subscribe.json', body)
+      .reply(201, '');
+
+    server.methods.user.signupUser({
+      name: 'boom',
+      password: '12345',
+      verify: '12345',
+      email: 'boom@boom.com',
+      npmweekly: 'on'
+    }, function (er, user) {
+      expect(mailchimp.isDone()).to.be.true();
+      done();
+    });
+  });
+
+  it('does not add the user to the mailing list when unchecked', function (done) {
+    var mailchimp = nock('https://us9.api.mailchimp.com')
+      .post('/2.0/lists/subscribe.json')
+      .reply(201, '');
+
+    server.methods.user.signupUser({
+      name: 'boom',
+      password: '12345',
+      verify: '12345',
+      email: 'boom@boom.com'
+    }, function (er, user) {
+      expect(mailchimp.isDone()).to.be.false();
       done();
     });
   });


### PR DESCRIPTION
Will fix #555 when it's done.

I figured I'd take a shot :) This is a first pass at adding mailchimp to the sign up flow. The `xxx` in there is a placeholder for the auth token. Where do we put that kind of config?

Also, it doesn't do anything on success or error. I don't think we want to display anything to the user, but should we log errors?