### PR TITLE
jshint setup

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,7 +22,17 @@ var paths = {
     browserify: ["./assets/scripts/*.js"],
     vendor: ["./assets/scripts/vendor/*.js"]
   },
-  templates: ['./assets/templates/*.hbs']
+  templates: ['./assets/templates/*.hbs'],
+  lintables: [
+    "./assets/scripts/**/*.js",
+    "./adapters/**/*.js",
+    "./facets/**/*.js",
+    "./lib/**/*.js",
+    "./locales/**/*.js",
+    "./presenters/**/*.js",
+    "./services/**/*.js",
+    "./test/**/*.js",
+  ]
 };
 
 gulp.task('watch', function(){
@@ -101,9 +111,9 @@ gulp.task('nodemon', function() {
 });
 
 gulp.task('lint', function() {
-  gulp.src('./**/*')
-      .pipe(jshint())
-      .pipe(jshint.reporter('default'));
+  gulp.src(paths.lintables)
+    .pipe(jshint())
+    .pipe(jshint.reporter('default'));
 });
 
 gulp.task('build', ['fonts', 'images', 'misc', 'styles', 'browserify', 'concat', 'lint']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -116,6 +116,6 @@ gulp.task('lint', function() {
     .pipe(jshint.reporter('default'));
 });
 
-gulp.task('build', ['fonts', 'images', 'misc', 'styles', 'browserify', 'concat', 'lint']);
+gulp.task('build', ['fonts', 'images', 'misc', 'styles', 'browserify', 'concat']);
 gulp.task('dev', ['build', 'nodemon', 'watch']);
 gulp.task('default', ['build']);


### PR DESCRIPTION
We're now using jshint, thanks to @ckross01 and @rockbot!

`gulp lint` works like a charm, but it's a little much to have it running on `gulp build` right now, because we have lots of files that don't meet our jshint requirements.

This PR disables linting on build for now until we are in a more stable state, and can do a sweeping "add semicolons to 100+ files" PR.