### PR TITLE
no null bearer

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -137,9 +137,10 @@ User.prototype.getPackages = function(name, callback) {
         format: 'detailed',
         per_page: 9999
       },
-      json: true,
-      headers: {bearer: _this.bearer}
+      json: true
     };
+
+    if (_this.bearer) opts.headers = {bearer: _this.bearer};
 
     request.get(opts, function(err, resp, body){
 
@@ -161,9 +162,10 @@ User.prototype.getStars = function(name, callback) {
   return new Promise(function(resolve, reject) {
     var opts = {
       url: url,
-      json: true,
-      headers: {bearer: _this.bearer}
+      json: true
     };
+
+    if (_this.bearer) opts.headers = {bearer: _this.bearer};
 
     request.get(opts, function(err, resp, body){
 


### PR DESCRIPTION
Don't add bearer token to request if user is not logged in.

This was crashing the profile page for logged-out users.