### PR TITLE
Registry relational queries are now cached.

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -3,6 +3,7 @@ var
     assert  = require('assert'),
     bole    = require('bole'),
     crypto  = require('crypto'),
+    P       = require('bluebird'),
     Redis   = require('redis-url'),
     Request = require('request')
     ;
@@ -95,7 +96,12 @@ exports._getNoCache = function _getNoCache(opts, callback)
     Request(opts, function(err, response, data)
     {
         if (err) { return callback(err); }
-        if (response.statusCode !== 200) { return callback(new Error('unexpected status code ' + response.statusCode)); }
+        if (response.statusCode !== 200)
+        {
+            var e = new Error('unexpected status code ' + response.statusCode);
+            e.statusCode = response.statusCode;
+            return callback(e);
+        }
         callback(null, data);
     });
 };
@@ -136,11 +142,13 @@ exports.get = function get(opts, callback)
 
             if (response.statusCode !== 200)
             {
-                return callback(new Error('unexpected status code ' + response.statusCode));
+                var e = new Error('unexpected status code ' + response.statusCode);
+                e.statusCode = response.statusCode;
+                return callback(e);
             }
 
             var ttl = opts.ttl || DEFAULT_TTL;
-            redis.setex(key, ttl, JSON.stringify(data), function(err, response)
+            redis.setex(key, ttl, JSON.stringify(data), function(err, unused)
             {
                 if (err)
                 {
@@ -156,4 +164,26 @@ exports.get = function get(opts, callback)
             callback(null, data);
         });
     });
+};
+
+// promisified editions
+
+exports.getP = function getP(opts)
+{
+    var deferred = P.defer();
+
+    exports.get(opts, function(err, result)
+    {
+        if (err) { return deferred.reject(err); }
+        deferred.resolve(result);
+    });
+
+    return deferred.promise;
+};
+
+exports.dropP = function dropP(opts)
+{
+    var deferred = P.defer();
+    exports.drop(opts, function() { deferred.resolve(); });
+    return deferred.promise;
 };

--- a/test/models/package.js
+++ b/test/models/package.js
@@ -91,7 +91,7 @@ describe("Package", function(){
         })
         .catch(function(err){
           expect(err).to.exist();
-          expect(err.message).to.equal("error getting package foo");
+          expect(err.message).to.match(/unexpected status code/);
           expect(err.statusCode).to.equal(404);
         })
         .then(function(){
@@ -215,7 +215,7 @@ describe("Package", function(){
         })
         .catch(function(err){
           expect(err).to.exist();
-          expect(err.message).to.equal("error getting package list");
+          expect(err.message).to.match(/unexpected status code/);
           expect(err.statusCode).to.equal(404);
         })
         .then(function(){


### PR DESCRIPTION
The package "model" now uses the cache for all package data gets. It drops any cached data for a specific package on update. There is now a convenience function for generating the predictable package Request options, so it is guaranteed to look the same every time.

Added promisified versions of `cache.get()` and `cache.drop()` for convenience, called `cache.getP()` and `cache.dropP()`. Added unit tests for the promisified wrappers.

Adjusted two package "model" tests to look for the regularized error messages that the cache generates on 404s.

While I was looking at it, parallelized the queries that build the home page, which should result in a modest speed improvement.

All tests pass. This of course means success is assured.

cc @rockbot, @bcoe 