### PR TITLE
redis cache thing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,4 @@ MAILCHIMP_KEY=12345-us9
 MAIL_ACCESS_KEY_ID=your_AWS_access_key_id
 MAIL_SECRET_ACCESS_KEY=your_AWS_secret_access_key
 DOWNLOADS_API=https://api.npmjs.org/downloads
+REDIS_URL=redis://localhost:6379

--- a/handlers/homepage.js
+++ b/handlers/homepage.js
@@ -14,10 +14,6 @@ module.exports = function (request, reply) {
       context.dependents = dependents
       return Download.getAll()
     })
-    .catch(function(err){
-      // tolerate timed-out downloads API calls
-      if (err.code === 'ETIMEDOUT') return null;
-    })
     .then(function(downloads){
       context.downloads = downloads
       return Package.count()

--- a/handlers/package.js
+++ b/handlers/package.js
@@ -62,10 +62,6 @@ package.show = function(request, reply) {
 
       return Download.getAll(package.name)
     })
-    .catch(function(err){
-      // tolerate timed-out downloads API calls
-      if (err.code === 'ETIMEDOUT') return null;
-    })
     .then(function(downloads) {
       package.downloads = downloads
 

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -30,7 +30,7 @@ exports.configure = function configure(opts)
     exports.logger = logger;
 };
 
-var _fingerprint = exports._fingerprint = function _fingerprint(obj)
+exports._fingerprint = function _fingerprint(obj)
 {
     var cleaned = {};
     var keys = Object.keys(obj).sort();
@@ -60,7 +60,7 @@ exports.get = function get(opts, callback)
     assert(_.isObject(redis), 'you must configure the redis client before using the cache.');
     assert(_.isObject(opts), 'you must pass a Request-ready options object to cache.get()');
 
-    var key = _fingerprint(opts);
+    var key = exports._fingerprint(opts);
     redis.get(key, function(err, value)
     {
         if (err)

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -35,6 +35,7 @@ var _fingerprint = exports._fingerprint = function _fingerprint(obj)
     var cleaned = {};
     var keys = Object.keys(obj).sort();
     _.each(keys, function(k) { k = k.toLowerCase(); cleaned[k] = obj[k]; });
+    delete cleaned.ttl;
 
     var hash = crypto
         .createHash('md5')

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,0 +1,95 @@
+var
+    _       = require('lodash'),
+    assert  = require('assert'),
+    bole    = require('bole'),
+    crypto  = require('crypto'),
+    Redis   = require('redis-url'),
+    Request = require('request')
+    ;
+
+var redis, DEFAULT_TTL, KEY_PREFIX, options;
+var DEFAULT_TTL = 300; // seconds
+var KEY_PREFIX = 'cache:';
+var logger = bole('cache');
+
+exports.configure = function configure(opts)
+{
+    assert(_.isObject(opts), 'you must pass an options object to the cache configuration');
+    assert(_.isString(opts.redis), 'you must pass a redis url in `options.redis`');
+
+    redis = Redis.connect(opts.redis);
+    if (opts.ttl)  { DEFAULT_TTL = opts.ttl; }
+    if (opts.prefix) { KEY_PREFIX = opts.prefix; }
+
+    options = opts;
+
+    // for testing convenience only
+    exports.redis = redis;
+    exports.DEFAULT_TTL = DEFAULT_TTL;
+    exports.KEY_PREFIX = KEY_PREFIX;
+};
+
+var _fingerprint = exports._fingerprint = function _fingerprint(obj)
+{
+    var cleaned = {};
+    var keys = Object.keys(obj).sort();
+    _.each(keys, function(k) { k = k.toLowerCase(); cleaned[k] = obj[k]; });
+
+    var hash = crypto
+        .createHash('md5')
+        .update(JSON.stringify(cleaned))
+        .digest('hex');
+    return KEY_PREFIX + hash;
+};
+
+function safeparse(input)
+{
+    try { return JSON.parse(input); }
+    catch(ex) { return null; }
+}
+
+// callback or promise
+exports.get = function get(opts, callback)
+{
+    assert(_.isObject(redis), 'you must configure the redis client before using the cache.');
+    assert(_.isObject(opts), 'you must pass a Request-ready options object to cache.get()');
+
+    var key = _fingerprint(opts);
+    redis.get(key, function(err, value)
+    {
+        if (err)
+        {
+            logger.error('problem getting ' + key + ' from redis @ ' + options.redis);
+            logger.error(err);
+        }
+        else if (value)
+        {
+            value = safeparse(value);
+        }
+
+        if (value)
+        {
+            return callback(null, value);
+        }
+
+        Request(opts, function(err, response, data)
+        {
+            if (err) { return callback(err); }
+
+            var ttl = opts.ttl || DEFAULT_TTL;
+            redis.setex(key, ttl, JSON.stringify(data), function(err, response)
+            {
+                if (err)
+                {
+                    logger.error('unable to cache ' + key + ' in redis @ ' + options.redis);
+                    logger.error(err);
+                }
+                else
+                {
+                    logger.info('cached ' + key);
+                }
+            });
+            callback(null, data);
+        });
+    });
+};

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -35,6 +35,10 @@ var _fingerprint = exports._fingerprint = function _fingerprint(obj)
     var cleaned = {};
     var keys = Object.keys(obj).sort();
     _.each(keys, function(k) { k = k.toLowerCase(); cleaned[k] = obj[k]; });
+    if (cleaned.method)
+    {
+        cleaned.method = cleaned.method.toLowerCase();
+    }
     delete cleaned.ttl;
 
     var hash = crypto

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -78,6 +78,8 @@ exports.get = function get(opts, callback)
             return callback(null, value);
         }
 
+        exports.logger.info('get: ' + opts.url);
+
         Request(opts, function(err, response, data)
         {
             if (err) { return callback(err); }

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -82,12 +82,12 @@ exports.get = function get(opts, callback)
             {
                 if (err)
                 {
-                    logger.error('unable to cache ' + key + ' in redis @ ' + options.redis);
-                    logger.error(err);
+                    exports.logger.error('unable to cache ' + key + ' in redis @ ' + options.redis);
+                    exports.logger.error(err);
                 }
                 else
                 {
-                    logger.info('cached ' + key);
+                  exports.logger.info('cached ' + key);
                 }
             });
             callback(null, data);

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -27,6 +27,7 @@ exports.configure = function configure(opts)
     exports.redis = redis;
     exports.DEFAULT_TTL = DEFAULT_TTL;
     exports.KEY_PREFIX = KEY_PREFIX;
+    exports.logger = logger;
 };
 
 var _fingerprint = exports._fingerprint = function _fingerprint(obj)
@@ -54,13 +55,13 @@ exports.get = function get(opts, callback)
     assert(_.isObject(redis), 'you must configure the redis client before using the cache.');
     assert(_.isObject(opts), 'you must pass a Request-ready options object to cache.get()');
 
-    var key = _fingerprint(opts);
+    var key = exports._fingerprint(opts);
     redis.get(key, function(err, value)
     {
         if (err)
         {
-            logger.error('problem getting ' + key + ' from redis @ ' + options.redis);
-            logger.error(err);
+            exports.logger.error('problem getting ' + key + ' from redis @ ' + options.redis);
+            exports.logger.error(err);
         }
         else if (value)
         {

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -60,7 +60,7 @@ exports.get = function get(opts, callback)
     assert(_.isObject(redis), 'you must configure the redis client before using the cache.');
     assert(_.isObject(opts), 'you must pass a Request-ready options object to cache.get()');
 
-    var key = exports._fingerprint(opts);
+    var key = _fingerprint(opts);
     redis.get(key, function(err, value)
     {
         if (err)

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -83,6 +83,10 @@ exports.get = function get(opts, callback)
         Request(opts, function(err, response, data)
         {
             if (err) { return callback(err); }
+            if (response.statusCode !== 200)
+            {
+                return callback(new Error('unexpected status code ' + response.statusCode));
+            }
 
             var ttl = opts.ttl || DEFAULT_TTL;
             redis.setex(key, ttl, JSON.stringify(data), function(err, response)
@@ -97,6 +101,7 @@ exports.get = function get(opts, callback)
                   exports.logger.info('cached ' + key);
                 }
             });
+            
             callback(null, data);
         });
     });

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -12,8 +12,8 @@ module.exports = function(){
     });
 
   if (missing.length) {
-    console.error("\nThe following required environment variables are missing: " + missing.join(", "));
-    console.error("Please add them to your .env file or service.json!");
+    console.error("\nmissing: " + missing.join(", "));
+    console.error("please update your .env or service.json");
     process.exit(1);
   }
 

--- a/models/download.js
+++ b/models/download.js
@@ -36,20 +36,17 @@ Download.prototype.getAll = function(packageName) {
   var _this = this;
   var result = {};
 
-  return _this.getDaily(packageName)
-    .then(function(dailies){
-      result['day'] = dailies
-      return _this.getWeekly(packageName)
-    })
-    .then(function(weeklies){
-      result['week'] = weeklies
-      return _this.getMonthly(packageName)
-    })
-    .then(function(monthlies){
-      result['month'] = monthlies
-      return result
-    })
-
+  return Promise.all([
+    _this.getDaily(packageName),
+    _this.getWeekly(packageName),
+    _this.getMonthly(packageName),
+  ]).then(function(result) {
+    return {
+      day: result[0],
+      week: result[1],
+      month: result[2]
+    }
+  })
 }
 
 Download.prototype.getSome = function(period, packageName) {

--- a/models/download.js
+++ b/models/download.js
@@ -14,7 +14,10 @@ var Download = module.exports = function (opts) {
 
 Download.new = function(request) {
   var bearer = request.auth.credentials && request.auth.credentials.name;
-  return new Download({bearer: bearer});
+  return new Download({
+    bearer: bearer,
+    cache: require("../lib/cache")
+  });
 };
 
 Download.prototype.getDaily = function(packageName) {

--- a/models/download.js
+++ b/models/download.js
@@ -59,19 +59,19 @@ Download.prototype.getSome = function(period, packageName) {
   }
 
   return new Promise(function(resolve, reject) {
-    var opts = {url: url, json: true, timeout: _this.timeout, headers: {bearer: _this.bearer}};
+    var opts = {
+      method: "GET",
+      url: url,
+      json: true,
+      timeout: _this.timeout,
+      headers: {
+        bearer: _this.bearer
+      }
+    };
 
     request.get(opts, function(err, resp, body){
-      if (err) {
-        return reject(err);
-      }
-
-      if (resp.statusCode > 399) {
-        var msg = 'error getting downloads for period ' + period;
-        msg += ' for ' + (packageName || "all packages");
-        err = Error(msg);
-        err.statusCode = resp.statusCode;
-        return reject(err);
+      if (err || resp.statusCode > 399) {
+        return resolve(null);
       }
 
       return resolve(body);

--- a/models/download.js
+++ b/models/download.js
@@ -2,6 +2,7 @@ var request = require('request');
 var Promise = require('bluebird');
 var _ = require('lodash');
 var fmt = require('util').format;
+var cache = require('../lib/cache');
 var URL = require('url');
 
 var Download = module.exports = function (opts) {
@@ -69,12 +70,8 @@ Download.prototype.getSome = function(period, packageName) {
       }
     };
 
-    request.get(opts, function(err, resp, body){
-      if (err || resp.statusCode > 399) {
-        return resolve(null);
-      }
-
-      return resolve(body);
+    cache.get(opts, function(err, body){
+      return resolve(body || null);
     });
   })
 };

--- a/models/download.js
+++ b/models/download.js
@@ -70,8 +70,15 @@ Download.prototype.getSome = function(period, packageName) {
       }
     };
 
-    cache.get(opts, function(err, body){
-      return resolve(body || null);
-    });
+    if (_this.cache) {
+      _this.cache.get(opts, function(err, body){
+        return resolve(body || null);
+      });
+    } else {
+      request(opts, function(err, resp, body){
+        return resolve(body || null);
+      })
+    }
+
   })
 };

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "pkgs": "^1.1.0",
     "prettydate": "0.0.1",
     "redis": "^0.12.1",
+    "redis-url": "~0.3.1",
     "relative-date": "^1.1.2",
     "repl-client": "~0.3.0",
     "replify": "~1.2.0",

--- a/server.js
+++ b/server.js
@@ -35,6 +35,13 @@ couchDB.init(config.couch);
 // configure metrics as a side effect
 var metrics = require('./adapters/metrics')(config.metrics);
 
+// configure http request cache
+require("./lib/cache").configure({
+    redis: process.env.REDIS_URL,
+    ttl: 500,
+    prefix: "cache:"
+})
+
 server.register(require('hapi-auth-cookie'), function (err) {
   if (err) { throw err; }
 

--- a/test/cache.js
+++ b/test/cache.js
@@ -62,7 +62,6 @@ describe('lib/cache.js', function()
         done();
     });
 
-
     it('_fingerprint() returns an md5 hash prefixed by the key prefix', function(done)
     {
         var testKey = { foo: 'bar' };
@@ -95,6 +94,18 @@ describe('lib/cache.js', function()
         expect(gen1).to.equal(gen2);
         done();
     });
+
+    it('_fingerprint() downcases the http `method` value', function(done)
+    {
+        var key1 = {method: 'get', url: '/fun'};
+        var key2 = {method: 'GET', url: '/fun'};
+        var gen1 = cache._fingerprint(key1);
+        var gen2 = cache._fingerprint(key2);
+
+        expect(gen1).to.equal(gen2);
+        done();
+    });
+
 
     it('get() requires an options argument', function(done)
     {

--- a/test/cache.js
+++ b/test/cache.js
@@ -309,11 +309,27 @@ describe('lib/cache.js', function()
             });
         });
 
+        it('responds with an error when the remote service responds with 404', function(done)
+        {
+            var opts = { url: 'http://example.com/not-found' };
+            var mock = nock('http://example.com')
+                .get('/not-found')
+                .reply(404);
+
+            cache.get(opts, function(err, data)
+            {
+                mock.done();
+                expect(err).to.exist();
+                expect(err.message).to.equal('unexpected status code 404');
+                done();
+            });
+        });
+
         it('respects a passed-in TTL', function(done)
         {
-            var opts = { url: 'https://example.com/boom', method: 'get', ttl: 5000 };
-            var mock = nock('https://example.com')
-                .get('/boom')
+            var opts = { url: 'http://example.com/ttl', method: 'get', ttl: 5000 };
+            var mock = nock('http://example.com')
+                .get('/ttl')
                 .reply(200, 'blistering barnacles');
             var key = cache._fingerprint(opts);
 
@@ -340,6 +356,7 @@ describe('lib/cache.js', function()
                 count++;
                 if (count === 2)
                 {
+                    cache.logger.error = saved;
                     done();
                 }
             };

--- a/test/cache.js
+++ b/test/cache.js
@@ -149,6 +149,7 @@ describe('lib/cache.js', function()
     {
 
       sinon.stub(cache.redis, 'get').yields(null);
+      sinon.spy(cache.logger, 'info');
 
       var opts = {
         method: "get",
@@ -162,7 +163,9 @@ describe('lib/cache.js', function()
       cache.get(opts, function(err, data)
       {
           expect(cache.redis.get.calledOnce).to.equal(true);
+          expect(cache.logger.info.calledWithMatch(/get: /i)).to.equal(true);
           cache.redis.get.restore();
+          cache.logger.info.restore();
           mock.done();
           done();
       });

--- a/test/cache.js
+++ b/test/cache.js
@@ -16,249 +16,358 @@ var cache = require('../lib/cache');
 
 describe('lib/cache.js', function()
 {
-
-    it('requires that configure be called before use', function(done)
+    describe('configure()', function()
     {
-        function shouldThrow() { return cache.get('foo'); }
-        expect(shouldThrow).to.throw(/configure/);
-        done();
-    });
-
-    it('configure() requires an options object', function(done)
-    {
-        function shouldThrow() { cache.configure(); }
-        expect(shouldThrow).to.throw(/options/);
-        done();
-    });
-
-    it('configure() requires a redis url option', function(done)
-    {
-        function shouldThrow() { cache.configure({}); }
-        expect(shouldThrow).to.throw(/redis/);
-        done();
-    });
-
-    it('configure() creates a redis client', function(done)
-    {
-        expect(cache.redis).to.not.exist();
-        cache.configure({ redis: 'redis://localhost:6379'});
-        expect(cache.redis).to.be.an.object();
-        done();
-    });
-
-    it('configure() respects the `ttl` option', function(done)
-    {
-        expect(cache.DEFAULT_TTL).to.equal(300);
-        cache.configure({ redis: 'redis://localhost:6379', ttl: 600 });
-        expect(cache.DEFAULT_TTL).to.equal(600);
-        done();
-    });
-
-    it('configure() respects the `prefix` option', function(done)
-    {
-        expect(cache.KEY_PREFIX).to.equal('cache:');
-        cache.configure({ redis: 'redis://localhost:6379', prefix: 'fred:' });
-        expect(cache.KEY_PREFIX).to.equal('fred:');
-        done();
-    });
-
-    it('_fingerprint() returns an md5 hash prefixed by the key prefix', function(done)
-    {
-        var testKey = { foo: 'bar' };
-        var expected = crypto.createHash('md5').update(JSON.stringify(testKey)).digest('hex');
-        var generated = cache._fingerprint(testKey);
-
-        expect(generated.indexOf(expected)).to.equal(5);
-        expect(generated.indexOf('fred:')).to.equal(0);
-        done();
-    });
-
-    it('_fingerprint() returns the same value for the same input', function(done)
-    {
-        var key1 = { foo: 'bar', baz: 'qux' };
-        var key2 = { baz: 'qux', foo: 'bar' };
-        var gen1 = cache._fingerprint(key1);
-        var gen2 = cache._fingerprint(key2);
-
-        expect(gen1).to.equal(gen2);
-        done();
-    });
-
-    it('_fingerprint() removes `ttl` key from the source object', function(done)
-    {
-        var key1 = {foo: 'bar', baz: 'qux'};
-        var key2 = {foo: 'bar', baz: 'qux', ttl: 234};
-        var gen1 = cache._fingerprint(key1);
-        var gen2 = cache._fingerprint(key2);
-
-        expect(gen1).to.equal(gen2);
-        done();
-    });
-
-    it('_fingerprint() downcases the http `method` value', function(done)
-    {
-        var key1 = {method: 'get', url: '/fun'};
-        var key2 = {method: 'GET', url: '/fun'};
-        var gen1 = cache._fingerprint(key1);
-        var gen2 = cache._fingerprint(key2);
-
-        expect(gen1).to.equal(gen2);
-        done();
-    });
-
-
-    it('get() requires an options argument', function(done)
-    {
-        function shouldThrow() { cache.get(); }
-        expect(shouldThrow).to.throw(/Request/);
-        done();
-    });
-
-    it('get() calls _fingerprint()', function(done)
-    {
-        sinon.spy(cache, '_fingerprint');
-
-        nock("https://fingerprint.com").get("/").reply(200);
-        var opts = {method: "get", url: 'https://fingerprint.com/'};
-
-        cache.get(opts, function(err, data)
+        it('requires that configure be called before use', function(done)
         {
-            expect(cache._fingerprint.calledOnce).to.be.true();
-            expect(cache._fingerprint.calledWith(opts)).to.be.true();
-            cache._fingerprint.restore();
+            function shouldThrow() { return cache.get('foo'); }
+            expect(shouldThrow).to.throw(/configure/);
+            done();
+        });
+
+        it('requires an options object', function(done)
+        {
+            function shouldThrow() { cache.configure(); }
+            expect(shouldThrow).to.throw(/options/);
+            done();
+        });
+
+        it('requires a redis url option', function(done)
+        {
+            function shouldThrow() { cache.configure({}); }
+            expect(shouldThrow).to.throw(/redis/);
+            done();
+        });
+
+        it('creates a redis client', function(done)
+        {
+            expect(cache.redis).to.not.exist();
+            cache.configure({ redis: 'redis://localhost:6379'});
+            expect(cache.redis).to.be.an.object();
+            done();
+        });
+
+        it('respects the `ttl` option', function(done)
+        {
+            expect(cache.DEFAULT_TTL).to.equal(300);
+            cache.configure({ redis: 'redis://localhost:6379', ttl: 600 });
+            expect(cache.DEFAULT_TTL).to.equal(600);
+            done();
+        });
+
+        it('respects the `prefix` option', function(done)
+        {
+            expect(cache.KEY_PREFIX).to.equal('cache:');
+            cache.configure({ redis: 'redis://localhost:6379', prefix: 'fred:' });
+            expect(cache.KEY_PREFIX).to.equal('fred:');
             done();
         });
     });
 
-    it('get() checks redis for the presence of the data first', function(done)
+    describe('_fingerprint()', function()
     {
-        sinon.spy(cache.redis, 'get');
-        var opts = {url: 'https://google.com/'};
-        var fingerprint = cache._fingerprint(opts);
-
-        cache.get(opts, function(err, data)
+        it('returns an md5 hash prefixed by the key prefix', function(done)
         {
-            expect(cache.redis.get.calledOnce).to.equal(true);
-            expect(cache.redis.get.calledWith(fingerprint)).to.equal(true);
-            cache.redis.get.restore();
+            var testKey = { foo: 'bar' };
+            var expected = crypto.createHash('md5').update(JSON.stringify(testKey)).digest('hex');
+            var generated = cache._fingerprint(testKey);
+
+            expect(generated.indexOf(expected)).to.equal(5);
+            expect(generated.indexOf('fred:')).to.equal(0);
+            done();
+        });
+
+        it('returns the same value for the same input', function(done)
+        {
+            var key1 = { foo: 'bar', baz: 'qux' };
+            var key2 = { baz: 'qux', foo: 'bar' };
+            var gen1 = cache._fingerprint(key1);
+            var gen2 = cache._fingerprint(key2);
+
+            expect(gen1).to.equal(gen2);
+            done();
+        });
+
+        it('removes `ttl` key from the source object', function(done)
+        {
+            var key1 = {foo: 'bar', baz: 'qux'};
+            var key2 = {foo: 'bar', baz: 'qux', ttl: 234};
+            var gen1 = cache._fingerprint(key1);
+            var gen2 = cache._fingerprint(key2);
+
+            expect(gen1).to.equal(gen2);
+            done();
+        });
+
+        it('downcases the http `method` value', function(done)
+        {
+            var key1 = {method: 'get', url: '/fun'};
+            var key2 = {method: 'GET', url: '/fun'};
+            var gen1 = cache._fingerprint(key1);
+            var gen2 = cache._fingerprint(key2);
+
+            expect(gen1).to.equal(gen2);
             done();
         });
     });
 
-    it('get() makes a request using the options argument if redis has no value', function(done)
+    describe('get()', function()
     {
+        it('requires an options argument', function(done)
+        {
+            function shouldThrow() { cache.get(); }
+            expect(shouldThrow).to.throw(/Request/);
+            done();
+        });
 
-      sinon.stub(cache.redis, 'get').yields(null);
-      sinon.spy(cache.logger, 'info');
+        it('calls _fingerprint()', function(done)
+        {
+            sinon.spy(cache, '_fingerprint');
 
-      var opts = {
-        method: "get",
-        url: 'https://google.com/searching'
-      };
+            nock('https://fingerprint.com').get('/').reply(200);
+            var opts = {method: 'get', url: 'https://fingerprint.com/'};
 
-      var mock = nock("https://google.com")
-          .get("/searching")
-          .reply(200);
+            cache.get(opts, function(err, data)
+            {
+                expect(cache._fingerprint.calledOnce).to.be.true();
+                expect(cache._fingerprint.calledWith(opts)).to.be.true();
+                cache._fingerprint.restore();
+                done();
+            });
+        });
 
-      cache.get(opts, function(err, data)
-      {
-          expect(cache.redis.get.calledOnce).to.equal(true);
-          expect(cache.logger.info.calledWithMatch(/get: /i)).to.equal(true);
-          cache.redis.get.restore();
-          cache.logger.info.restore();
-          mock.done();
-          done();
-      });
+        it('checks redis for the presence of the data first', function(done)
+        {
+            sinon.spy(cache.redis, 'get');
+            var opts = {url: 'https://google.com/'};
+            var fingerprint = cache._fingerprint(opts);
+
+            cache.get(opts, function(err, data)
+            {
+                expect(cache.redis.get.calledOnce).to.equal(true);
+                expect(cache.redis.get.calledWith(fingerprint)).to.equal(true);
+                cache.redis.get.restore();
+                done();
+            });
+        });
+
+        it('makes a request using the options argument if redis has no value', function(done)
+        {
+          sinon.stub(cache.redis, 'get').yields(null);
+          sinon.spy(cache.logger, 'info');
+
+          var opts = {
+            method: 'get',
+            url: 'https://google.com/searching'
+          };
+
+          var mock = nock('https://google.com')
+              .get('/searching')
+              .reply(200);
+
+          cache.get(opts, function(err, data)
+          {
+              expect(cache.redis.get.calledOnce).to.equal(true);
+              expect(cache.logger.info.calledWithMatch(/get: /i)).to.equal(true);
+              cache.redis.get.restore();
+              cache.logger.info.restore();
+              mock.done();
+              done();
+          });
+        });
+
+        it('makes a request to the backing service if the redis value is garbage', function (done)
+        {
+          sinon.stub(cache.redis, 'get').yields(null, null);
+
+          var opts = {
+              method: 'get',
+              url: 'https://google.com/again'
+          };
+
+          var mock = nock('https://google.com')
+              .get('/again')
+              .reply(200);
+
+          cache.get(opts, function(err, data)
+          {
+              expect(cache.redis.get.calledOnce).to.equal(true);
+              cache.redis.get.restore();
+              mock.done();
+              done();
+          });
+        });
+
+        it('gracefully handles a missing or error-returning redis', function(done)
+        {
+          sinon.stub(cache.redis, 'get').yields(Error('hello redis error'));
+          sinon.spy(cache.logger, 'error');
+
+          var opts = {
+              url: 'https://logging.com/'
+          };
+
+          cache.get(opts, function(err, data)
+          {
+              expect(cache.logger.error.calledTwice).to.equal(true);
+              expect(cache.logger.error.calledWithMatch(/problem getting/)).to.equal(true);
+              cache.logger.error.restore();
+              done();
+          });
+        });
+
+        it('sets the value in redis after retrieval', function(done)
+        {
+          sinon.spy(cache.redis, 'setex');
+
+          var opts = {
+              method: 'get',
+              url: 'https://cache.com/hello'
+          };
+          var fingerprint = cache._fingerprint(opts);
+          var mock = nock('https://cache.com')
+              .get('/hello')
+              .reply(200);
+
+          cache.get(opts, function(err, data)
+          {
+              mock.done();
+              expect(cache.redis.setex.calledWith(fingerprint)).to.equal(true);
+              cache.redis.setex.restore();
+              done();
+          });
+        });
+
+        it('respects the default TTL', function(done)
+        {
+          sinon.spy(cache.redis, 'setex');
+
+          var opts = {
+              method: 'get',
+              url: 'https://cache.com/hello-again'
+          };
+          var fingerprint = cache._fingerprint(opts);
+          var mock = nock('https://cache.com')
+              .get('/hello-again')
+              .reply(200);
+
+          cache.get(opts, function(err, data)
+          {
+              mock.done();
+              expect(cache.DEFAULT_TTL).to.equal(600);
+              expect(cache.redis.setex.calledWithMatch(fingerprint, 600)).to.equal(true);
+              cache.redis.setex.restore();
+              done();
+          });
+        });
+
+        it('gracefully handles bad json in a redis key', function(done)
+        {
+            var opts = {
+                method: 'get',
+                url: 'https://cache.com/hello-again'
+            };
+            var fingerprint = cache._fingerprint(opts);
+            var mock = nock('https://cache.com')
+                .get('/hello-again')
+                .reply(200, 'yo');
+
+            cache.configure({ redis: 'redis://localhost:6379'});
+
+            cache.redis.set(fingerprint, 'i am bad json', function(err, reply)
+            {
+                cache.get(opts, function(err, data)
+                {
+                    expect(err).to.not.exist();
+                    expect(data).to.equal('yo');
+                    mock.done();
+                    cache.redis.get(fingerprint, function(err, reply)
+                    {
+                        expect(err).to.not.exist();
+                        expect(reply).to.equal('"yo"');
+                        done();
+                    });
+                });
+            });
+        });
+
+        it('returns a previously cached value without calling the remote service', function(done)
+        {
+            var opts = {
+                method: 'get',
+                url: 'https://cache.com/hello-again'
+            };
+            var mock = nock('https://cache.com')
+                .get('/hello-again')
+                .reply(200, 'blistering barnacles');
+            cache.get(opts, function(err, data)
+            {
+                expect(err).to.not.exist();
+                expect(data).to.equal('yo');
+                expect(mock.isDone()).to.be.false();
+                done();
+            });
+        });
+
+        it('respects a passed-in TTL', function(done)
+        {
+            var opts = { url: 'https://example.com/boom', method: 'get', ttl: 5000 };
+            var mock = nock('https://example.com')
+                .get('/boom')
+                .reply(200, 'blistering barnacles');
+            var key = cache._fingerprint(opts);
+
+            cache.get(opts, function(err, data)
+            {
+                expect(err).to.not.exist();
+                cache.redis.ttl(key, function(err, ttl)
+                {
+                    expect(err).to.not.exist();
+                    expect(ttl).to.be.above(4990);
+                    cache.redis.del(key, done);
+                });
+            });
+        });
+
+        it('logs if it is unable to set the cache', function(done)
+        {
+            sinon.stub(cache.redis, 'setex').yields(Error('setex error'));
+            var saved = cache.logger.error;
+
+            var count = 0;
+            cache.logger.error = function()
+            {
+                count++;
+                if (count === 2)
+                {
+                    done();
+                }
+            };
+            sinon.spy(cache.logger, 'error');
+
+            var opts = { url: 'https://example.com/setex-fails' };
+            var mock = nock('https://example.com')
+                .get('/setex-fails')
+                .reply(200, 'blistering barnacles');
+
+            cache.get(opts, function(err, data)
+            {
+                expect(err).to.not.exist();
+                expect(data).to.equal('blistering barnacles');
+            });
+        });
     });
 
-    it('get() makes a request to the backing service if the redis value is garbage', function (done)
+    after(function(done)
     {
-
-      sinon.stub(cache.redis, 'get').yields(null, null);
-
-      var opts = {
-          method: "get",
-          url: 'https://google.com/again'
-      };
-
-      var mock = nock("https://google.com")
-          .get("/again")
-          .reply(200);
-
-      cache.get(opts, function(err, data)
-      {
-          expect(cache.redis.get.calledOnce).to.equal(true);
-          cache.redis.get.restore();
-          mock.done();
-          done();
-      });
+        cache.redis.keys('fred:*', function(err, list)
+        {
+            expect(err).to.not.exist();
+            cache.redis.del(list, function(err, reply)
+            {
+                expect(err).to.not.exist();
+                done();
+            });
+        });
     });
-
-    it('get() gracefully handles a missing or error-returning redis', function(done)
-    {
-
-      sinon.stub(cache.redis, 'get').yields(Error("hello redis error"));
-      sinon.spy(cache.logger, 'error');
-
-      var opts = {
-          url: 'https://logging.com/'
-      };
-
-      cache.get(opts, function(err, data)
-      {
-          expect(cache.logger.error.calledTwice).to.equal(true);
-          expect(cache.logger.error.calledWithMatch(/problem getting/)).to.equal(true);
-          cache.logger.error.restore();
-          done();
-      });
-    });
-
-    it('get() sets the value in redis after retrieval', function(done)
-    {
-
-      sinon.spy(cache.redis, 'setex');
-
-      var opts = {
-          method: "get",
-          url: 'https://cache.com/hello'
-      };
-      var fingerprint = cache._fingerprint(opts);
-      var mock = nock("https://cache.com")
-          .get("/hello")
-          .reply(200);
-
-      cache.get(opts, function(err, data)
-      {
-          mock.done();
-          expect(cache.redis.setex.calledWith(fingerprint)).to.equal(true);
-          cache.redis.setex.restore();
-          done();
-      });
-    });
-
-    it('get() respects the default TTL', function(done)
-    {
-
-      sinon.spy(cache.redis, 'setex');
-
-      var opts = {
-          method: "get",
-          url: 'https://cache.com/hello-again'
-      };
-      var fingerprint = cache._fingerprint(opts);
-      var mock = nock("https://cache.com")
-          .get("/hello-again")
-          .reply(200);
-
-      cache.get(opts, function(err, data)
-      {
-          mock.done();
-          expect(cache.DEFAULT_TTL).to.equal(600);
-          expect(cache.redis.setex.calledWithMatch(fingerprint, 600)).to.equal(true);
-          cache.redis.setex.restore();
-          done();
-      });
-    });
-
-    it('get() responds with a promise if no callback is provided');
 });

--- a/test/cache.js
+++ b/test/cache.js
@@ -85,6 +85,17 @@ describe('lib/cache.js', function()
         done();
     });
 
+    it('_fingerprint() removes `ttl` key from the source object', function(done)
+    {
+        var key1 = {foo: 'bar', baz: 'qux'};
+        var key2 = {foo: 'bar', baz: 'qux', ttl: 234};
+        var gen1 = cache._fingerprint(key1);
+        var gen2 = cache._fingerprint(key2);
+
+        expect(gen1).to.equal(gen2);
+        done();
+    });
+
     it('get() requires an options argument', function(done)
     {
         function shouldThrow() { cache.get(); }

--- a/test/models/download.js
+++ b/test/models/download.js
@@ -64,24 +64,17 @@ describe("Download", function(){
 
       });
 
-      it("generates an error message when the request fails", function(done){
+      it("swallows errors and returns null when the request fails", function(done){
         var mock = nock(Download.host)
           .get('/point/last-day/request')
           .reply(400);
 
         Download.getDaily("request")
           .then(function(result) {
-            expect(result).to.not.exist();
-          })
-          .catch(function(err){
-            expect(err).to.exist();
-            expect(err.message).to.equal("error getting downloads for period day for request");
-          })
-          .then(function(){
+            expect(result).to.be.null();
             mock.done();
             done();
           });
-
       });
 
     })
@@ -108,41 +101,22 @@ describe("Download", function(){
 
       });
 
-      it("generates an error message when the request fails", function(done){
+      it("returns null if request duration exceeds specified timeout", function(done){
+
+        Download = new (require("../../models/download"))({
+          host: "https://fake-download.com",
+          timeout: 50,
+        });
+        done();
+
         var mock = nock(Download.host)
           .get('/point/last-day')
-          .reply(400);
-
-        Download.getDaily()
-          .then(function(result) {
-            expect(result).to.not.exist();
-          })
-          .catch(function(err){
-            expect(err).to.exist();
-            expect(err.message).to.equal("error getting downloads for period day for all packages");
-          })
-          .then(function(){
-            mock.done();
-            done();
-          });
-
-      });
-
-      it("returns an error if request duration exceeds specified timeout", function(done){
-        var mock = nock(Download.host)
-          .get('/point/last-day')
-          .delayConnection(51)
+          .delayConnection(100)
           .reply(200, fixtures.downloads.all.day);
 
         Download.getDaily()
           .then(function(result) {
-            expect(result).to.not.exist();
-          })
-          .catch(function(err){
-            expect(err).to.exist();
-            expect(err.code).to.equal('ETIMEDOUT');
-          })
-          .then(function(){
+            expect(result).to.be.null();
             mock.done();
             done();
           });

--- a/test/models/download.js
+++ b/test/models/download.js
@@ -107,7 +107,6 @@ describe("Download", function(){
           host: "https://fake-download.com",
           timeout: 50,
         });
-        done();
 
         var mock = nock(Download.host)
           .get('/point/last-day')


### PR DESCRIPTION
@ceej I started adding more tests, but got stuck with sinon and scope stuff and need your input:

- Some of our tests were (wrongly) passing before because we had `to.be.true` assertions instead of `to.be.true()`
- The `get() calls _fingerprint()` test is only passing now because I changed the code to use `exports._fingerprint()`. This is obviously not the right way to do it. Please advise.
- I suspect this is the same reason the logger tests are failing too.
- In the later tests I'm calling `cache.redis.set.restore();`, but subsequent tests are whining: `Attempted to wrap set which is already wrapped`.. is this a race condition or something?
