### PR TITLE
Add Constructor.io autocomplete to search bar

### DIFF
--- a/assets/scripts/vendor/constructor-io.js
+++ b/assets/scripts/vendor/constructor-io.js
@@ -1,0 +1,6 @@
+$(function() {
+  $.getScript("//cnstrc.com/js/ac.js", function() {
+    $('#site-search').constructorAutocomplete({ key: 'CD06z4gVeqSXRiDL2ZNK', directResults: true, maxHeight: 400 });
+  })
+});
+

--- a/assets/styles/_header.styl
+++ b/assets/styles/_header.styl
@@ -263,6 +263,16 @@ nav
     background: npmred url(../images/ico-search-hover.svg) no-repeat 50% 50%
     background-size 16px 16px
 
+#autocomplete-direct-results:before
+  content "Packages"
+
+#autocomplete-search-suggestions:before
+  content "Search Suggestions"
+
+.autocomplete-group
+  font-size .7em
+  padding: 3px
+  background-color: #F0F0F0
 
 #user-info
   position absolute

--- a/lib/csp.js
+++ b/lib/csp.js
@@ -49,6 +49,7 @@ csp.default = {
     'https://partners.npmjs.com/',
     'https://api.github.com',
     'https://ac.constructor.io',
+    'https://ac.cnstrc.com',
   ],
   fontSrc: [
     'self',

--- a/lib/csp.js
+++ b/lib/csp.js
@@ -36,6 +36,7 @@ csp.default = {
 
     // Constructor.io
     'https://cnstrc.com/js/ac.js',
+    'https://ac.cnstrc.com',
   ],
   styleSrc: [
     'self',
@@ -48,7 +49,6 @@ csp.default = {
     'https://typeahead.npmjs.com/',
     'https://partners.npmjs.com/',
     'https://api.github.com',
-    'https://ac.constructor.io',
     'https://ac.cnstrc.com',
   ],
   fontSrc: [

--- a/lib/csp.js
+++ b/lib/csp.js
@@ -33,6 +33,9 @@ csp.default = {
 
     // HTML5 tag support for old browsers
     'https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.2/html5shiv.min.js',
+
+    // Constructor.io
+    'https://cnstrc.com/js/ac.js',
   ],
   styleSrc: [
     'self',
@@ -45,6 +48,7 @@ csp.default = {
     'https://typeahead.npmjs.com/',
     'https://partners.npmjs.com/',
     'https://api.github.com',
+    'https://ac.constructor.io',
   ],
   fontSrc: [
     'self',


### PR DESCRIPTION
Closes #720  Hi guys -- Co-founder of Constructor.io here. @EliFinkelshteyn and I have an autocomplete all ready for you. Currently, we have it auto-completing to packages for your users who know exactly what they're looking for, and to common searches for users who are looking more serendipitously.

Right now, we have you on the ad-based/branded plan, but we'd be happy to talk about taking you off of that and moving to something else, if you'd prefer.

Finally, we just made some basic styling for your current autocomplete, thinking you'd be likely to change it. That's very easy to do with css (in _header.styl), if you're interested. Otherwise, you're more than welcome to use everything as is. Please let us know if you have any questions, comments, or concerns!