### PR TITLE
Promise.catch(err).then() considered incorrect.

### DIFF
--- a/handlers/star.js
+++ b/handlers/star.js
@@ -21,32 +21,31 @@ module.exports = function (request, reply) {
 
   if (starIt) {
     Package.star(pkg)
+      .then(function () {
+        request.timing.page = 'star';
+        request.metrics.metric({ name: 'star', package: pkg });
+        return reply(username + ' starred ' + pkg).code(200);
+      })
       .catch(function (err) {
         request.logger.error(username + ' was unable to star ' + pkg);
         request.logger.error(err);
         reply('not ok').code(500);
         return;
-      })
-      .then(function () {
-        request.timing.page = 'star';
-        request.metrics.metric({ name: 'star', package: pkg });
-        return reply(username + ' starred ' + pkg).code(200);
       });
-
   } else {
 
     Package.unstar(pkg)
-      .catch(function (err) {
-        request.logger.error(username + ' was unable to unstar ' + pkg);
-        request.logger.error(err);
-        reply('not ok').code(500);
-        return;
-      })
       .then(function () {
         request.timing.page = 'unstar';
         request.metrics.metric({ name: 'unstar', package: pkg });
 
         return reply(username + ' unstarred ' + pkg).code(200);
+      })
+      .catch(function (err) {
+        request.logger.error(username + ' was unable to unstar ' + pkg);
+        request.logger.error(err);
+        reply('not ok').code(500);
+        return;
       });
   }
 };


### PR DESCRIPTION
The correct order of operations here is `Promise.then(normal-flow).catch(error);`

If you catch an error, return from that function, then pass the result along to a then(), whatever's in the then will be executed. If you want it not to be executed, you need to cancel the promise in the error handler. However, the pattern `then().then().catch()` is the expected use of promise chains, and that's what we're now doing here.

Caught this because a misconfigured service was causing all star operations to error, which then caused a double-reply error in www.