### PR TITLE
Changing #npm-search hover from darken(greigh5) to greigh4

### DIFF
--- a/assets/styles/_header.styl
+++ b/assets/styles/_header.styl
@@ -217,7 +217,7 @@ nav
   border-radius 2px
   background background-color
   &:hover
-    border 1px solid darken(greigh5, 10%)
+    border 1px solid greigh4
 
   @media only screen and (max-width: mobileMaxWidth)
     margin-top 20px


### PR DESCRIPTION
So it turns out that `darken (greigh5, 10%)` doesn't actually do anything. I tried up to 200% and it had no change, so I just switched to `greigh4`.

I'm also compiling the changes now so I can actually confirm the results :smile: 