### PR TITLE
Signup and Email Confirmation Flows

### DIFF
--- a/assets/styles/forms.styl
+++ b/assets/styles/forms.styl
@@ -267,10 +267,3 @@ label.wrapping-hidden-radio
     font-weight normal
     border-radius 3px
     padding 1px 8px 3px 8px
-
-.email-label:hover, .email-field:hover
-  text-decoration none
-  color greigh2
-
-.email-field input
-  background-color greigh6

--- a/assets/styles/typography.styl
+++ b/assets/styles/typography.styl
@@ -125,7 +125,7 @@ p
   margin 0 0 15px 0
 
   &.notice
-    line-height 1.3
+    line-height 1.5
 
   &.whoa
     background npmred

--- a/config.js
+++ b/config.js
@@ -116,7 +116,7 @@ config.user = {
       secretAccessKey: process.env.MAIL_SECRET_ACCESS_KEY,
       region: "us-west-2"
     }),
-    emailFrom: 'support@npmjs.com'
+    emailFrom: 'npm <support@npmjs.com>'
   }
 };
 

--- a/facets/user/show-profile-edit.js
+++ b/facets/user/show-profile-edit.js
@@ -26,7 +26,6 @@ module.exports = function (request, reply) {
       }
 
       merge(loggedInUser.resource, userChanges);
-
       loggedInUser = presenter(loggedInUser);
 
       User.new(request).save(loggedInUser, function (err, data) {
@@ -54,6 +53,7 @@ module.exports = function (request, reply) {
   if (request.method === 'get' || opts.error) {
     request.timing.page = 'profile-edit';
     opts.title = 'Edit Profile';
+    opts.showEmailSentNotice = request.query['verification-email-sent'] === "yep"
     return reply.view('user/profile-edit', opts);
   }
 };

--- a/facets/user/show-profile-edit.js
+++ b/facets/user/show-profile-edit.js
@@ -54,6 +54,7 @@ module.exports = function (request, reply) {
     request.timing.page = 'profile-edit';
     opts.title = 'Edit Profile';
     opts.showEmailSentNotice = request.query['verification-email-sent'] === "yep"
+    opts.showWelcomeMessage = request.query['new-user'] === "yep"
     return reply.view('user/profile-edit', opts);
   }
 };

--- a/facets/user/show-resend-email-confirmation.js
+++ b/facets/user/show-resend-email-confirmation.js
@@ -10,7 +10,7 @@ module.exports = function resendConfirmation (request, reply) {
       request.timing.page = 'resend-confirm-email';
       request.metrics.metric({name: 'resend-confirm-email'});
 
-      return reply.redirect('/profile-edit');
+      return reply.redirect('/profile-edit?verification-email-sent=yep');
     })
     .catch(function(er) {
       var message = 'Unable to resend email confirmation to ' + user.email;

--- a/facets/user/show-signup.js
+++ b/facets/user/show-signup.js
@@ -85,7 +85,7 @@ module.exports = function signup (request, reply) {
                   request.timing.page = 'signup';
                   request.metrics.metric({name: 'signup'});
 
-                  return reply.redirect('/profile-edit');
+                  return reply.redirect('/profile-edit?new-user=yep');
                 })
                 .catch(function(er) {
                   var message = 'Unable to send email to ' + user.email;
@@ -101,7 +101,7 @@ module.exports = function signup (request, reply) {
                   request.timing.page = 'signup';
                   request.metrics.metric({name: 'signup'});
 
-                  return reply.redirect('/profile-edit');
+                  return reply.redirect('/profile-edit?new-user=yep');
                 });
               });
             });

