### PR TITLE
Let major search engines hit /browse/ pages

### DIFF
--- a/assets/misc/robots.txt
+++ b/assets/misc/robots.txt
@@ -28,3 +28,9 @@
 #
 User-agent: *
 Disallow: /browse/
+User-agent: Googlebot
+Allow: /browse/
+User-agent: Slurp
+Allow: /browse/
+User-Agent: msnbot
+Allow: /browse/


### PR DESCRIPTION
Per http://stackoverflow.com/questions/671491/robots-txt-allow-only-major-se this may resolve a recent drop in search traffic we've noticed.