### PR TITLE
adds logging for external apis, plus test fixes

### DIFF
--- a/handlers/customer.js
+++ b/handlers/customer.js
@@ -1,5 +1,5 @@
 var billing = module.exports = {};
-var Customer = require("../models/customer").new();
+var Customer = require("../models/customer");
 
 billing.getBillingInfo = function (request, reply) {
 
@@ -18,10 +18,10 @@ billing.getBillingInfo = function (request, reply) {
   // Display a message to unpaid collaborators about the
   // package they could be accessing if they paid for it
   if (request.query.package) {
-    opts.package = request.query.package
+    opts.package = request.query.package;
   }
 
-  Customer.get(request.loggedInUser.name, function(err, customer) {
+  Customer.new(request).get(request.loggedInUser.name, function(err, customer) {
 
     if (customer) {
       opts.customer = customer;
@@ -44,7 +44,7 @@ billing.updateBillingInfo = function(request, reply) {
     card: request.payload.stripeToken
   };
 
-  Customer.update(billingInfo, function(err, customer) {
+  Customer.new(request).update(billingInfo, function(err, customer) {
     if (err) {
       request.logger.error(err);
       return reply.view('errors/internal').code(500);
@@ -68,7 +68,7 @@ billing.deleteBillingInfo = function(request, reply) {
     return reply.view('errors/not-found').code(404);
   }
 
-  Customer.del(request.loggedInUser.name, function(err, customer) {
+  Customer.new(request).del(request.loggedInUser.name, function(err, customer) {
     if (err) {
       request.logger.error("unable to delete billing info for " + customer);
       request.logger.error(err);

--- a/handlers/customer.js
+++ b/handlers/customer.js
@@ -1,5 +1,5 @@
 var billing = module.exports = {};
-var Customer = require("../models/customer");
+var Customer = require("../models/customer").new();
 
 billing.getBillingInfo = function (request, reply) {
 
@@ -21,7 +21,7 @@ billing.getBillingInfo = function (request, reply) {
     opts.package = request.query.package;
   }
 
-  Customer.new(request).get(request.loggedInUser.name, function(err, customer) {
+  Customer.get(request.loggedInUser.name, function(err, customer) {
 
     if (customer) {
       opts.customer = customer;
@@ -44,7 +44,7 @@ billing.updateBillingInfo = function(request, reply) {
     card: request.payload.stripeToken
   };
 
-  Customer.new(request).update(billingInfo, function(err, customer) {
+  Customer.update(billingInfo, function(err, customer) {
     if (err) {
       request.logger.error(err);
       return reply.view('errors/internal').code(500);
@@ -68,7 +68,7 @@ billing.deleteBillingInfo = function(request, reply) {
     return reply.view('errors/not-found').code(404);
   }
 
-  Customer.new(request).del(request.loggedInUser.name, function(err, customer) {
+  Customer.del(request.loggedInUser.name, function(err, customer) {
     if (err) {
       request.logger.error("unable to delete billing info for " + customer);
       request.logger.error(err);

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -2,6 +2,7 @@ var
     _       = require('lodash'),
     assert  = require('assert'),
     bole    = require('bole'),
+    clf     = require('../lib/utils').toCommonLogFormat,
     crypto  = require('crypto'),
     P       = require('bluebird'),
     Redis   = require('redis-url'),
@@ -95,7 +96,15 @@ exports._getNoCache = function _getNoCache(opts, callback)
 
     Request(opts, function(err, response, data)
     {
-        if (err) { return callback(err); }
+        if (response) {
+            logger('EXTERNAL').info(clf(response));
+        }
+
+        if (err)
+        {
+            logger.error(data);
+            return callback(err);
+        }
         if (response.statusCode !== 200)
         {
             var e = new Error('unexpected status code ' + response.statusCode);
@@ -138,7 +147,13 @@ exports.get = function get(opts, callback)
 
         Request(opts, function(err, response, data)
         {
-            if (err) { return callback(err); }
+            exports.logger('EXTERNAL').info(clf(response));
+
+            if (err)
+            {
+                exports.logger.info(data);
+                return callback(err);
+            }
 
             if (response.statusCode !== 200)
             {

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -2,7 +2,6 @@ var
     _       = require('lodash'),
     assert  = require('assert'),
     bole    = require('bole'),
-    clf     = require('../lib/utils').toCommonLogFormat,
     crypto  = require('crypto'),
     P       = require('bluebird'),
     Redis   = require('redis-url'),
@@ -96,10 +95,7 @@ exports._getNoCache = function _getNoCache(opts, callback)
 
     Request(opts, function(err, response, data)
     {
-        if (err)
-        {
-            return callback(err);
-        }
+        if (err) { return callback(err); }
         if (response.statusCode !== 200)
         {
             var e = new Error('unexpected status code ' + response.statusCode);
@@ -142,11 +138,7 @@ exports.get = function get(opts, callback)
 
         Request(opts, function(err, response, data)
         {
-            if (err)
-            {
-                return callback(err);
-            }
-
+            if (err) { return callback(err); }
             if (response.statusCode !== 200)
             {
                 var e = new Error('unexpected status code ' + response.statusCode);

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -6,7 +6,7 @@ var
     crypto  = require('crypto'),
     P       = require('bluebird'),
     Redis   = require('redis-url'),
-    Request = require('request')
+    Request = require('../lib/external-request');
     ;
 
 var redis, DEFAULT_TTL, KEY_PREFIX, options;
@@ -96,13 +96,8 @@ exports._getNoCache = function _getNoCache(opts, callback)
 
     Request(opts, function(err, response, data)
     {
-        if (response) {
-            logger('EXTERNAL').info(clf(response));
-        }
-
         if (err)
         {
-            logger.error(data);
             return callback(err);
         }
         if (response.statusCode !== 200)
@@ -147,11 +142,8 @@ exports.get = function get(opts, callback)
 
         Request(opts, function(err, response, data)
         {
-            exports.logger('EXTERNAL').info(clf(response));
-
             if (err)
             {
-                exports.logger.info(data);
                 return callback(err);
             }
 

--- a/lib/external-request.js
+++ b/lib/external-request.js
@@ -7,7 +7,9 @@ var externalRequest = function externalRequest (opts, cb) {
 
   Request(opts, function (err, resp, body) {
 
-    logger.info(clf(resp));
+    if (resp) {
+      logger.info(clf(resp));
+    }
 
     if (err) {
       logger.error(body); // get more info about the error

--- a/lib/external-request.js
+++ b/lib/external-request.js
@@ -1,0 +1,44 @@
+var Request = require('request');
+var bole = require('bole');
+var clf = require('../lib/utils').toCommonLogFormat;
+var logger = bole('EXTERNAL');
+
+var externalRequest = function externalRequest (opts, cb) {
+
+  Request(opts, function (err, resp, body) {
+
+    logger.info(clf(resp));
+
+    if (err) {
+      logger.error(body); // get more info about the error
+      logger.error(err);
+    }
+
+    return cb(err, resp, body);
+  });
+
+};
+
+externalRequest.get = function (opts, cb) {
+  opts.method = 'get';
+  return externalRequest(opts, cb);
+};
+
+externalRequest.post = function (opts, cb) {
+  opts.method = 'post';
+  return externalRequest(opts, cb);
+};
+
+externalRequest.put = function (opts, cb) {
+  opts.method = 'put';
+  return externalRequest(opts, cb);
+};
+
+externalRequest.del = function (opts, cb) {
+  opts.method = 'delete';
+  return externalRequest(opts, cb);
+};
+
+externalRequest.logger = logger;
+
+module.exports = externalRequest;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,5 @@
 var crypto = require('crypto');
+var moment = require('moment-tokens');
 
 var utils = {};
 
@@ -10,13 +11,35 @@ utils.safeJsonParse = function safeJsonParse (str) {
   }
 };
 
-utils.pbkdf2 = function pbkdf2 (pass, salt, iterations) {
-  return crypto.pbkdf2Sync(pass, salt, iterations, 20).toString('hex');
-};
-
 utils.sha = function sha (token) {
   return crypto.createHash('sha1').update(token).digest('hex');
 };
 
+utils.toCommonLogFormat = function toCommonLogFormat (resp) {
+
+  var method = resp.request.method,
+      path = resp.request.uri.href,
+      httpProtocol = 'HTTP/' + resp.httpVersion;
+
+  var clientIp = '-',
+      clientId = process.env.CANONICAL_HOST,
+      userid = '-',
+      time = '[' + moment().strftime('%d/%b/%Y:%H:%M:%S %z') + ']',
+      requestLine = '"' + [method, path, httpProtocol].join(' ') + '"',
+      statusCode = resp.statusCode,
+      objectSize = '-';
+
+  return [clientIp, clientId, userid, time, requestLine, statusCode, objectSize].join(' ');
+};
+
+utils.testLogger = function testLogger () {
+  return {
+    error: console.error,
+    info: console.log
+  };
+};
+
+utils.testLogger.error = console.error;
+utils.testLogger.info = console.info;
 
 module.exports = utils;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -32,14 +32,4 @@ utils.toCommonLogFormat = function toCommonLogFormat (resp) {
   return [clientIp, clientId, userid, time, requestLine, statusCode, objectSize].join(' ');
 };
 
-utils.testLogger = function testLogger () {
-  return {
-    error: console.error,
-    info: console.log
-  };
-};
-
-utils.testLogger.error = console.error;
-utils.testLogger.info = console.info;
-
 module.exports = utils;

--- a/models/collaborator.js
+++ b/models/collaborator.js
@@ -1,10 +1,9 @@
-var request = require('request');
+var Request = require('../lib/external-request');
 var Promise = require('bluebird');
 var _ = require('lodash');
 var fmt = require('util').format;
 var decorate = require(__dirname + '/../presenters/collaborator');
 var utils    = require('../lib/utils');
-var clf      = utils.toCommonLogFormat;
 
 var Collaborator = module.exports = function(opts) {
   _.extend(this, {
@@ -38,15 +37,9 @@ Collaborator.prototype.list = function(package, callback) {
 
     if (_this.bearer) { opts.headers = {bearer: _this.bearer}; }
 
-    request(opts,
+    Request(opts,
       function(err, resp, body) {
-        _this.logger('EXTERNAL').info(clf(resp));
-
-        if (err) {
-          _this.logger.error(body);
-          return reject(err);
-        }
-
+        if (err) {return reject(err);}
         if (resp.statusCode > 399) {
           err = Error(fmt("error getting collaborators for package '%s': %s)", package, resp.body));
           err.statusCode = resp.statusCode;
@@ -76,14 +69,8 @@ Collaborator.prototype.add = function(package, collaborator, callback) {
 
     if (_this.bearer) { opts.headers = {bearer: _this.bearer}; }
 
-    request(opts, function(err, resp, body) {
-      _this.logger('EXTERNAL').info(clf(resp));
-
-      if (err) {
-        _this.logger.error(body);
-        return reject(err);
-      }
-
+    Request(opts, function(err, resp, body) {
+      if (err) {return reject(err);}
       if (resp.statusCode > 399) {
         err = Error(fmt("error adding collaborator to package '%s': %s)", package, resp.body));
         err.statusCode = resp.statusCode;
@@ -108,14 +95,8 @@ Collaborator.prototype.update = function(package, collaborator, callback) {
   if (_this.bearer) { opts.headers = {bearer: _this.bearer}; }
 
   return new Promise(function(resolve, reject) {
-    request(opts, function(err, resp, body) {
-      _this.logger('EXTERNAL').info(clf(resp));
-
-      if (err) {
-        _this.logger.error(body);
-        return reject(err);
-      }
-
+    Request(opts, function(err, resp, body) {
+      if (err) {return reject(err);}
       if (resp.statusCode > 399) {
         err = Error(fmt("error updating collaborator access to package '%s': %s)", package, resp.body));
         err.statusCode = resp.statusCode;
@@ -139,14 +120,8 @@ Collaborator.prototype.del = function(package, collaboratorName, callback) {
 
     if (_this.bearer) { opts.headers = {bearer: _this.bearer}; }
 
-    request(opts, function(err, resp, body){
-      _this.logger('EXTERNAL').info(clf(resp));
-
-      if (err) {
-        _this.logger.error(body);
-        return reject(err);
-      }
-
+    Request(opts, function(err, resp, body){
+      if (err) {return reject(err);}
       if (resp.statusCode > 399) {
         err = Error(fmt("error removing collaborator from package '%s': %s)", package, resp.body));
         err.statusCode = resp.statusCode;

--- a/models/collaborator.js
+++ b/models/collaborator.js
@@ -3,25 +3,19 @@ var Promise = require('bluebird');
 var _ = require('lodash');
 var fmt = require('util').format;
 var decorate = require(__dirname + '/../presenters/collaborator');
-var utils    = require('../lib/utils');
 
 var Collaborator = module.exports = function(opts) {
   _.extend(this, {
     host: process.env.USER_API || "https://user-api-example.com",
-    bearer: false,
-    logger: utils.testLogger
+    bearer: false
   }, opts);
 
   return this;
 };
 
 Collaborator.new = function(request) {
-  var opts = {
-    logger: request.logger,
-    bearer: request.loggedInUser && request.loggedInUser.name
-  };
-
-  return new Collaborator(opts);
+  var bearer = request.loggedInUser && request.loggedInUser.name;
+  return new Collaborator({bearer: bearer});
 };
 
 Collaborator.prototype.list = function(package, callback) {
@@ -70,7 +64,7 @@ Collaborator.prototype.add = function(package, collaborator, callback) {
     if (_this.bearer) { opts.headers = {bearer: _this.bearer}; }
 
     Request(opts, function(err, resp, body) {
-      if (err) {return reject(err);}
+      if (err) { return reject(err); }
       if (resp.statusCode > 399) {
         err = Error(fmt("error adding collaborator to package '%s': %s)", package, resp.body));
         err.statusCode = resp.statusCode;
@@ -96,7 +90,7 @@ Collaborator.prototype.update = function(package, collaborator, callback) {
 
   return new Promise(function(resolve, reject) {
     Request(opts, function(err, resp, body) {
-      if (err) {return reject(err);}
+      if (err) { return reject(err); }
       if (resp.statusCode > 399) {
         err = Error(fmt("error updating collaborator access to package '%s': %s)", package, resp.body));
         err.statusCode = resp.statusCode;
@@ -121,7 +115,7 @@ Collaborator.prototype.del = function(package, collaboratorName, callback) {
     if (_this.bearer) { opts.headers = {bearer: _this.bearer}; }
 
     Request(opts, function(err, resp, body){
-      if (err) {return reject(err);}
+      if (err) { return reject(err); }
       if (resp.statusCode > 399) {
         err = Error(fmt("error removing collaborator from package '%s': %s)", package, resp.body));
         err.statusCode = resp.statusCode;

--- a/models/customer.js
+++ b/models/customer.js
@@ -1,7 +1,6 @@
 var _       = require('lodash');
 var utils   = require('../lib/utils');
-var clf     = utils.toCommonLogFormat;
-var request = require('request');
+var Request = require('../lib/external-request');
 
 var Customer = module.exports = function(opts) {
   _.extend(this, {
@@ -21,19 +20,10 @@ Customer.new = function(request) {
 };
 
 Customer.prototype.get = function(name, callback) {
-  var _this = this;
   var url = this.host + '/stripe/' + name;
 
-  request.get({url: url, json: true}, function(err, resp, body){
-
-    _this.logger('EXTERNAL').info(clf(resp));
-
-    if (err) {
-      _this.logger.error(body);
-      _this.logger.error(err);
-      return callback(err);
-    }
-
+  Request.get({url: url, json: true}, function(err, resp, body){
+    if (err) {return callback(err);}
     if (resp.statusCode === 404) {
       err = Error('customer not found: ' + name);
       err.statusCode = resp.statusCode;
@@ -66,16 +56,8 @@ Customer.prototype.update = function(body, callback) {
     // Create new customer
     if (err && err.statusCode === 404) {
       url = _this.host + '/stripe';
-      return request.put({url: url, json: true, body: body}, function(err, resp, body){
-        _this.logger('EXTERNAL').info(clf(resp));
-
-        if (err) {
-          _this.logger.error(body);
-          _this.logger.error(err);
-          return callback(err);
-        }
-
-        return callback(null, body);
+      return Request.put({url: url, json: true, body: body}, function(err, resp, body){
+        return err ? callback(err) : callback(null, body);
       });
     }
 
@@ -84,7 +66,7 @@ Customer.prototype.update = function(body, callback) {
 
     // Update existing customer
     url = _this.host + '/stripe/' + body.name;
-    return request.post({url: url, json: true, body: body}, function(err, resp, body){
+    return Request.post({url: url, json: true, body: body}, function(err, resp, body){
       return err ? callback(err) : callback(null, body);
     });
 
@@ -92,17 +74,8 @@ Customer.prototype.update = function(body, callback) {
 };
 
 Customer.prototype.del = function(name, callback) {
-  var _this = this;
   var url = this.host + '/stripe/' + name;
-  request.del({url: url, json: true}, function(err, resp, body){
-    _this.logger('EXTERNAL').info(clf(resp));
-
-    if (err) {
-      _this.logger.error(body);
-      _this.logger.error(err);
-      return callback(err);
-    }
-
-    return callback(null, body);
+  Request.del({url: url, json: true}, function(err, resp, body){
+    return err ? callback(err) : callback(null, body);
   });
 };

--- a/models/customer.js
+++ b/models/customer.js
@@ -1,29 +1,23 @@
 var _       = require('lodash');
-var utils   = require('../lib/utils');
 var Request = require('../lib/external-request');
 
 var Customer = module.exports = function(opts) {
   _.extend(this, {
     host: process.env.LICENSE_API || "https://license-api-example.com",
-    logger: utils.testLogger
   }, opts);
 };
 
-Customer.new = function(request) {
-  var opts = {};
-
-  if (request && request.logger) {
-    opts.logger = request.logger;
-  }
-
-  return new Customer(opts);
+Customer.new = function() {
+  return new Customer();
 };
 
 Customer.prototype.get = function(name, callback) {
   var url = this.host + '/stripe/' + name;
 
   Request.get({url: url, json: true}, function(err, resp, body){
-    if (err) {return callback(err);}
+
+    if (err) { return callback(err); }
+
     if (resp.statusCode === 404) {
       err = Error('customer not found: ' + name);
       err.statusCode = resp.statusCode;

--- a/models/customer.js
+++ b/models/customer.js
@@ -1,22 +1,38 @@
+var _       = require('lodash');
+var utils   = require('../lib/utils');
+var clf     = utils.toCommonLogFormat;
 var request = require('request');
-var _ = require('lodash');
 
 var Customer = module.exports = function(opts) {
   _.extend(this, {
     host: process.env.LICENSE_API || "https://license-api-example.com",
+    logger: utils.testLogger
   }, opts);
 };
 
-Customer.new = function() {
-  return new Customer();
+Customer.new = function(request) {
+  var opts = {};
+
+  if (request && request.logger) {
+    opts.logger = request.logger;
+  }
+
+  return new Customer(opts);
 };
 
 Customer.prototype.get = function(name, callback) {
+  var _this = this;
   var url = this.host + '/stripe/' + name;
 
   request.get({url: url, json: true}, function(err, resp, body){
 
-    if (err) { return callback(err); }
+    _this.logger('EXTERNAL').info(clf(resp));
+
+    if (err) {
+      _this.logger.error(body);
+      _this.logger.error(err);
+      return callback(err);
+    }
 
     if (resp.statusCode === 404) {
       err = Error('customer not found: ' + name);
@@ -34,7 +50,7 @@ Customer.prototype.get = function(name, callback) {
 };
 
 Customer.prototype.update = function(body, callback) {
-  var self = this;
+  var _this = this;
   var url;
   var props = ['name', 'email', 'card'];
 
@@ -49,17 +65,25 @@ Customer.prototype.update = function(body, callback) {
 
     // Create new customer
     if (err && err.statusCode === 404) {
-      url = self.host + '/stripe';
+      url = _this.host + '/stripe';
       return request.put({url: url, json: true, body: body}, function(err, resp, body){
-        return err ? callback(err) : callback(null, body);
+        _this.logger('EXTERNAL').info(clf(resp));
+
+        if (err) {
+          _this.logger.error(body);
+          _this.logger.error(err);
+          return callback(err);
+        }
+
+        return callback(null, body);
       });
     }
 
     // Some other kind of error
-    if (err) return callback(err);
+    if (err) { return callback(err); }
 
     // Update existing customer
-    url = self.host + '/stripe/' + body.name;
+    url = _this.host + '/stripe/' + body.name;
     return request.post({url: url, json: true, body: body}, function(err, resp, body){
       return err ? callback(err) : callback(null, body);
     });
@@ -68,8 +92,17 @@ Customer.prototype.update = function(body, callback) {
 };
 
 Customer.prototype.del = function(name, callback) {
+  var _this = this;
   var url = this.host + '/stripe/' + name;
   request.del({url: url, json: true}, function(err, resp, body){
-    return err ? callback(err) : callback(null, body);
+    _this.logger('EXTERNAL').info(clf(resp));
+
+    if (err) {
+      _this.logger.error(body);
+      _this.logger.error(err);
+      return callback(err);
+    }
+
+    return callback(null, body);
   });
 };

--- a/models/package.js
+++ b/models/package.js
@@ -1,13 +1,11 @@
 var _        = require('lodash');
 var cache    = require('../lib/cache');
-var utils    = require('../lib/utils');
-var clf      = utils.toCommonLogFormat;
 var decorate = require(__dirname + '/../presenters/package');
 var fmt      = require('util').format;
 var P        = require('bluebird');
-var Request  = require('request');
+var Request  = require('../lib/external-request');
 var URL      = require('url');
-
+var utils    = require('../lib/utils');
 
 var Package = module.exports = function(opts) {
   _.extend(this, {
@@ -76,12 +74,8 @@ Package.prototype.update = function(name, body) {
   .then(function() {
     return new P(function(resolve, reject) {
       Request(opts, function(err, resp, body) {
-        _this.logger('EXTERNAL').info(clf(resp));
 
-        if (err) {
-          _this.logger.error(body); // get more info about the error
-          return reject(err);
-        }
+        if (err) { return reject(err); }
 
         if (resp.statusCode > 399) {
           err = Error('error updating package ' + name);
@@ -139,13 +133,7 @@ Package.prototype.star = function (package) {
     return new P(function (resolve, reject) {
 
       Request.put(opts, function (err, resp, body) {
-        _this.logger('EXTERNAL').info(clf(resp));
-        if (err) {
-          _this.logger.error(body); // get more info about the error
-          _this.logger.error(err);
-          return reject(err);
-        }
-
+        if (err) {return reject(err);}
         if (resp.statusCode > 399) {
           err = Error('error starring package ' + package);
           err.statusCode = resp.statusCode;
@@ -173,13 +161,7 @@ Package.prototype.unstar = function (package) {
     return new P(function (resolve, reject) {
 
       Request.del(opts, function (err, resp, body) {
-        _this.logger('EXTERNAL').info(clf(resp));
-        if (err) {
-          _this.logger.error(body); // get more info about the error
-          _this.logger.error(err);
-          return reject(err);
-        }
-
+        if (err) {return reject(err);}
         if (resp.statusCode > 399) {
           err = Error('error unstarring package ' + package);
           err.statusCode = resp.statusCode;

--- a/models/package.js
+++ b/models/package.js
@@ -5,13 +5,11 @@ var fmt      = require('util').format;
 var P        = require('bluebird');
 var Request  = require('../lib/external-request');
 var URL      = require('url');
-var utils    = require('../lib/utils');
 
 var Package = module.exports = function(opts) {
   _.extend(this, {
     host: process.env.USER_API || "https://user-api-example.com",
-    bearer: false,
-    logger: utils.testLogger
+    bearer: false
   }, opts);
 
   return this;
@@ -19,7 +17,6 @@ var Package = module.exports = function(opts) {
 
 Package.new = function(request) {
   var opts = {
-    logger: request.logger,
     bearer: request.loggedInUser && request.loggedInUser.name
   };
 
@@ -52,7 +49,6 @@ Package.prototype.dropCache = function dropCache(name) {
 };
 
 Package.prototype.update = function(name, body) {
-  var _this = this;
 
   var url = fmt("%s/package/%s", this.host, name.replace("/", "%2F"));
   var opts = {
@@ -74,15 +70,12 @@ Package.prototype.update = function(name, body) {
   .then(function() {
     return new P(function(resolve, reject) {
       Request(opts, function(err, resp, body) {
-
         if (err) { return reject(err); }
-
         if (resp.statusCode > 399) {
           err = Error('error updating package ' + name);
           err.statusCode = resp.statusCode;
           return reject(err);
         }
-
         return resolve(body);
       });
     });
@@ -133,7 +126,7 @@ Package.prototype.star = function (package) {
     return new P(function (resolve, reject) {
 
       Request.put(opts, function (err, resp, body) {
-        if (err) {return reject(err);}
+        if (err) { return reject(err); }
         if (resp.statusCode > 399) {
           err = Error('error starring package ' + package);
           err.statusCode = resp.statusCode;
@@ -161,7 +154,8 @@ Package.prototype.unstar = function (package) {
     return new P(function (resolve, reject) {
 
       Request.del(opts, function (err, resp, body) {
-        if (err) {return reject(err);}
+        if (err) { return reject(err); }
+
         if (resp.statusCode > 399) {
           err = Error('error unstarring package ' + package);
           err.statusCode = resp.statusCode;

--- a/models/user.js
+++ b/models/user.js
@@ -24,7 +24,6 @@ User.new = function(request) {
 };
 
 User.prototype.confirmEmail = function (user, callback) {
-  var _this = this;
   var url = fmt("%s/user/%s/verify", this.host, user.name);
 
   return new Promise(function(resolve, reject) {

--- a/models/user.js
+++ b/models/user.js
@@ -6,14 +6,19 @@ var mailchimp = require('mailchimp-api');
 var Promise = require('bluebird');
 var Request = require('../lib/external-request');
 var userValidate = require('npm-user-validate');
-var utils = require('../lib/utils');
 
 var User = module.exports = function(opts) {
   _.extend(this, {
     host: process.env.USER_API || "https://user-api-example.com",
-    bearer: false,
-    logger: utils.testLogger,
+    bearer: false
   }, opts);
+
+  if (!this.logger) {
+    this.logger = {
+      error: console.error,
+      info: console.log
+    };
+  }
 
   return this;
 };
@@ -36,7 +41,7 @@ User.prototype.confirmEmail = function (user, callback) {
     };
 
     Request.post(opts, function (err, resp, body) {
-      if (err) {return reject(err);}
+      if (err) { return reject(err); }
       if (resp.statusCode > 399) {
         err = Error('error verifying user ' + user.name);
         err.statusCode = resp.statusCode;
@@ -48,7 +53,6 @@ User.prototype.confirmEmail = function (user, callback) {
 };
 
 User.prototype.login = function(loginInfo, callback) {
-  var _this = this;
   var url = fmt("%s/user/%s/login", this.host, loginInfo.name);
 
   return new Promise(function (resolve, reject) {
@@ -59,7 +63,9 @@ User.prototype.login = function(loginInfo, callback) {
         password: loginInfo.password
       }
     }, function (err, resp, body) {
-      if (err) {return reject(err);}
+
+      if (err) { return reject(err); }
+
       if (resp.statusCode === 401) {
         err = Error('password is incorrect for ' + loginInfo.name);
         err.statusCode = resp.statusCode;
@@ -136,7 +142,9 @@ User.prototype.getPackages = function(name, callback) {
     if (_this.bearer) { opts.headers = {bearer: _this.bearer}; }
 
     Request.get(opts, function(err, resp, body){
-      if (err) {return reject(err);}
+
+      if (err) { return reject(err); }
+
       if (resp.statusCode > 399) {
         err = Error('error getting packages for user ' + name);
         err.statusCode = resp.statusCode;
@@ -160,7 +168,8 @@ User.prototype.getStars = function(name, callback) {
     if (_this.bearer) { opts.headers = {bearer: _this.bearer}; }
 
     Request.get(opts, function(err, resp, body){
-      if (err) {return reject(err);}
+
+      if (err) { return reject(err); }
       if (resp.statusCode > 399) {
         err = Error('error getting stars for user ' + name);
         err.statusCode = resp.statusCode;
@@ -185,7 +194,9 @@ User.prototype.login = function(loginInfo, callback) {
         password: loginInfo.password
       }
     }, function (err, resp, body) {
-      if (err) {return reject(err);}
+
+      if (err) { return reject(err); }
+
       if (resp.statusCode === 401) {
         err = Error('password is incorrect for ' + loginInfo.name);
         err.statusCode = resp.statusCode;
@@ -217,7 +228,7 @@ User.prototype.lookupEmail = function(email, callback) {
     var url = _this.host + "/user/" + email;
 
     Request.get({url: url, json: true}, function (err, resp, body) {
-      if (err) {return reject(err);}
+      if (err) { return reject(err); }
       if (resp.statusCode > 399) {
         err = Error('error looking up username(s) for ' + email);
         err.statusCode = resp.statusCode;
@@ -241,7 +252,7 @@ User.prototype.save = function (user, callback) {
     };
 
     Request.post(opts, function (err, resp, body) {
-      if (err) {return reject(err);}
+      if (err) { return reject(err); }
       if (resp.statusCode > 399) {
         err = Error('error updating profile for ' + user.name);
         err.statusCode = resp.statusCode;
@@ -277,7 +288,7 @@ User.prototype.signup = function (user, callback) {
     };
 
     Request.put(opts, function (err, resp, body) {
-      if (err) {return reject(err);}
+      if (err) { return reject(err); }
       if (resp.statusCode > 399) {
         err = Error('error creating user ' + user.name);
         err.statusCode = resp.statusCode;

--- a/models/user.js
+++ b/models/user.js
@@ -1,13 +1,12 @@
 var _ = require('lodash');
 var cache = require('../lib/cache');
-var utils = require('../lib/utils');
-var clf = utils.toCommonLogFormat;
 var decorate = require(__dirname + '/../presenters/user');
 var fmt = require('util').format;
 var mailchimp = require('mailchimp-api');
 var Promise = require('bluebird');
-var request = require('request');
+var Request = require('../lib/external-request');
 var userValidate = require('npm-user-validate');
+var utils = require('../lib/utils');
 
 var User = module.exports = function(opts) {
   _.extend(this, {
@@ -37,14 +36,8 @@ User.prototype.confirmEmail = function (user, callback) {
       }
     };
 
-    request.post(opts, function (err, resp, body) {
-      _this.logger('EXTERNAL').info(clf(resp));
-
-      if (err) {
-        _this.logger.error(body);
-        return reject(err);
-      }
-
+    Request.post(opts, function (err, resp, body) {
+      if (err) {return reject(err);}
       if (resp.statusCode > 399) {
         err = Error('error verifying user ' + user.name);
         err.statusCode = resp.statusCode;
@@ -60,20 +53,14 @@ User.prototype.login = function(loginInfo, callback) {
   var url = fmt("%s/user/%s/login", this.host, loginInfo.name);
 
   return new Promise(function (resolve, reject) {
-    request.post({
+    Request.post({
       url: url,
       json: true,
       body: {
         password: loginInfo.password
       }
     }, function (err, resp, body) {
-      _this.logger('EXTERNAL').info(clf(resp));
-
-      if (err) {
-        _this.logger.error(body);
-        return reject(err);
-      }
-
+      if (err) {return reject(err);}
       if (resp.statusCode === 401) {
         err = Error('password is incorrect for ' + loginInfo.name);
         err.statusCode = resp.statusCode;
@@ -149,14 +136,8 @@ User.prototype.getPackages = function(name, callback) {
 
     if (_this.bearer) { opts.headers = {bearer: _this.bearer}; }
 
-    request.get(opts, function(err, resp, body){
-      _this.logger('EXTERNAL').info(clf(resp));
-
-      if (err) {
-        _this.logger.error(body);
-        return reject(err);
-      }
-
+    Request.get(opts, function(err, resp, body){
+      if (err) {return reject(err);}
       if (resp.statusCode > 399) {
         err = Error('error getting packages for user ' + name);
         err.statusCode = resp.statusCode;
@@ -179,14 +160,8 @@ User.prototype.getStars = function(name, callback) {
 
     if (_this.bearer) { opts.headers = {bearer: _this.bearer}; }
 
-    request.get(opts, function(err, resp, body){
-      _this.logger('EXTERNAL').info(clf(resp));
-
-      if (err) {
-        _this.logger.error(body);
-        return reject(err);
-      }
-
+    Request.get(opts, function(err, resp, body){
+      if (err) {return reject(err);}
       if (resp.statusCode > 399) {
         err = Error('error getting stars for user ' + name);
         err.statusCode = resp.statusCode;
@@ -204,20 +179,14 @@ User.prototype.login = function(loginInfo, callback) {
 
   return new Promise(function (resolve, reject) {
 
-    request.post({
+    Request.post({
       url: url,
       json: true,
       body: {
         password: loginInfo.password
       }
     }, function (err, resp, body) {
-      _this.logger('EXTERNAL').info(clf(resp));
-
-      if (err) {
-        _this.logger.error(body);
-        return reject(err);
-      }
-
+      if (err) {return reject(err);}
       if (resp.statusCode === 401) {
         err = Error('password is incorrect for ' + loginInfo.name);
         err.statusCode = resp.statusCode;
@@ -248,14 +217,8 @@ User.prototype.lookupEmail = function(email, callback) {
 
     var url = _this.host + "/user/" + email;
 
-    request.get({url: url, json: true}, function (err, resp, body) {
-      _this.logger('EXTERNAL').info(clf(resp));
-
-      if (err) {
-        _this.logger.error(body);
-        return reject(err);
-      }
-
+    Request.get({url: url, json: true}, function (err, resp, body) {
+      if (err) {return reject(err);}
       if (resp.statusCode > 399) {
         err = Error('error looking up username(s) for ' + email);
         err.statusCode = resp.statusCode;
@@ -278,14 +241,8 @@ User.prototype.save = function (user, callback) {
       body: user
     };
 
-    request.post(opts, function (err, resp, body) {
-      _this.logger('EXTERNAL').info(clf(resp));
-
-      if (err) {
-        _this.logger.error(body);
-        return reject(err);
-      }
-
+    Request.post(opts, function (err, resp, body) {
+      if (err) {return reject(err);}
       if (resp.statusCode > 399) {
         err = Error('error updating profile for ' + user.name);
         err.statusCode = resp.statusCode;
@@ -320,14 +277,8 @@ User.prototype.signup = function (user, callback) {
       json: true
     };
 
-    request.put(opts, function (err, resp, body) {
-      _this.logger('EXTERNAL').info(clf(resp));
-
-      if (err) {
-        _this.logger.error(body);
-        return reject(err);
-      }
-
+    Request.put(opts, function (err, resp, body) {
+      if (err) {return reject(err);}
       if (resp.statusCode > 399) {
         err = Error('error creating user ' + user.name);
         err.statusCode = resp.statusCode;

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "malarkey": "^1.1.0",
     "marky-markdown": "^5.0.2",
     "moment": "^2.9.0",
+    "moment-tokens": "^1.0.0",
     "month": "^1.0.0",
     "mousetrap": "0.0.1",
     "murmurhash": "0.0.2",

--- a/test/adapters/bonbon.js
+++ b/test/adapters/bonbon.js
@@ -33,32 +33,38 @@ describe("bonbon", function() {
   });
 
   nock("https://user-api-example.com")
-    .get('/user/' + username1).times(8)
+    .get('/user/bob').times(8)
     .reply(200, fixtures.users.bob)
     .get('/user/seldo').times(3)
     .reply(200, fixtures.users.npmEmployee)
-    .get('/user/' + username1 + '/package?format=detailed&per_page=9999').times(6)
+    .get('/user/bob/package?format=detailed&per_page=9999').times(6)
     .reply(200, fixtures.users.packages)
-    .get('/user/' + username1 + '/stars?format=detailed').times(6)
-    .reply(200, fixtures.users.stars);
+    .get('/user/bob/stars?format=detailed').times(6)
+    .reply(200, fixtures.users.stars)
+    .get('/user/bob').times(5)
+    .reply(404)
+    .get('/user/seldo')
+    .reply(404)
+    .get('/user/mikeal')
+    .reply(404);
 
   describe("feature flags", function() {
 
     beforeEach(function(done){
-      process.env.FEATURE_STEALTH = 'false'
-      process.env.FEATURE_ALPHA = 'group:npm-humans'
-      process.env.FEATURE_BETA = 'group:npm-humans,group:friends,bob'
-      process.env.FEATURE_COMMON = 'true'
-      done()
-    })
+      process.env.FEATURE_STEALTH = 'false';
+      process.env.FEATURE_ALPHA = 'group:npm-humans';
+      process.env.FEATURE_BETA = 'group:npm-humans,group:friends,bob';
+      process.env.FEATURE_COMMON = 'true';
+      done();
+    });
 
     afterEach(function(done){
-      delete process.env.FEATURE_STEALTH
-      delete process.env.FEATURE_ALPHA
-      delete process.env.FEATURE_BETA
-      delete process.env.FEATURE_COMMON
-      done()
-    })
+      delete process.env.FEATURE_STEALTH;
+      delete process.env.FEATURE_ALPHA;
+      delete process.env.FEATURE_BETA;
+      delete process.env.FEATURE_COMMON;
+      done();
+    });
 
     it('gives anonymous users access to common features', function(done){
       var options = {
@@ -66,7 +72,7 @@ describe("bonbon", function() {
       };
 
       server.inject(options, function (resp) {
-        var context = resp.request.response.source.context
+        var context = resp.request.response.source.context;
         expect(context.features).to.deep.equal({
           stealth: false,
           alpha: false,
@@ -75,7 +81,7 @@ describe("bonbon", function() {
         });
         done();
       });
-    })
+    });
 
     it('gives people in the friends group access to beta and common features', function(done){
       var options = {
@@ -84,7 +90,7 @@ describe("bonbon", function() {
       };
 
       server.inject(options, function (resp) {
-        var context = resp.request.response.source.context
+        var context = resp.request.response.source.context;
         expect(context.features).to.deep.equal({
           stealth: false,
           alpha: false,
@@ -93,7 +99,7 @@ describe("bonbon", function() {
         });
         done();
       });
-    })
+    });
 
     it('gives one-off listed friends access to beta and common features', function(done){
       var options = {
@@ -102,7 +108,7 @@ describe("bonbon", function() {
       };
 
       server.inject(options, function (resp) {
-        var context = resp.request.response.source.context
+        var context = resp.request.response.source.context;
         expect(context.features).to.deep.equal({
           stealth: false,
           alpha: false,
@@ -111,7 +117,7 @@ describe("bonbon", function() {
         });
         done();
       });
-    })
+    });
 
     it('gives npm employees access to alpha, beta, and common features', function(done){
       var options = {
@@ -120,7 +126,7 @@ describe("bonbon", function() {
       };
 
       server.inject(options, function (resp) {
-        var context = resp.request.response.source.context
+        var context = resp.request.response.source.context;
         expect(context.features).to.deep.equal({
           stealth: false,
           alpha: true,
@@ -129,9 +135,9 @@ describe("bonbon", function() {
         });
         done();
       });
-    })
+    });
 
-  })
+  });
 
   it('allows logged-in npm employees to request the view context with a `json` query param', function (done) {
 

--- a/test/cache.js
+++ b/test/cache.js
@@ -145,6 +145,11 @@ describe('lib/cache.js', function()
         {
             sinon.spy(cache.redis, 'get');
             var opts = {url: 'https://google.com/'};
+
+            var mock = nock('https://google.com')
+                .get('/')
+                .reply(200);
+
             var fingerprint = cache._fingerprint(opts);
 
             cache.get(opts, function(err, data)
@@ -152,6 +157,7 @@ describe('lib/cache.js', function()
                 expect(cache.redis.get.calledOnce).to.equal(true);
                 expect(cache.redis.get.calledWith(fingerprint)).to.equal(true);
                 cache.redis.get.restore();
+                mock.done();
                 done();
             });
         });
@@ -212,11 +218,16 @@ describe('lib/cache.js', function()
               url: 'https://logging.com/'
           };
 
+          var mock = nock('https://logging.com')
+              .get('/')
+              .reply(200);
+
           cache.get(opts, function(err, data)
           {
               expect(cache.logger.error.calledTwice).to.equal(true);
               expect(cache.logger.error.calledWithMatch(/problem getting/)).to.equal(true);
               cache.logger.error.restore();
+              mock.done();
               done();
           });
         });

--- a/test/external-request.js
+++ b/test/external-request.js
@@ -1,0 +1,29 @@
+var Lab = require('lab'),
+    Code = require('code'),
+    nock = require('nock'),
+    lab = exports.lab = Lab.script(),
+    describe = lab.experiment,
+    it = lab.test,
+    expect = Code.expect,
+    Request = require('../lib/external-request'),
+    sinon = require('sinon');
+
+describe('external-request', function () {
+  it('logs interesting data when passing a request through', function (done) {
+    var infoSpy = sinon.spy();
+    var oldLogger = Request.logger.info;
+    Request.logger.info = infoSpy;
+
+    var mock = nock('https://google.com')
+      .get('/')
+      .reply(200);
+
+    Request.get('https://google.com/', function (err, resp, body) {
+      expect(err).to.not.exist();
+      expect(infoSpy.called).to.be.true();
+      Request.logger.info = oldLogger;
+      mock.done();
+      done();
+    });
+  });
+});

--- a/test/handlers/access.js
+++ b/test/handlers/access.js
@@ -39,7 +39,6 @@ describe("package access", function(){
   });
 
   describe('features.feature_page disabled', function() {
-    var resp;
 
     before(function(done){
       delete process.env.FEATURE_ACCESS_PAGE;
@@ -68,13 +67,24 @@ describe("package access", function(){
     var resp;
     var context;
     var options = {url: '/package/browserify/access'};
-    var mock = nock("https://user-api-example.com")
-      .get('/package/browserify')
-      .times(3)
-      .reply(200, fixtures.packages.browserify)
-      .get('/package/browserify/collaborators')
-      .times(3)
-      .reply(200, fixtures.collaborators);
+    var mock;
+
+    before(function (done) {
+      mock = nock("https://user-api-example.com")
+        .get('/package/browserify')
+        .times(3)
+        .reply(200, fixtures.packages.browserify)
+        .get('/package/browserify/collaborators')
+        .times(3)
+        .reply(200, fixtures.collaborators);
+
+      done();
+    });
+
+    after(function (done) {
+      mock.done();
+      done();
+    });
 
     describe('anonymous user', function () {
 
@@ -532,7 +542,7 @@ describe("package access", function(){
     });
 
     describe('logged-in unpaid collaborator', function () {
-      var resp
+      var resp;
       var options = {
         url: '/package/@wrigley_the_writer/scoped_private/access',
         credentials: fixtures.users.wrigley_the_writer,
@@ -540,12 +550,12 @@ describe("package access", function(){
 
       before(function(done) {
         var mock = nock("https://user-api-example.com")
-          .get('/package/@wrigley_the_writer%2Fscoped_private')
-          .reply(402)
+          .get('/user/wrigley_the_writer')
+          .reply(404);
 
         process.env.FEATURE_ACCESS_PAGE = 'true';
         server.inject(options, function(response) {
-          // mock.done()
+          mock.done();
           resp = response;
           delete process.env.FEATURE_ACCESS_PAGE;
           done();

--- a/test/handlers/package.js
+++ b/test/handlers/package.js
@@ -53,7 +53,13 @@ describe("package handler", function(){
       .get('/point/last-week/request').twice()
       .reply(200, fixtures.downloads.request.week)
       .get('/point/last-month/request').twice()
-      .reply(200, fixtures.downloads.request.month);
+      .reply(200, fixtures.downloads.request.month)
+      .get('/point/last-day/request').twice()
+      .reply(404)
+      .get('/point/last-week/request').twice()
+      .reply(404)
+      .get('/point/last-month/request').twice()
+      .reply(404);
 
     userMock = nock("https://user-api-example.com")
       .get('/user/bob').times(3)

--- a/test/handlers/user/login.js
+++ b/test/handlers/user/login.js
@@ -93,6 +93,11 @@ describe('Getting to the login page', function () {
   });
 
   it('renders an error if the username or password is incorrect', function (done) {
+
+    var mock = nock("https://user-api-example.com")
+      .post("/user/fakeboom/login", {"password":"booooom"})
+      .reply(404);
+
     generateCrumb(server, function (crumb){
       var options = {
         url: '/login',
@@ -106,6 +111,7 @@ describe('Getting to the login page', function () {
       };
 
       server.inject(options, function (resp) {
+        mock.done();
         expect(resp.statusCode).to.equal(400);
         var source = resp.request.response.source;
         expect(source.template).to.equal('user/login');

--- a/test/handlers/user/signup.js
+++ b/test/handlers/user/signup.js
@@ -86,7 +86,13 @@ describe('Signing up a new user', function () {
   });
 
   it('fails validation with incomplete form fields', function (done) {
+
+    var mock = nock("https://user-api-example.com")
+      .get("/user/fakeusercli")
+      .reply(404);
+
     server.inject(postSignup(forms.incomplete), function (resp) {
+      mock.done();
       expect(resp.statusCode).to.equal(400);
       var source = resp.request.response.source;
       expect(source.template).to.equal('user/signup-form');
@@ -96,7 +102,12 @@ describe('Signing up a new user', function () {
   });
 
   it('fails validation with a bad email address', function (done) {
+    var mock = nock("https://user-api-example.com")
+      .get("/user/fakeusercli")
+      .reply(404);
+
     server.inject(postSignup(forms.badEmail), function (resp) {
+      mock.done();
       expect(resp.statusCode).to.equal(400);
       var source = resp.request.response.source;
       expect(source.template).to.equal('user/signup-form');
@@ -106,7 +117,12 @@ describe('Signing up a new user', function () {
   });
 
   it('fails validation with a bad username (dot)', function (done) {
+    var mock = nock("https://user-api-example.com")
+      .get("/user/.fakeusercli")
+      .reply(404);
+
     server.inject(postSignup(forms.badUsernameDot), function (resp) {
+      mock.done();
       expect(resp.statusCode).to.equal(400);
       var source = resp.request.response.source;
       expect(source.template).to.equal('user/signup-form');
@@ -116,7 +132,12 @@ describe('Signing up a new user', function () {
   });
 
   it('fails validation with a bad username (uppercase)', function (done) {
+    var mock = nock("https://user-api-example.com")
+      .get("/user/FAkeusercli")
+      .reply(404);
+
     server.inject(postSignup(forms.badUsernameCaps), function (resp) {
+      mock.done();
       expect(resp.statusCode).to.equal(400);
       var source = resp.request.response.source;
       expect(source.template).to.equal('user/signup-form');
@@ -126,6 +147,10 @@ describe('Signing up a new user', function () {
   });
 
   it('fails validation with a bad username (encodeURI)', function (done) {
+    var mock = nock("https://user-api-example.com")
+      .get("/user/blärgh")
+      .reply(404);
+
     server.inject(postSignup(forms.badUsernameEncodeURI), function (resp) {
       expect(resp.statusCode).to.equal(400);
       var source = resp.request.response.source;
@@ -136,7 +161,12 @@ describe('Signing up a new user', function () {
   });
 
   it('fails validation with non-matching passwords', function (done) {
+    var mock = nock("https://user-api-example.com")
+      .get("/user/fakeusercli")
+      .reply(404);
+
     server.inject(postSignup(forms.invalidPassMatch), function (resp) {
+      mock.done();
       expect(resp.statusCode).to.equal(400);
       var source = resp.request.response.source;
       expect(source.template).to.equal('user/signup-form');

--- a/test/models/user.js
+++ b/test/models/user.js
@@ -518,6 +518,13 @@ describe("User", function(){
       var params = { id: 'e17fe5d778', email: {email:'boom@boom.com'} };
 
       it('adds the user to the mailing list when checked', function (done) {
+
+        var userMock = nock("https://user.com")
+          .put('/user', {"name":"boom","password":"12345","verify":"12345","email":"boom@boom.com"})
+          .reply(404)
+          .put('/user', {"name":"boom","password":"12345","verify":"12345","email":"boom@boom.com","npmweekly":"on"})
+          .reply(404);
+
         spy.reset();
         User.signup({
           name: 'boom',
@@ -526,12 +533,14 @@ describe("User", function(){
           email: 'boom@boom.com',
           npmweekly: "on"
         }, function (er, user) {
+          // userMock.done();
           expect(spy.calledWith(params)).to.be.true();
           done();
         });
       });
 
       it('does not add the user to the mailing list when unchecked', function (done) {
+
         spy.reset();
         User.getMailchimp = function () {return {lists: {subscribe: spy}}};
 


### PR DESCRIPTION
addresses https://github.com/npm/newww/issues/860

note that we're now logging the `body` coming from the Request calls in errors - this is because the error messages that come from the LICENSE_API are actually being sent in the body, and not in the `err` param.