--- a/locales/en_US/user.js
+++ b/locales/en_US/user.js
@@ -1,49 +1,49 @@
 module.exports = {
   signup: {
-    title: "Create an Account",
-    subtitle: "Sign all the way up",
+    title: "create an account",
+    subtitle: "sign all the way up",
     error: "There was a problem! The server said:",
     form: {
-      username: "Username",
-      nameHelp: "Must be lowercase and composed of URL-safe characters.",
-      password: "Password",
-      verify: "Verify Password",
-      email: "Email Address",
+      username: "username",
+      nameHelp: "must be lowercase and composed of URL-safe characters.",
+      password: "password",
+      verify: "verify password",
+      email: "email address",
       emailHelp: "This <strong>will</strong> be public and shown on all the packages you publish. Accounts with invalid emails may be deleted without notice.",
-      npmWeekly: "Sign up for npm Weekly emails",
-      submit: "Make it so"
+      npmWeekly: "sign up for npm weekly emails",
+      submit: "make it so"
     }
   },
 
   login: {
-    title: "Login",
-    subtitle: "You look lovely today, btw.",
+    title: "login",
+    subtitle: "you look lovely today, btw.",
     error: {
-      invalid: "Invalid username or password",
+      invalid: "invalid username or password",
       invalidContext: "If you feel that this is a mistake, please email <a href='mailto:support@npmjs.com'>support@npmjs.com</a> with the following unique error ID:"
     },
     form: {
-      username: "Username",
-      password: "Password",
-      forgot: "Forgot your password?",
-      signup: "Create an Account",
-      submit: "Login"
+      username: "username",
+      password: "password",
+      forgot: "forgot your password?",
+      signup: "create an account",
+      submit: "login"
     }
   },
 
   password: {
-    title: "Forgot your password?",
-    subtitle: "Don't worry. It happens to the best of us.",
+    title: "forgot your password?",
+    subtitle: "don't worry. it happens to the best of us.",
     emailed: "An email has been sent. Click the link when you get it.",
     multipleUsernames: "Found multiple usernames for the given email address. Please choose one.",
     form: {
-      submit: "Email me a recovery link"
+      submit: "email me a recovery link"
     }
   },
 
   profile: {
     not_found: {
-      subtitle: "Sorry, there's no user by that name."
+      subtitle: "sorry, there's no user by that name."
     }
   }
 

--- a/models/download.js
+++ b/models/download.js
@@ -64,10 +64,9 @@ Download.prototype.getSome = function(period, packageName) {
       url: url,
       json: true,
       timeout: _this.timeout,
-      headers: {
-        bearer: _this.bearer
-      }
     };
+
+    if (_this.bearer) opts.headers = {bearer: _this.bearer};
 
     if (_this.cache) {
       _this.cache.get(opts, function(err, body){

--- a/models/package.js
+++ b/models/package.js
@@ -15,9 +15,13 @@ var Package = module.exports = function(opts) {
 };
 
 Package.new = function(request) {
-  var bearer = request.auth.credentials && request.auth.credentials.name;
-  var logger = request.logger;
-  return new Package({bearer: bearer, logger: logger});
+  var opts = {
+    logger: request.logger
+  }
+  if (request.auth.credentials) {
+    opts.bearer = request.auth.credentials.name;
+  }
+  return new Package(opts);
 };
 
 Package.prototype.get = function(name) {
@@ -28,8 +32,9 @@ Package.prototype.get = function(name) {
     var opts = {
       url: url,
       json: true,
-      headers: {bearer: _this.bearer}
     };
+
+    if (_this.bearer) opts.headers = {bearer: _this.bearer};
 
     request.get(opts, function(err, resp, body) {
       if (err) { return reject(err); }
@@ -58,9 +63,10 @@ Package.prototype.update = function(name, body) {
       method: "POST",
       url: url,
       json: true,
-      headers: {bearer: _this.bearer},
       body: body
     };
+
+    if (_this.bearer) opts.headers = {bearer: _this.bearer};
 
     request(opts, function(err, resp, body) {
       if (err) { return reject(err); }
@@ -134,8 +140,9 @@ Package.prototype.star = function (package) {
     var opts = {
       url: url,
       json: true,
-      headers: {bearer: _this.bearer}
     };
+
+    if (_this.bearer) opts.headers = {bearer: _this.bearer};
 
     request.put(opts, function (err, resp, body) {
       if (err) {
@@ -161,8 +168,9 @@ Package.prototype.unstar = function (package) {
     var opts = {
       url: url,
       json: true,
-      headers: {bearer: _this.bearer}
     };
+
+    if (_this.bearer) opts.headers = {bearer: _this.bearer};
 
     request.del(opts, function (err, resp, body) {
       if (err) { return reject(err); }

--- a/presenters/user.js
+++ b/presenters/user.js
@@ -8,7 +8,7 @@ module.exports = function(user) {
   user = merge({}, user);
   user.emailObfuscated = obfuscateEmail(user.email);
   user.avatar = avatar(user.email);
-  user.meta = deriveMetaObjectFromFieldsArray(user.resource);
+  sanitizeResources(user.resource);
   return user;
 };
 
@@ -19,53 +19,57 @@ var obfuscateEmail = function(email) {
   }).join('');
 };
 
-var deriveMetaObjectFromFieldsArray = function(resources) {
-  var meta = {};
+var sanitizeResources = function sanitizeResources(resources) {
+  if (!resources) return
+  Object.keys(resources).forEach(function(key){
+    var value = resources[key]
 
-  if (!resources) {
-    return meta;
+    if (!key || !value) {
+      delete resources[key]
+    }
+
+    if (key in sanitizers) {
+      resources[key] = sanitizers[key](value)
+    }
+  })
+}
+
+var sanitizers = {
+
+  homepage: function(input) {
+    // URL
+    if (isURL(input)) { return input; }
+
+    // Not-fully-qualified URL
+    if (isURL("http://"+input)) { return "http://"+input; }
+  },
+
+  twitter: function(input) {
+    // URL
+    if (isURL(input)) { return URL.parse(input).path.replace("/", ""); }
+
+    // Not-fully-qualified URL
+    var twittery = new RegExp("^twitter.com/", "i");
+    if (input.match(twittery)) { return input.replace(twittery, ""); }
+
+    // Starts with @
+    if (input.match(atty)) { return input.replace(atty, ""); }
+
+    return input;
+  },
+
+  github: function(input) {
+    // URL
+    if (isURL(input)) { return URL.parse(input).path.replace("/", ""); }
+
+    // Not-fully-qualified URL
+    var githubby = new RegExp("^github.com/", "i");
+    if (input.match(githubby)) { return input.replace(githubby, ""); }
+
+    // Starts with @
+    if (input.match(atty)) { return input.replace(atty, ""); }
+
+    return input;
   }
 
-  meta.homepage = resources.homepage && sanitizeHomepage(resources.homepage);
-  meta.github = resources.github && sanitizeGitHubHandle(resources.github);
-  meta.twitter = resources.twitter && sanitizeTwitterHandle(resources.twitter);
-  meta.freenode = resources.freenode;
-
-  return meta;
-};
-
-var sanitizeHomepage = function(input) {
-  // URL
-  if (isURL(input)) { return input; }
-
-  // Not-fully-qualified URL
-  if (isURL("http://"+input)) { return "http://"+input; }
-};
-
-var sanitizeTwitterHandle = function(input) {
-  // URL
-  if (isURL(input)) { return URL.parse(input).path.replace("/", ""); }
-
-  // Not-fully-qualified URL
-  var twittery = new RegExp("^twitter.com/", "i");
-  if (input.match(twittery)) { return input.replace(twittery, ""); }
-
-  // Starts with @
-  if (input.match(atty)) { return input.replace(atty, ""); }
-
-  return input;
-};
-
-var sanitizeGitHubHandle = function(input) {
-  // URL
-  if (isURL(input)) { return URL.parse(input).path.replace("/", ""); }
-
-  // Not-fully-qualified URL
-  var githubby = new RegExp("^github.com/", "i");
-  if (input.match(githubby)) { return input.replace(githubby, ""); }
-
-  // Starts with @
-  if (input.match(atty)) { return input.replace(atty, ""); }
-
-  return input;
-};
+}

--- a/presenters/user.js
+++ b/presenters/user.js
@@ -1,8 +1,7 @@
 var merge = require("lodash").merge,
     URL = require("url"),
     isURL = require("is-url"),
-    avatar = require("../lib/avatar"),
-    atty = new RegExp("^@");
+    avatar = require("../lib/avatar");
 
 module.exports = function(user) {
   user = merge({}, user);
@@ -52,10 +51,7 @@ var sanitizers = {
     var twittery = new RegExp("^twitter.com/", "i");
     if (input.match(twittery)) { return input.replace(twittery, ""); }
 
-    // Starts with @
-    if (input.match(atty)) { return input.replace(atty, ""); }
-
-    return input;
+    return input.replace("@", "");
   },
 
   github: function(input) {
@@ -66,10 +62,7 @@ var sanitizers = {
     var githubby = new RegExp("^github.com/", "i");
     if (input.match(githubby)) { return input.replace(githubby, ""); }
 
-    // Starts with @
-    if (input.match(atty)) { return input.replace(atty, ""); }
-
-    return input;
+    return input.replace("@", "");
   }
 
 }

--- a/templates/partials/email-verify-nag.hbs
+++ b/templates/partials/email-verify-nag.hbs
@@ -1,0 +1,10 @@
+{{#if user}}
+  {{#unless user.email_verified}}
+    <p class="notice">
+      Howdy, {{user.name}}. You'll need to
+      <a href="/resend-email-confirmation">confirm your email address</a>
+      before you can use
+      <a href="/private-modules">private and scoped modules</a>.
+    </p>
+  {{/unless}}
+{{/if}}

--- a/templates/partials/email-verify-nag.hbs
+++ b/templates/partials/email-verify-nag.hbs
@@ -2,7 +2,7 @@
   {{#unless user.email_verified}}
     <p class="notice">
       Howdy, {{user.name}}. You'll need to
-      <a href="/resend-email-confirmation">confirm your email address</a>
+      <a href="/resend-email-confirmation">verify your email address</a>
       before you can use
       <a href="/private-modules">private and scoped modules</a>.
     </p>

--- a/templates/user/billing.hbs
+++ b/templates/user/billing.hbs
@@ -6,6 +6,8 @@
     <h1>your billing info</h1>
   </hgroup>
 
+  {{> email-verify-nag}}
+
   {{#if canceled}}
     <p class="notice cancellation-notice">
       You have successfully cancelled your private npm subscription. Your free account

--- a/templates/user/billing.hbs
+++ b/templates/user/billing.hbs
@@ -3,7 +3,7 @@
 <div class="container narrow">
 
   <hgroup>
-    <h1>Your Billing Info</h1>
+    <h1>your billing info</h1>
   </hgroup>
 
   {{#if canceled}}

--- a/templates/user/email-confirmed.hbs
+++ b/templates/user/email-confirmed.hbs
@@ -2,8 +2,19 @@
 
 <div class="container narrow">
 
-  <h2>Email Address Confirmed!</h2>
+  <hgroup>
+    <h1>hi again</h1>
+    <h2>thanks for verifying your email address</h2>
+  </hgroup>
 
-  <p>Thank you for confirming your email address. You are all set!</p>
+  {{#if emailJustConfirmed}}
+    <p class="notice">
+      Now that you've cleared that up, you should
+      <a href="/profile-edit">update your profile</a>,
+      sign up for <a href="/settings/billing">private modules</a>,
+      or learn how to
+      <a href="https://docs.npmjs.com/">get started with npm</a>.
+    </p>
+  {{/if}}
 
 </div>

--- a/templates/user/email-confirmed.hbs
+++ b/templates/user/email-confirmed.hbs
@@ -9,7 +9,7 @@
 
   {{#if emailJustConfirmed}}
     <p class="notice">
-      Now that you've cleared that up, you should
+      Now that you've cleared that up, you might want to
       <a href="/profile-edit">update your profile</a>,
       sign up for <a href="/settings/billing">private modules</a>,
       or learn how to

--- a/templates/user/email-edit.hbs
+++ b/templates/user/email-edit.hbs
@@ -3,14 +3,14 @@
 <div class="container narrow">
 
   <hgroup>
-    <h1>Edit Email Address</h1>
+    <h1>edit email address</h1>
   </hgroup>
 
   {{#unless submitted}}
 
     <form data-tab="edit-email" method="post" action="/email-edit">
 
-      <p>An email will be sent to the new address to confirm. Please click the link when you receive it. An informative confirmation email will be sent to the old address just to verify that this is intentional.</p>
+      <p>An email will be sent to the new address to confirm. Another email will also be sent to the old address to verify that this is intentional.</p>
 
       <input type="hidden" name="_id" value="{{profile._id}}">
       <input type="hidden" name="name" value="{{profile.name}}">

--- a/templates/user/password.hbs
+++ b/templates/user/password.hbs
@@ -2,7 +2,7 @@
 
 <div class="container narrow">
   <hgroup>
-    <h1>Change Password</h1>
+    <h1>change password</h1>
   </hgroup>
 
   <form data-tab="password" method="post">

--- a/templates/user/profile-edit.hbs
+++ b/templates/user/profile-edit.hbs
@@ -6,7 +6,13 @@
     <h1>edit your profile</h1>
   </hgroup>
 
-  {{> email-verify-nag}}
+  {{#if showEmailSentNotice}}
+    <p class="notice">
+      Go check your <a href="mailto:{{user.email}}">{{user.email}}</a> inbox. You should see something from us :)
+    </p>
+  {{else}}
+    {{> email-verify-nag}}
+  {{/if}}
 
   {{> errors}}
 

--- a/templates/user/profile-edit.hbs
+++ b/templates/user/profile-edit.hbs
@@ -6,12 +6,19 @@
     <h1>edit your profile</h1>
   </hgroup>
 
-  {{#if showEmailSentNotice}}
+  {{#if showWelcomeMessage}}
     <p class="notice">
+      Thanks for signing up, {{user.name}}!
       Go check your <a href="mailto:{{user.email}}">{{user.email}}</a> inbox. You should see something from us :)
     </p>
   {{else}}
-    {{> email-verify-nag}}
+    {{#if showEmailSentNotice}}
+      <p class="notice">
+        Go check your <a href="mailto:{{user.email}}">{{user.email}}</a> inbox. You should see something from us :)
+      </p>
+    {{else}}
+      {{> email-verify-nag}}
+    {{/if}}
   {{/if}}
 
   {{> errors}}

--- a/templates/user/profile-edit.hbs
+++ b/templates/user/profile-edit.hbs
@@ -14,28 +14,23 @@
     {{#with user}}
 
       <label for="fullname">full name</label>
-      <input type="text" id="fullname" name="fullname" value="{{fullname}}">
+      <input type="text" id="fullname" name="fullname" value="{{resource.fullname}}">
       <p class="help-text example">Wombat Watson</p>
 
-      <a href="/email-edit" class="email-label">email address</a>
-      <a href="/email-edit" class="email-field">
-        <input type="text" id="email" name="email" value="{{email}}" disabled='disabled'>
-      </a>
-
       <label for="homepage">homepage</label>
-      <input type="text" id="homepage" name="homepage" value="{{homepage}}" autocorrect="off" autocapitalize="off">
+      <input type="text" id="homepage" name="homepage" value="{{resource.homepage}}" autocorrect="off" autocapitalize="off">
       <p class="help-text example">wombats-rule.com</p>
 
       <label for="github">github</label>
-      <input type="text" id="github" name="github" value="{{github}}" autocorrect="off" autocapitalize="off">
+      <input type="text" id="github" name="github" value="{{resource.github}}" autocorrect="off" autocapitalize="off">
       <p class="help-text example">wombat</p>
 
       <label for="twitter">twitter</label>
-      <input type="text" id="twitter" name="twitter" value="{{twitter}}" autocorrect="off" autocapitalize="off">
+      <input type="text" id="twitter" name="twitter" value="{{resource.twitter}}" autocorrect="off" autocapitalize="off">
       <p class="help-text example">wombat</p>
 
       <label for="freenode">freenode</label>
-      <input type="text" id="freenode" name="freenode" value="{{freenode}}" autocorrect="off" autocapitalize="off">
+      <input type="text" id="freenode" name="freenode" value="{{resource.freenode}}" autocorrect="off" autocapitalize="off">
       <p class="help-text example">wombat</p>
 
     {{/with}}
@@ -48,6 +43,11 @@
   <p class="change-avatar">
     <a href="https://en.gravatar.com/emails/"><img src="{{user.avatar.small}}"></a>
     Change your avatar at <a href="https://en.gravatar.com/emails/">gravatar.com</a>
+  </p>
+
+  <p>
+    Need to change your email address?
+    <a href="/email-edit">Right this way.</a>
   </p>
 
 </div>

--- a/templates/user/profile-edit.hbs
+++ b/templates/user/profile-edit.hbs
@@ -3,19 +3,10 @@
 <div class="container narrow">
 
   <hgroup>
-    <h1>Edit your Profile</h1>
+    <h1>edit your profile</h1>
   </hgroup>
 
-  <p class="notice whoa">
-    Need to reconfirm your email?
-    <a href="/resend-email-confirmation">Click here</a>.
-  </p>
-
-  <p class="notice">
-    Private npm is here at last. To start creating your own private packages,
-    <a href="/private-npm">read more</a> or
-    <a href="/settings/billing">sign up</a>.
-  </p>
+  {{> email-verify-nag}}
 
   {{> errors}}
 

--- a/templates/user/profile-edit.hbs
+++ b/templates/user/profile-edit.hbs
@@ -8,13 +8,13 @@
 
   {{#if showWelcomeMessage}}
     <p class="notice">
-      Thanks for signing up, {{user.name}}!
-      Go check your <a href="mailto:{{user.email}}">{{user.email}}</a> inbox. You should see something from us :)
+      Welcome to npm, {{user.name}}!
+      If you check your <a href="mailto:{{user.email}}">{{user.email}}</a> inbox, you should see something from us :)
     </p>
   {{else}}
     {{#if showEmailSentNotice}}
       <p class="notice">
-        Go check your <a href="mailto:{{user.email}}">{{user.email}}</a> inbox. You should see something from us :)
+        If you check your <a href="mailto:{{user.email}}">{{user.email}}</a> inbox, you should see something from us :)
       </p>
     {{else}}
       {{> email-verify-nag}}

--- a/templates/user/profile.hbs
+++ b/templates/user/profile.hbs
@@ -47,7 +47,20 @@
     </a>
   {{/if}}
 
-  <h2>{{fullname}}</h2>
+  {{#if isSelf}}
+    <p class="notice">
+      This is your profile page, {{name}}! You can
+      <a href=/profile-edit>update your social info</a>,
+      <a href=/password >change your password</a>, or
+      <a href="http://gravatar.com/emails/">update your avatar</a>.
+    </p>
+
+    {{> email-verify-nag}}
+  {{/if}}
+
+  {{#if resource.fullname}}
+    <h2>{{resource.fullname}}</h2>
+  {{/if}}
 
   <ul class="meta">
 
@@ -83,12 +96,6 @@
       <li class="freenode">
         <a href="irc://chat.freenode.net/npm">{{meta.freenode}}</a> on freenode
       </li>
-    {{/if}}
-
-    {{#if isSelf}}
-        <li><a href=/profile-edit class="unadorned">Edit your Profile</a></li>
-        <li><a href=/password class="unadorned">Change your Password</a></li>
-        <li><a href="http://gravatar.com/emails/" class="unadorned">Change your Picture</a></li>
     {{/if}}
 
   </ul>

--- a/test/adapters/bonbon.js
+++ b/test/adapters/bonbon.js
@@ -67,7 +67,7 @@ describe("bonbon", function() {
     server.inject(options, function (resp) {
       expect(resp.statusCode).to.equal(200);
       expect(resp.result.profile).to.exist();
-      expect(resp.result.profile.meta).to.exist();
+      expect(resp.result.profile.name).to.exist();
       done();
     });
   });
@@ -75,7 +75,7 @@ describe("bonbon", function() {
   it('returns a subset of the context if `json` has a value', function (done) {
 
     var options = {
-      url: '/~' + username1 + '?json=profile.meta',
+      url: '/~' + username1 + '?json=profile.resource',
       credentials: fixtures.users.npmEmployee
     };
     expect(process.env.NODE_ENV).to.equal("production");

--- a/test/fixtures/users.js
+++ b/test/fixtures/users.js
@@ -62,12 +62,6 @@ exports.bobUpdateBody = {
     small: 'https://secure.gravatar.com/avatar/5cf1283a6c89c584954971789eda3656?size=50&default=https%3A%2F%2Fwww.npmjs.com%2Fstatic%2Fimages%2Fwombat-avatar-small.png',
     medium: 'https://secure.gravatar.com/avatar/5cf1283a6c89c584954971789eda3656?size=100&default=https%3A%2F%2Fwww.npmjs.com%2Fstatic%2Fimages%2Fwombat-avatar-small.png',
     large: 'https://secure.gravatar.com/avatar/5cf1283a6c89c584954971789eda3656?size=496&default=https%3A%2F%2Fwww.npmjs.com%2Fstatic%2Fimages%2Fwombat-avatar-large.png'
-  },
-  meta: {
-    homepage: 'http://boom.me',
-    github: 'bob',
-    twitter: 'bobby',
-    freenode: 'bobob'
   }
 };
 

--- a/test/handlers/user/edit-profile.js
+++ b/test/handlers/user/edit-profile.js
@@ -99,7 +99,7 @@ describe('Modifying the profile', function () {
       options.payload.crumb = crumb;
 
       server.inject(options, function (resp) {
-
+        mock.done()
         expect(resp.statusCode).to.equal(302);
         expect(resp.headers.location).to.include('profile');
         var cache = resp.request.server.app.cache._cache.connection.cache['|sessions'];

--- a/test/handlers/user/login.js
+++ b/test/handlers/user/login.js
@@ -10,12 +10,10 @@ var generateCrumb = require("../crumb"),
     it = lab.test,
     expect = Code.expect,
     nock = require("nock"),
-    redis = require("../../../adapters/redis-sessions");
-
-var server,
+    redis = require("../../../adapters/redis-sessions"),
+    server,
     users = require('../../fixtures').users;
 
-// prepare the server
 before(function (done) {
   require('../../mocks/server')(function (obj) {
     server = obj;

--- a/test/handlers/user/resend-email-confirmation.js
+++ b/test/handlers/user/resend-email-confirmation.js
@@ -47,7 +47,7 @@ describe('Request to resend confirmation email', function () {
 
     server.inject(opts, function (resp) {
       expect(resp.statusCode).to.equal(302);
-      expect(resp.headers.location).to.equal('/profile-edit');
+      expect(resp.headers.location).to.equal('/profile-edit?verification-email-sent=yep');
       done();
     });
   });
@@ -66,4 +66,3 @@ describe('Request to resend confirmation email', function () {
     });
   });
 });
-

--- a/test/handlers/user/signup.js
+++ b/test/handlers/user/signup.js
@@ -1,4 +1,5 @@
 var generateCrumb = require("../crumb"),
+    nock = require('nock'),
     Code = require('code'),
     Lab = require('lab'),
     lab = exports.lab = Lab.script(),
@@ -7,13 +8,11 @@ var generateCrumb = require("../crumb"),
     after = lab.after,
     it = lab.test,
     expect = Code.expect,
-    nock = require('nock'),
-    users = require('../../fixtures').users;
+    fixtures = require('../../fixtures'),
+    forms = require('../../fixtures/signup'),
+    server,
+    cookieCrumb;
 
-var server, cookieCrumb,
-    forms = require('../../fixtures/signup');
-
-// prepare the server
 before(function (done) {
   require('../../mocks/server')(function (obj) {
     server = obj;
@@ -74,7 +73,7 @@ describe('Signing up a new user', function () {
 
     var mock = nock("https://user-api-example.com")
       .get("/user/bob")
-      .reply(200, users.bob);
+      .reply(200, fixtures.users.bob);
 
     server.inject(postSignup(forms.alreadyExists), function (resp) {
       mock.done();
@@ -158,7 +157,7 @@ describe('Signing up a new user', function () {
         email: 'fakeusercli@boom.com',
         sid: "39071865"
       })
-      .reply(200, users.mikeal);
+      .reply(200, fixtures.users.mikeal);
 
     server.inject(postSignup(forms.good), function (resp) {
       mock.done();
@@ -180,7 +179,7 @@ describe('Signing up a new user', function () {
         email: 'fakeusercli@boom.com',
         sid: '39071865'
       })
-      .reply(200, users.mikeal);
+      .reply(200, fixtures.users.mikeal);
 
     server.inject(postSignup(forms.goodPassWithUmlaut), function (resp) {
       mock.done();

--- a/test/presenters/user.js
+++ b/test/presenters/user.js
@@ -46,12 +46,12 @@ describe("avatar", function(){
   });
 });
 
-describe("meta", function () {
+describe("resource", function () {
 
-  it("is an object with key-value pairs", function(done){
-    var user = present(fixtures.users.full_meta);
-    expect(user.meta).to.exist();
-    expect(user.meta).to.be.an.object();
+  it("is an object", function(done){
+    var user = present({name: "zeke", resource: {github: "zeke"}});
+    expect(user.resource).to.exist();
+    expect(user.resource).to.be.an.object();
     done();
   });
 
@@ -65,11 +65,11 @@ describe("meta", function () {
         ICQ: ''
       }
     });
-    expect(Object.keys(user.meta)).to.have.length(4);
-    expect(user.meta.github).to.exist();
-    expect(user.meta.twitter).to.exist();
-    expect(user.meta.freenode).to.be.undefined();
-    expect(user.meta.ICQ).to.not.exist();
+    expect(Object.keys(user.resource)).to.have.length(2);
+    expect(user.resource.github).to.exist();
+    expect(user.resource.twitter).to.exist();
+    expect(user.resource.freenode).to.be.undefined();
+    expect(user.resource.ICQ).to.be.undefined();
     done();
   });
 
@@ -82,7 +82,7 @@ describe("meta", function () {
           homepage: "https://lisa.org"
         }
       });
-      expect(user.meta.homepage).to.equal("https://lisa.org");
+      expect(user.resource.homepage).to.equal("https://lisa.org");
       done();
     });
 
@@ -93,7 +93,7 @@ describe("meta", function () {
           homepage: "margaret.com"
         }
       });
-      expect(user.meta.homepage).to.equal("http://margaret.com");
+      expect(user.resource.homepage).to.equal("http://margaret.com");
       done();
     });
 
@@ -105,7 +105,7 @@ describe("meta", function () {
           homepage: "kate"
         }
       });
-      expect(user.meta.homepage).to.not.exist();
+      expect(user.resource.homepage).to.not.exist();
       done();
     });
   });
@@ -119,7 +119,7 @@ describe("meta", function () {
           github: "@eleanor"
         }
       });
-      expect(user.meta.github).to.equal("eleanor");
+      expect(user.resource.github).to.equal("eleanor");
       done();
     });
 
@@ -130,7 +130,7 @@ describe("meta", function () {
           github: "https://github.com/suzan"
         }
       });
-      expect(user.meta.github).to.equal("suzan");
+      expect(user.resource.github).to.equal("suzan");
       done();
     });
 
@@ -141,7 +141,7 @@ describe("meta", function () {
           github: "github.com/jimbo"
         }
       });
-      expect(user.meta.github).to.equal("jimbo");
+      expect(user.resource.github).to.equal("jimbo");
       done();
     });
 
@@ -153,8 +153,8 @@ describe("meta", function () {
           github: ""
         }
       });
-      expect(user.meta.twitter).to.equal("suzan");
-      expect(user.meta.github).to.be.empty();
+      expect(user.resource.twitter).to.equal("suzan");
+      expect(user.resource.github).to.be.empty();
       done();
     });
   });
@@ -167,7 +167,7 @@ describe("meta", function () {
           twitter: "@eleanor"
         }
       });
-      expect(user.meta.twitter).to.equal("eleanor");
+      expect(user.resource.twitter).to.equal("eleanor");
       done();
     });
 
@@ -178,7 +178,7 @@ describe("meta", function () {
           twitter: "https://twitter.com/suzan"
         }
       });
-      expect(user.meta.twitter).to.equal("suzan");
+      expect(user.resource.twitter).to.equal("suzan");
       done();
     });
 
@@ -189,7 +189,7 @@ describe("meta", function () {
           twitter: "twitter.com/suzan"
         }
       });
-      expect(user.meta.twitter).to.equal("suzan");
+      expect(user.resource.twitter).to.equal("suzan");
       done();
     });
   });
@@ -203,7 +203,7 @@ describe("meta", function () {
           freenode: "eleanor1"
         }
       });
-      expect(user.meta.freenode).to.equal("eleanor1");
+      expect(user.resource.freenode).to.equal("eleanor1");
       done();
     });
   });


### PR DESCRIPTION
Fixes https://github.com/npm/newww/issues/686 and https://github.com/npm/newww/issues/755

- [x] Post signup, add "check your email" message
- [x] Email should come from npm, not support
- [x] Confirmation page encourage user to do the "next" thing
- [x] Add a "confirm your email" notice on the profile-edit and billing pages.


## post-signup notice

![screen shot 2015-03-19 at 9 23 23 pm](https://cloud.githubusercontent.com/assets/2289/6746038/a71a9f3e-ce7e-11e4-8eb9-6037efdaf53e.png)

##  existing, unverified user notice

![screen shot 2015-03-19 at 7 26 20 pm](https://cloud.githubusercontent.com/assets/2289/6746061/c4107708-ce7e-11e4-9341-a466fbcb64f5.png)

## existing, unverified user post-verification-sendage notice

![screen shot 2015-03-19 at 7 36 41 pm](https://cloud.githubusercontent.com/assets/2289/6746065/07781a32-ce7f-11e4-8a5d-db331540646f.png)

## revised admin thingy on profile page

![screen shot 2015-03-19 at 9 31 12 pm](https://cloud.githubusercontent.com/assets/2289/6746077/55ed9c6e-ce7f-11e4-86b9-5e921a3161e2.png)

## email from "npm"

![screen shot 2015-03-19 at 9 37 56 pm](https://cloud.githubusercontent.com/assets/2289/6746131/56485b58-ce80-11e4-9906-0030617a614d.png)
