### PR TITLE
[WIP] attempt to cache download counts with hapi server methods

### DIFF
--- a/adapters/plugins.js
+++ b/adapters/plugins.js
@@ -18,13 +18,10 @@ module.exports = [
   require('../services/registry'),
   require('../services/corporate'),
   require('../services/email'),
+  require('../services/downloads'),
   {
     register: require('../services/npme'),
     options: config
-  },
-  {
-    register: require('../services/downloads'),
-    options: config.downloads
   },
   {
     register: require('./bonbon'),

--- a/handlers/package.js
+++ b/handlers/package.js
@@ -8,7 +8,7 @@ package.show = function(request, reply) {
   var context = {title: name};
   var loggedInUser = request.auth.credentials;
   var Package = require("../models/package").new(request)
-  var Download = require("../models/download").new(request)
+
   var name = request.params.package ||
     request.params.scope + "/" + request.params.project;
 
@@ -60,7 +60,7 @@ package.show = function(request, reply) {
         return promise.cancel();
       }
 
-      return Download.getAll(package.name)
+      return request.server.methods.downloads.getAll(package.name)
     })
     .then(function(downloads) {
       package.downloads = downloads

--- a/models/download.js
+++ b/models/download.js
@@ -11,12 +11,8 @@ var Download = module.exports = function (opts) {
   return this;
 };
 
-Download.new = function(request) {
-  var bearer = request.auth.credentials && request.auth.credentials.name;
-  return new Download({
-    bearer: bearer,
-    cache: require("../lib/cache")
-  });
+Download.new = function() {
+  return new Download()
 };
 
 Download.prototype.getDaily = function(packageName) {
@@ -33,7 +29,6 @@ Download.prototype.getMonthly = function(packageName) {
 
 Download.prototype.getAll = function(packageName) {
   var _this = this;
-
   return Promise.all([
     _this.getDaily(packageName),
     _this.getWeekly(packageName),
@@ -54,6 +49,7 @@ Download.prototype.getSome = function(period, packageName) {
   if (packageName) {
     url += "/" + packageName;
   }
+  console.log("getSome: ", url)
 
   return new Promise(function(resolve, reject) {
     var opts = {
@@ -61,9 +57,6 @@ Download.prototype.getSome = function(period, packageName) {
       url: url,
       json: true,
       timeout: _this.timeout,
-      headers: {
-        bearer: _this.bearer
-      }
     };
 
     if (_this.cache) {

--- a/services/downloads/index.js
+++ b/services/downloads/index.js
@@ -1,39 +1,24 @@
-var Hapi = require('hapi'),
-    request = require('request'),
-    SECOND = 1000;
-
-var timer = {};
+var SECOND = 1000;
 
 exports.register = function Downloads (server, options, next) {
 
-  server.method('downloads.getDownloadsForPackage', require('./methods/getDownloads')(options.url), {
-    cache: {
+  var opts = {};
+  if (process.env.USE_CACHE) {
+    opts.cache = {
       staleTimeout: 1 * SECOND, // don't wait more than a second for fresh data
       staleIn: 60 * 60 * SECOND, // refresh after an hour
       segment: '##packagedownloads'
     }
-  });
+  };
 
-  server.method('downloads.getAllDownloadsForPackage', require('./methods/getAllDownloads')(options.url), {
-    cache: {
-      staleTimeout: 1 * SECOND, // don't wait more than a second for fresh data
-      staleIn: 60 * 60 * SECOND, // refresh after an hour
-      segment: '##packagedownloadsall'
-    }
-  });
-
-  server.method('downloads.getAllDownloads', require('./methods/getAllDownloads')(options.url), {
-    cache: {
-      staleTimeout: 1 * SECOND, // don't wait more than a second for fresh data
-      staleIn: 60 * 60 * SECOND, // refresh after an hour
-      segment: '##alldownloads'
-    }
-  });
+  server.method('downloads.getAll', function(packageName) {
+    return require('../../models/download').new().getAll(packageName);
+  }, opts);
 
   return next();
 };
 
 exports.register.attributes = {
-  "name": "newww-service-downloads",
-  "version": "0.0.1",
+  "name": "downloads",
+  "version": "1.0.0",
 };

--- a/test/mocks/server-methods.js
+++ b/test/mocks/server-methods.js
@@ -25,33 +25,7 @@ module.exports = function (server) {
         return next(new Error('Not Found'));
       }
     },
-
-    downloads: {
-      getAllDownloads: function (next) {
-        var d = {
-          day: 0,
-          week: 0,
-          month: 0
-        };
-
-        return next(null, d);
-      },
-
-      getAllDownloadsForPackage: function (name, next) {
-        var d = [
-                  { day: 32789, week: 268291, month: 1480446 },
-                  null,
-                  { msec: 3, error: null }
-                ];
-
-        return next(null, d);
-      },
-
-      getDownloadsForPackage: function (period, detail, package, next) {
-        return next(null, [{day: '2014-07-12', downloads: 0}, {day: '2014-07-13', downloads: 0}]);
-      }
-    },
-
+    
     email: {
       send: function (template, user, redis) {
         assert(typeof redis === 'object', 'whoops need redis');

--- a/test/mocks/server.js
+++ b/test/mocks/server.js
@@ -1,5 +1,6 @@
 var Hapi = require('hapi'),
-    config = require('../../config');
+    config = require('../../config'),
+    _ = require('lodash');
 
 module.exports = function (done) {
   process.env.NODE_ENV = 'dev';
@@ -9,7 +10,6 @@ module.exports = function (done) {
   var server = new Hapi.Server();
   server.connection();
   server.views(config.views);
-  server.methods = require('./server-methods')(server);
 
   server.register(require('hapi-auth-cookie'), function (err) {
     if (err) { throw err; }
@@ -28,10 +28,11 @@ module.exports = function (done) {
         register: require('crumb'),
         options: { cookieOptions: { isSecure: true } }
       },
-      require('../../adapters/bonbon')
+      require('../../adapters/bonbon'),
+      require('../../services/downloads'),
     ], function (err) {
       server.route(require('../../routes/index'));
-
+      server.methods = _.extend({}, server.methods, require('./server-methods')(server));
       server.start(function () {
         return done(server);
       });


### PR DESCRIPTION
Trying to make use of hapi's built-in catbox caching for fetching package download counts, instead of rolling our own. Download counts in this branch are currently not working when the cache is enabled.