### PR TITLE
DRY static routes

### DIFF
--- a/assets/misc/google17836d108133913c.html
+++ b/assets/misc/google17836d108133913c.html
@@ -1,0 +1,1 @@
+google-site-verification: google17836d108133913c.html

--- a/routes/public.js
+++ b/routes/public.js
@@ -1,6 +1,7 @@
 var config = require('../config');
 var fmt = require('util').format;
-var _ = require("lodash");
+var fs = require('fs');
+var _ = require('lodash');
 
 var unathenticatedRouteConfig = {
   config: {
@@ -30,38 +31,8 @@ var enterpriseConfig = {
   }
 };
 
-module.exports = [
+var publicRoutes = [
   {
-    path: '/favicon.ico',
-    method: 'GET',
-    handler: {
-      file: '../static/misc/favicon.ico'
-    }
-  },{
-    path: '/robots.txt',
-    method: 'GET',
-    handler: {
-      file: '../static/misc/robots.txt'
-    }
-  },{
-    path: '/google17836d108133913c.html',
-    method: 'GET',
-    handler: function (request, reply) {
-      reply("google-site-verification: google17836d108133913c.html");
-    }
-  },{
-    path: '/install.sh',
-    method: 'GET',
-    handler: {
-      file: '../static/misc/install.sh'
-    }
-  },{
-    path: '/opensearch.xml',
-    method: 'GET',
-    handler: {
-      file: '../static/misc/opensearch.xml'
-    }
-  },{
     path: '/static/{path*}',
     method: 'GET',
     handler: {
@@ -320,6 +291,21 @@ module.exports = [
     handler: require("../handlers/fallback")
   }
 
-].map(function(route){
+]
+
+// Allow files in /static/misc to be web-accessible from /
+fs.readdirSync("./static/misc").forEach(function(filename) {
+  publicRoutes.push({
+    path: '/' + filename,
+    method: 'GET',
+    handler: {
+      file: './static/misc/' + filename
+    }
+  })
+})
+
+publicRoutes = publicRoutes.map(function(route){
   return _.merge({}, unathenticatedRouteConfig, route)
 })
+
+module.exports = publicRoutes

--- a/test/handlers/static.js
+++ b/test/handlers/static.js
@@ -1,0 +1,55 @@
+var fixtures = require("../fixtures"),
+    Code = require('code'),
+    Lab = require('lab'),
+    lab = exports.lab = Lab.script(),
+    describe = lab.experiment,
+    beforeEach = lab.beforeEach,
+    afterEach = lab.afterEach,
+    it = lab.test,
+    expect = Code.expect,
+    server;
+
+describe('static routes', function () {
+
+  beforeEach(function (done) {
+    require('../mocks/server')(function (obj) {
+      server = obj;
+      done();
+    });
+  });
+
+  it('GET /robots.txt', function (done) {
+    var options = {
+      url: '/robots.txt'
+    };
+    server.inject(options, function (resp) {
+      expect(resp.statusCode).to.equal(200);
+      expect(resp.result).to.include("User-agent: *");
+      done();
+    });
+  });
+
+  it('GET /opensearch.xml', function (done) {
+    var options = {
+      url: '/opensearch.xml'
+    };
+    server.inject(options, function (resp) {
+      expect(resp.statusCode).to.equal(200);
+      expect(resp.result).to.include("OpenSearchDescription");
+      done();
+    });
+  });
+
+  it('GET /google17836d108133913c.html', function (done) {
+    var options = {
+      url: '/google17836d108133913c.html'
+    };
+    server.inject(options, function (resp) {
+      expect(resp.statusCode).to.equal(200);
+      expect(resp.result).to.include("google-site-verification: google17836d108133913c.html");
+      done();
+    });
+  });
+
+
+});


### PR DESCRIPTION
Instead of manually adding a route for every file in `/static/misc`, this iterates over the contents of the directory and creates a route to serve each from `/`. This means less code, and the next time you add a file to `/assets/misc`, it will be served from `/` without the need for a new route.

PS This also fixes a path bug I introduced last Friday. :)