### PR TITLE
use percentages for a more adaptive mobile/desktop package page

### DIFF
--- a/assets/styles/forms.styl
+++ b/assets/styles/forms.styl
@@ -158,9 +158,9 @@ form.star
   left -16px
   display block
   margin 10px 0
-  @media only screen and (max-width: minColumnWidth)
+  @media only screen and (max-width: mobileMaxWidth)
     left auto
-    top 4px
+    top 28px
     right starHeight+2px
 
   input[type=checkbox]

--- a/assets/styles/layout.styl
+++ b/assets/styles/layout.styl
@@ -28,20 +28,20 @@ section
 
 .content-column
   float left
-  width minColumnWidth - sidebarMaxWidth - 100px
+  width 65%
   margin-bottom 90px
 
-  @media only screen and (max-width: minColumnWidth)
+  @media only screen and (max-width: mobileMaxWidth)
     float none
-    max-width 100%
+    width 100%
     margin-bottom 40px
 
 .sidebar
   float right
   margin-top 40px
-  max-width sidebarMaxWidth
-  @media only screen and (max-width: minColumnWidth)
-    max-width 100%
+  width 30%
+  @media only screen and (max-width: mobileMaxWidth)
+    width 100%
     float none
     clear both
     overflow hidden

--- a/assets/styles/typography.styl
+++ b/assets/styles/typography.styl
@@ -33,7 +33,7 @@ a
 
 h1
   margin 0
-  padding 30px 0 0 0
+  padding 20px 0 0 0
   font-weight 400
   font-size 44px
   line-height 1.2

--- a/assets/styles/variables.styl
+++ b/assets/styles/variables.styl
@@ -31,7 +31,7 @@ tablet-width = 640px
 mobileMaxWidth = 767px
 npmInstallHeight = 18px
 npmInstallFontSize = 15px
-sidebarMaxWidth = 320px
+sidebarMinWidth = 320px
 
 // Avatars
 

--- a/templates/package/show.hbs
+++ b/templates/package/show.hbs
@@ -1,11 +1,11 @@
 {{#with package}}
 
-<h1 class="package-name">
-  <a href="/package/{{name}}">{{name}}</a>
-</h1>
-<p class="package-description">{{{description}}}</p>
-
 <div class="content-column">
+
+  <h1 class="package-name">
+    <a href="/package/{{name}}">{{name}}</a>
+  </h1>
+  <p class="package-description">{{{description}}}</p>
 
   <form class="star">
     <input type="hidden" name="name" value="{{name}}">


### PR DESCRIPTION
This fixes that whitespace above the sidebar on package pages, and lowers the "switch to mobile" threshold from 900px to 767px.