### PR TITLE
Fixing the hover styles for last-publisher links to not underline whitespace

### DIFF
--- a/assets/styles/layout.styl
+++ b/assets/styles/layout.styl
@@ -227,6 +227,10 @@ li.last-publisher
   a
     height avatarSizeInline
     vertical-align top
+    &:hover
+      text-decoration none
+      span
+        text-decoration underline
     span
       line-height avatarSizeInline
       vertical-align top


### PR DESCRIPTION
Currently, the hover styles look like this:

![image](https://cloud.githubusercontent.com/assets/730664/6174033/0ec7bd00-b2a1-11e4-8045-3f32750f3fe2.png)

Post change, they should look like this:

![image](https://cloud.githubusercontent.com/assets/730664/6174038/15a8c010-b2a1-11e4-8abd-7b0238658347.png)

*caveat I didn't build locally*