### PR TITLE
A more restrictive CSP for Hubspot

### DIFF
--- a/lib/csp.js
+++ b/lib/csp.js
@@ -4,18 +4,24 @@ csp.default = {
   defaultSrc: 'self',
   scriptSrc: [
     'self',
-    'https://checkout.stripe.com',
-    'https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.2/html5shiv.min.js',
-    'https://fonts.googleapis.com',
-    'https://forms.hubspot.com/',
+
+    'https://forms.hubspot.com/uploads/form/v2/419727/9a2b4ac5-ef09-43e6-854a-d82c92347c9d',
+    'https://forms.hubspot.com/uploads/form/v2/419727/6672f0d7-d2df-4696-a164-a8fa139d8f15',
+    'https://forms.hubspot.com/uploads/form/v2/419727/64c6e95b-b2c7-4989-a8ae-d967645e5198',
+    'https://forms.hubspot.com/uploads/form/v2/419727/d9ba17d5-606e-456d-a703-733c67f5e708',
     'https://js.hsforms.net/forms/current.js',
-    'https://api.stripe.com',
-    'https://internal.hubapi.com',
     'https://api.hubapi.com',
-    'https://js.stripe.com/v2/',
+    'https://internal.hubapi.com',
     'https://js.hs-analytics.net',
+
+    'https://api.stripe.com',
+    'https://checkout.stripe.com',
+    'https://js.stripe.com/v2/',
+
     'https://www.google-analytics.com',
+    'https://fonts.googleapis.com',
     'https://s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js',
+    'https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.2/html5shiv.min.js',
   ],
   styleSrc: [
     'self',

--- a/lib/csp.js
+++ b/lib/csp.js
@@ -1,4 +1,3 @@
-var cloneDeep = require("lodash").cloneDeep
 var csp = module.exports = {}
 
 csp.default = {
@@ -9,8 +8,10 @@ csp.default = {
     'https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.2/html5shiv.min.js',
     'https://fonts.googleapis.com',
     'https://forms.hubspot.com/',
-    'https://js.hsforms.net/',
+    'https://js.hsforms.net/forms/current.js',
     'https://api.stripe.com',
+    'https://internal.hubapi.com',
+    'https://api.hubapi.com',
     'https://js.stripe.com/v2/',
     'https://js.hs-analytics.net',
     'https://www.google-analytics.com',
@@ -40,12 +41,3 @@ csp.default = {
   // sandbox: Values for the sandbox directive,
   reportUri: '/-/csplog'
 }
-
-// Allow extra script sources on enterprise signup pages
-csp.enterprise = cloneDeep(csp.default)
-csp.enterprise.scriptSrc = csp.enterprise.scriptSrc.concat(
-  'https://js.hsforms.net/forms/current.js',
-  'https://forms.hubspot.com',
-  'https://internal.hubapi.com',
-  'https://api.hubapi.com'
-);

--- a/lib/csp.js
+++ b/lib/csp.js
@@ -15,7 +15,7 @@ csp.default = {
     'https://js.hs-analytics.net',
 
     'https://api.stripe.com',
-    'https://checkout.stripe.com',
+    'https://checkout.stripe.com/checkout.js',
     'https://js.stripe.com/v2/',
 
     'https://www.google-analytics.com',

--- a/routes/public.js
+++ b/routes/public.js
@@ -24,12 +24,6 @@ var ajaxy = {
   }
 };
 
-var enterpriseConfig = {
-  plugins: {
-    blankie: require('../lib/csp').enterprise
-  }
-};
-
 module.exports = [
   {
     path: '/favicon.ico',
@@ -113,28 +107,23 @@ module.exports = [
   },{
     path: "/enterprise",
     method: "GET",
-    handler: require('../facets/enterprise/show-index'),
-    config: enterpriseConfig
+    handler: require('../facets/enterprise/show-index')
   },{
     path: "/enterprise-start-signup",
     method: "POST",
-    handler: require('../facets/enterprise/show-ula'),
-    config: enterpriseConfig
+    handler: require('../facets/enterprise/show-ula')
   },{
     path: "/enterprise-contact-me",
     method: "POST",
-    handler: require('../facets/enterprise/show-contact-me'),
-    config: enterpriseConfig
+    handler: require('../facets/enterprise/show-contact-me')
   },{
     path: "/enterprise-trial-signup",
     method: "POST",
-    handler: require('../facets/enterprise/show-trial-signup'),
-    config: enterpriseConfig
+    handler: require('../facets/enterprise/show-trial-signup')
   },{
     path: "/enterprise-verify",
     method: "GET",
-    handler: require('../facets/enterprise/show-verification'),
-    config: enterpriseConfig
+    handler: require('../facets/enterprise/show-verification')
   },{
     path: "/package/{package}/collaborators",
     method: "GET",

--- a/test/csp.js
+++ b/test/csp.js
@@ -55,21 +55,4 @@ describe("csp (content security policy)", function () {
 
   })
 
-  describe("enterprise", function() {
-    it("is an object", function (done) {
-      expect(csp.enterprise).to.be.an.object();
-      done();
-    })
-
-    describe("scriptSrc", function(){
-      it("allows the same scripts as the default CSP, plus some others", function (done) {
-        csp.default.scriptSrc.forEach(function(src){
-          expect(csp.enterprise.scriptSrc).to.include(src);
-        });
-        expect(csp.enterprise.scriptSrc.length).to.be.above(csp.default.scriptSrc.length);
-        done();
-      })
-    })
-  })
-
 })

--- a/test/routes.js
+++ b/test/routes.js
@@ -35,13 +35,6 @@ describe("routes", function () {
     done();
   })
 
-  it("applies configuration to enterprise routes", function(done){
-    var enterprise = routes.at("GET /enterprise")
-    expect(enterprise).to.be.an.object();
-    expect(enterprise.config.plugins.blankie).to.deep.equal(require('../lib/csp').enterprise);
-    done();
-  })
-
   it("defines the same handler for /~ and /profile", function (done) {
     var unix = routes.at("GET /~")
     var bore = routes.at("GET /profile")


### PR DESCRIPTION
From @jlamendo:

> the hubspot CSP urls are not restrictive enough, and could cause a bypass if a less restrictive injection point were to be found. I know it results in adding to an already lengthy CSP header, but you should whitelist specific pages on hubspot, or at least only allow pages located within your client ID folder.

It would be nice to factor out the hubspot config from `config.js` into its own module like `lib/hubspot.js` and stop passing config through the handlers, but it's tangled and I don't want to go down a rabbit hole this morning.