### PR TITLE
402

### DIFF
--- a/handlers/access.js
+++ b/handlers/access.js
@@ -20,10 +20,16 @@ module.exports = function(request, reply) {
   .catch(function(err){
     request.logger.error("unable to get package " + request.packageName);
     request.logger.error(err);
-    if (err.statusCode === 404) {
-      return reply.view('errors/not-found').code(404);
-    } else {
-      reply.view('errors/internal', context).code(500);
+
+    switch(err.statusCode) {
+      case 402:
+        reply.redirect('/settings/billing?package='+request.packageName);
+        break
+      case 404:
+        reply.view('errors/not-found').code(404);
+        break;
+      default:
+        reply.view('errors/internal', context).code(500);
     }
     return promise.cancel();
   })

--- a/handlers/customer.js
+++ b/handlers/customer.js
@@ -15,6 +15,12 @@ billing.getBillingInfo = function (request, reply) {
     stripePublicKey: process.env.STRIPE_PUBLIC_KEY
   };
 
+  // Display a message to unpaid collaborators about the
+  // package they could be accessing if they paid for it
+  if (request.query.package) {
+    opts.package = request.query.package
+  }
+
   Customer.get(request.loggedInUser.name, function(err, customer) {
 
     if (customer) {

--- a/handlers/package.js
+++ b/handlers/package.js
@@ -18,6 +18,12 @@ package.show = function(request, reply) {
   var promise = Package.get(name)
     .catch(function(err){
 
+      // unpaid collaborator
+      if (err.statusCode === 402) {
+        reply.redirect('/settings/billing?package='+name);
+        return promise.cancel();
+      }
+
       if (err.statusCode === 404) {
         var package = npa(name);
         package.available = false;

--- a/templates/user/billing.hbs
+++ b/templates/user/billing.hbs
@@ -23,6 +23,13 @@
     </p>
   {{/if}}
 
+  {{#if package}}
+    <p class="notice payment-required-notice">
+      Someone added you as a collaborator on the <a href="/package/{{package}}">{{package}}</a> package,
+      but you'll need to sign up as a paying user before you can access the package.
+    </p>
+  {{/if}}
+
   {{#if customer.license_expired }}
     <p class="error license-expired">
       Your license has expired, and your account

--- a/templates/user/profile.hbs
+++ b/templates/user/profile.hbs
@@ -50,7 +50,7 @@
   {{#if isSelf}}
     <p class="notice profile-edit">
       This is your profile page, {{name}}! You can
-      <a href="/profile-edit">update your social info</a>,
+      <a href="/profile-edit">update your profile</a>,
       <a href="/password">change your password</a>, or
       <a href="http://gravatar.com/emails/">update your avatar</a>.
     </p>

--- a/test/handlers/access.js
+++ b/test/handlers/access.js
@@ -2,6 +2,7 @@ var fixtures = require("../fixtures"),
     merge = require("lodash").merge,
     nock = require("nock"),
     cheerio = require("cheerio"),
+    URL = require('url'),
     Code = require('code'),
     Lab = require('lab'),
     lab = exports.lab = Lab.script(),
@@ -528,6 +529,41 @@ describe("package access", function(){
         done();
       });
     });
+
+    describe('logged-in unpaid collaborator', function () {
+      var resp
+      var options = {
+        url: '/package/@wrigley_the_writer/scoped_private/access',
+        credentials: fixtures.users.wrigley_the_writer,
+      };
+
+      before(function(done) {
+        var mock = nock("https://user-api-example.com")
+          .get('/package/@wrigley_the_writer%2Fscoped_private')
+          .reply(402)
+
+        process.env.FEATURE_ACCESS_PAGE = 'true';
+        server.inject(options, function(response) {
+          // mock.done()
+          resp = response;
+          delete process.env.FEATURE_ACCESS_PAGE;
+          done();
+        });
+      });
+
+      it('redirects to the billing page'/*, function (done) {
+        expect(resp.statusCode).to.equal(302);
+        expect(URL.parse(resp.headers.location).pathname).to.equal("/settings/billing");
+        done()
+      }*/);
+
+      it('sets a `package` query param so a helpful message can be displayed'/*, function (done) {
+        expect(URL.parse(resp.headers.location, true).query.package).to.equal("@wrigley_the_writer/scope_private");
+        done()
+      }*/);
+
+    });
+
 
   });
 


### PR DESCRIPTION
When an unpaid collaborator on a private package tries to view a package page or access page, they get redirected to the billing page, and the following message is displayed:

![screen shot 2015-04-08 at 3 49 21 pm](https://cloud.githubusercontent.com/assets/2289/7057096/ea334d4c-de06-11e4-8546-a50c827609db.png)

This could use more tests but I'm pulling my hair out trying to get them to pass, and there are too many other fish to fry for launch. :fish: