### PR TITLE
add schema.org metadata to package pages

### DIFF
--- a/templates/registry/package-page.hbs
+++ b/templates/registry/package-page.hbs
@@ -166,6 +166,22 @@
     </p>
   {{/if}}
 
+  <script type="application/ld+json">
+    {
+      "@context": "http://schema.org",
+      "@type": "SoftwareApplication",
+      "name": "{{name}}",
+      "description": "{{description}}",
+      "url": "{{../canonicalURL}}",
+      "keywords": "{{keywords}}",
+      "applicationCategory": "DeveloperApplication",
+      "offers": {
+         "@type": "Offer",
+         "price": "0.00"
+      }
+    }
+  </script>
+
   <div class="hiring-container" data-template="sidebar"></div>
 
 </div>


### PR DESCRIPTION
Fixes #625 

The applicationCategory and offers values are a little weird. I added them because you're required to have 2 of 4 optional fields, and those two were the closest to making sense for our use case (the other two are aggregateRating and operatingSystem).

This could potentially go in `package-page.hbs`, but I wasn't sure whether canonicalURL was/should be exposed as a variable there.