### PR TITLE
tiny addition to logging

### DIFF
--- a/handlers/customer.js
+++ b/handlers/customer.js
@@ -18,7 +18,7 @@ billing.getBillingInfo = function (request, reply) {
   // Display a message to unpaid collaborators about the
   // package they could be accessing if they paid for it
   if (request.query.package) {
-    opts.package = request.query.package
+    opts.package = request.query.package;
   }
 
   Customer.get(request.loggedInUser.name, function(err, customer) {
@@ -46,6 +46,7 @@ billing.updateBillingInfo = function(request, reply) {
 
   Customer.update(billingInfo, function(err, customer) {
     if (err) {
+      request.logger.error('unable to update billing info');
       request.logger.error(err);
       return reply.view('errors/internal').code(500);
     }


### PR DESCRIPTION
Attempts to address #857

Note: the [customer model](https://github.com/npm/newww/blob/master/models/customer.js) takes whatever errors are coming from LICENSE_API and spits them out directly to the request.logger via the [customer handler](https://github.com/npm/newww/blob/master/handlers/customer.js). So if we're not logging the LICENSE_API errors, it would seem they're not getting sent?

cc: @bcoe 