### PR TITLE
use the same delimiting style for dependencies and dependents

### DIFF
--- a/templates/registry/package-page.hbs
+++ b/templates/registry/package-page.hbs
@@ -134,15 +134,11 @@
   <p class="list-of-links">
     {{#if dependencies}}
       {{#each dependencies}}
-        {{#unless @last}}
-          <a href="/package/{{this}}">{{this}}</a>,
+        {{#if @last}}
+          <a href="/package/{{this}}">{{this}}</a>
         {{else}}
-          {{#unless noHref}}
-            <a href="/package/{{this}}">{{this}}</a>
-          {{else}}
-            <a>{{text}}</a>
-          {{/unless}}
-        {{/unless}}
+          <a href="/package/{{this}}">{{this}}</a>,
+        {{/if}}
       {{/each}}
     {{else}}
       None
@@ -154,13 +150,9 @@
     <p class="list-of-links">
       {{#each dependents}}
         {{#if @last}}
-          <a href="{{url}}">{{name}}</a>.
+          <a href="/package/{{name}}">{{name}}</a>
         {{else}}
-          {{#if url}}
-            <a href="{{url}}">{{name}}</a>,
-          {{else}}
-            {{name}},
-          {{/if}}
+          <a href="/package/{{name}}">{{name}}</a>,
         {{/if}}
       {{/each}}
     </p>


### PR DESCRIPTION
Fixes #645 and removes excess template logic.

![screen shot 2015-02-17 at 10 23 42 pm](https://cloud.githubusercontent.com/assets/2289/6243320/cfd02338-b6f3-11e4-882c-4a6d2a7d24b0.png)

![screen shot 2015-02-17 at 10 24 07 pm](https://cloud.githubusercontent.com/assets/2289/6243321/d181de9c-b6f3-11e4-9e48-5771c996c253.png)
