### PR TITLE
Changes status code for unpublished package pages from 200 to 410

### DIFF
--- a/facets/registry/show-package.js
+++ b/facets/registry/show-package.js
@@ -44,7 +44,7 @@ function showPackage(request, reply) {
       opts.package = pkg;
       request.timing.page = 'showUnpublishedPackage';
 
-      return reply.view('registry/unpublished-package-page', opts);
+      return reply.view('registry/unpublished-package-page', opts).code(410);
     }
 
     var tasks = {

--- a/test/registry/package.js
+++ b/test/registry/package.js
@@ -73,7 +73,7 @@ describe('Retreiving packages from the registry', function () {
     };
 
     server.inject(options, function (resp) {
-      expect(resp.statusCode).to.equal(200);
+      expect(resp.statusCode).to.equal(410);
       var source = resp.request.response.source;
       expect(source.template).to.equal('registry/unpublished-package-page');
       expect(source.context.package.unpubFromNow).to.exist();


### PR DESCRIPTION
The major benefit of this change is that now when a package is unpublished, google search will hit the page but refrain from putting it in their search results, as per http://searchenginewatch.com/sew/how-to/2340728/matt-cutts-on-how-google-handles-404-410-status-codes#