### PR TITLE
update gulp for iojs compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "code": "^1.2.1",
     "dotenv": "^0.4.0",
     "grunt": "^0.4.5",
-    "gulp": "^3.6.2",
+    "gulp": "^3.8.10",
     "gulp-concat": "^2.2.0",
     "gulp-nodemon": "^1.0.2",
     "gulp-rename": "^1.2.0",


### PR DESCRIPTION
I tried to run the site on iojs 1.0.3 and got some gulp errors. This version bump fixes it.