### PR TITLE
no license hyperlink if we have a name but no URL

### DIFF
--- a/templates/registry/package-page.hbs
+++ b/templates/registry/package-page.hbs
@@ -72,7 +72,11 @@
 
     {{#if license}}
       <li>
-        <a href="{{license.url}}">{{license.name}}</a> <span> license</span>
+        {{#if license.url}}
+          <a href="{{license.url}}">{{license.name}}</a> <span> license</span>
+        {{else}}
+          {{license.name}} <span> license</span>
+        {{/if}}
       </li>
     {{/if}}
 


### PR DESCRIPTION
This is the second half of https://github.com/npm/newww/pull/441 - the first half was moved to https://github.com/npm/oss-license-name-to-url/pull/1

With that change, the license.url would be `null` if it's not a known license instead of something like http://opensource.org/licenses/Copyright%20(c)%20Foo%20Bar so now the template will detect that and just show the text without a broken link.