### PR TITLE
github stats refactor

### DIFF
--- a/assets/scripts/github2.js
+++ b/assets/scripts/github2.js
@@ -1,0 +1,42 @@
+/* globals $ */
+
+var Octokat = require('octokat')
+var github = new Octokat()
+var URL = require('url')
+var repo
+
+module.exports = function () {
+  $(init)
+}
+
+var init = function () {
+  repo = github.repos('npm', 'newwwzzz')
+  repo.counts = {}
+
+  repo.pulls.fetch({per_page: 1})
+    .then(function (pulls) {
+      repo.counts.pulls = count(pulls)
+      return repo.issues.fetch({per_page: 1})
+    })
+    .then(function (issues) {
+      repo.counts.issues = count(issues)
+      // GitHub API still includes PRs in /issues endpoints
+      repo.counts.issues -= repo.counts.pulls
+      return repo.contributors.fetch({per_page: 1})
+    })
+    .then(function (contributors) {
+      repo.counts.contributors = count(contributors)
+      console.log(repo.counts)
+    })
+    .catch(function (e) {
+      console.error('oh noes', e)
+    })
+}
+
+var count = function (response) {
+  try {
+    return Number(URL.parse(response.lastPage.url, true).query.page)
+  } catch(e) {
+    console.error('error parsing github API result', e)
+  }
+}

--- a/assets/scripts/index.js
+++ b/assets/scripts/index.js
@@ -18,6 +18,6 @@ require("./add-active-class-to-links")()
 require("./autoselect-inputs")()
 require("./package-access")()
 require("./buy-enterprise-license")()
+require("./github2")()
 
-window.github = require("./github")()
 window.star = require("./star")()

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "numbat-collector": "~1.0.1",
     "numbat-emitter": "~1.1.0",
     "number-grouper": "0.0.1",
+    "octokat": "^0.4.9",
     "parse-link-header": "^0.2.0",
     "pkgs": "^1.1.0",
     "pretty-hrtime": "^1.0.0",


### PR DESCRIPTION
This is a work-in-progress refactor of the code that fetches github issue and PR counts on package pages. Related:

- https://github.com/philschatz/octokat.js/issues/31
- https://github.com/philschatz/octokat.js/issues/33
- https://github.com/npm/newww/pull/777

## The Plan

- Extract github user and repo name from `package.repository.url` using [github-url-to-object](http://npm.im/github-url-to-object) in the [package presenter](presenters/package.js).
- Inject those two variables into HTML data attributes in the [package template](package/show.hbs).
- Update [client-side github code](assets/scripts/github2.js) to detect the data attributes.
- Handle errors better. See https://github.com/philschatz/octokat.js/issues/33 for using a single `catch()` block
- Create a handlebars template to inject `repo.counts` into
- Use the [pluralize helper](templates/helpers/pluralize.js) to account singular (1 issue) vs plural (2 issues). See [hbsfy docs](https://github.com/epeli/node-hbsfy#helpers) for details.