### PR TITLE
Events

### DIFF
--- a/assets/scripts/banner.js
+++ b/assets/scripts/banner.js
@@ -1,6 +1,6 @@
 module.exports = function() {
   $(function(){
-    var ready = new Date() > new Date("2015-04-14T06:00:00-07:00")
+    var ready = new Date() > new Date("2015-04-13T06:00:00-07:00")
     var disabled = localStorage.getItem('disable-private-modules-banner')
 
     if (!ready || disabled || location.pathname === "/private-modules") {

--- a/assets/scripts/banner.js
+++ b/assets/scripts/banner.js
@@ -1,6 +1,6 @@
 module.exports = function() {
   $(function(){
-    var ready = new Date() > new Date("2015-04-13T06:00:00-07:00")
+    var ready = new Date() > new Date("2015-04-14T06:00:00-07:00")
     var disabled = localStorage.getItem('disable-private-modules-banner')
 
     if (!ready || disabled || location.pathname === "/private-modules") {

--- a/assets/scripts/npm-expansions.js
+++ b/assets/scripts/npm-expansions.js
@@ -2,6 +2,7 @@ var expansions = require("npm-expansions")
 var clickCount = -1
 
 var updateExpansion = function(event) {
+  if (event) event.preventDefault()
 
   if (++clickCount > 10) {
     return window.location = "https://github.com/npm/npm-expansions"
@@ -9,7 +10,6 @@ var updateExpansion = function(event) {
 
   var expansion = expansions[Math.floor(Math.random()*expansions.length)]
   $("#npm-expansions").text(expansion)
-  return false
 }
 
 $(function(){

--- a/assets/scripts/vendor/google-analytics.js
+++ b/assets/scripts/vendor/google-analytics.js
@@ -22,7 +22,7 @@ $(document).ready(function () {
   });
 
   $(document).on("click", "[data-event-trigger='click']", function (e) {
-    ga('send', 'event', $(this).data("eventName"), 'click', $(this).attr("title"));
+    ga('send', 'event', $(this).data("eventName"), 'click');
   });
 
 });

--- a/assets/scripts/vendor/google-analytics.js
+++ b/assets/scripts/vendor/google-analytics.js
@@ -21,4 +21,8 @@ $(document).ready(function () {
     ga('send', 'event', 'npm Enterprise', 'click');
   });
 
+  $(document).on("click", "[data-event-trigger='click']", function (e) {
+    ga('send', 'event', $(this).data("eventName"), 'click', $(this).attr("title"));
+  });
+
 });

--- a/templates/layouts/default.hbs
+++ b/templates/layouts/default.hbs
@@ -39,20 +39,24 @@
   <div id="notification-banner" style="display:none">
     <div class="container">
       <hgroup>
-        <a href="/private-modules">
+        <a href="/private-modules"
+          data-event-trigger="click"
+          data-event-name="private-modules-banner-signup-via-wombat">
           <img src="/static/images/wombat-by-night.svg" alt="night wombat">
         </a>
         <h2>private npm is here.</h2>
         <h3>publish unlimited private modules for just $7/month</h3>
       </hgroup>
-      <a class="button" href="/private-modules">sign up</a>
-      <a class="button button-subtle banner-close">no thanks</a>
+      <a class="button" href="/private-modules"
+        data-event-trigger="click"
+        data-event-name="private-modules-banner-signup">sign up</a>
+      <a class="button button-subtle banner-close" data-event-trigger="click" data-event-name="private-modules-banner-no-thanks">no thanks</a>
     </div>
   </div>
 
   <nav>
     <div class="container">
-      <a href="#" id="npm-expansions">node package manager</a>
+      <a href="#" id="npm-expansions" data-event-trigger="click" data-event-name="npm-expansions">node package manager</a>
       <a href="/private-modules">npm private modules</a>
       <a href="/enterprise">npm Enterprise</a>
       <a href="https://docs.npmjs.com">documentation</a>

--- a/templates/layouts/default.hbs
+++ b/templates/layouts/default.hbs
@@ -57,7 +57,7 @@
   <nav>
     <div class="container">
       <a href="#" id="npm-expansions" data-event-trigger="click" data-event-name="npm-expansions">node package manager</a>
-      <a href="/private-modules">npm private modules</a>
+      <a href="/private-modules" data-event-trigger="click" data-event-name="private-modules-nav-link">npm private modules</a>
       <a href="/enterprise">npm Enterprise</a>
       <a href="https://docs.npmjs.com">documentation</a>
       <a href="http://blog.npmjs.org/">blog</a>

--- a/templates/user/email-confirmed.hbs
+++ b/templates/user/email-confirmed.hbs
@@ -9,7 +9,7 @@
 
   <p>
     Now that you've cleared that up, you might want to
-    <a href="/settings/billing">sign up for private modules</a>,
+    <a href="/settings/billing" data-event-trigger="click" data-event-name="post-confirmation-signup">sign up for private modules</a>,
     <a href="/profile-edit">update your profile</a>,
     or learn how to
     <a href="https://docs.npmjs.com/">get started with npm</a>.


### PR DESCRIPTION
stick `data` attributes on anything you wanna measure:

```html
<a 
  href="/some/place" 
  data-event-trigger="click" 
  data-event-name="npm-expansions"
>node package manager</a>
```

Hmmm not sure how this is gonna work for [outbound links](https://support.google.com/analytics/answer/1136920?hl=en)...