### PR TITLE
tomorrow

### DIFF
--- a/assets/scripts/banner.js
+++ b/assets/scripts/banner.js
@@ -1,6 +1,6 @@
 module.exports = function() {
   $(function(){
-    var ready = new Date() > new Date("2015-04-14T06:00:00-07:00")
+    var ready = new Date() > new Date("2015-04-14T03:30:00-07:00")
     var disabled = localStorage.getItem('disable-private-modules-banner')
 
     if (!ready || disabled || location.pathname === "/private-modules") {

--- a/assets/scripts/banner.js
+++ b/assets/scripts/banner.js
@@ -1,6 +1,6 @@
 module.exports = function() {
   $(function(){
-    var ready = new Date() > new Date("2015-04-13T06:00:00-07:00")
+    var ready = new Date() > new Date("2015-04-14T06:00:00-07:00")
     var disabled = localStorage.getItem('disable-private-modules-banner')
 
     if (!ready || disabled || location.pathname === "/private-modules") {

--- a/services/corporate/methods/getPage.js
+++ b/services/corporate/methods/getPage.js
@@ -18,7 +18,12 @@ function getPage (repo) {
       }
 
       var org = "npm";
-      var branch = (new Date() > new Date("2015-04-14T03:30:00-07:00")) ? "master" : "prerelease";
+      if (repo === "static-pages"){
+        var branch = (new Date() > new Date("2015-04-14T03:30:00-07:00")) ? "master" : "prerelease";
+      } else {
+        var branch = "master";
+      }
+
       var url = fmt('https://raw.githubusercontent.com/%s/%s/%s/%s.md', org, repo, branch, validName);
 
       request(url, function (err, resp, content) {

--- a/services/corporate/methods/getPage.js
+++ b/services/corporate/methods/getPage.js
@@ -18,7 +18,7 @@ function getPage (repo) {
       }
 
       var org = "npm";
-      var branch = (new Date() > new Date("2015-04-13T03:30:00-07:00")) ? "master" : "prerelease";
+      var branch = (new Date() > new Date("2015-04-14T03:30:00-07:00")) ? "master" : "prerelease";
       var url = fmt('https://raw.githubusercontent.com/%s/%s/%s/%s.md', org, repo, branch, validName);
 
       request(url, function (err, resp, content) {

--- a/services/corporate/methods/getPage.js
+++ b/services/corporate/methods/getPage.js
@@ -17,7 +17,9 @@ function getPage (repo) {
         return next(err, null);
       }
 
-      var url = fmt('https://raw.githubusercontent.com/npm/' + repo + '/master/%s.md', validName);
+      var org = (new Date() > new Date("2015-04-13T03:30:00-07:00")) ? "linclark" : "npm";
+      var branch = "master"
+      var url = fmt('https://raw.githubusercontent.com/%s/%s/%s/%s.md', org, repo, branch, validName);
 
       request(url, function (err, resp, content) {
 

--- a/services/corporate/methods/getPage.js
+++ b/services/corporate/methods/getPage.js
@@ -17,8 +17,8 @@ function getPage (repo) {
         return next(err, null);
       }
 
-      var org = (new Date() > new Date("2015-04-13T03:30:00-07:00")) ? "linclark" : "npm";
-      var branch = "master"
+      var org = "npm";
+      var branch = (new Date() > new Date("2015-04-13T03:30:00-07:00")) ? "master" : "prerelease";
       var url = fmt('https://raw.githubusercontent.com/%s/%s/%s/%s.md', org, repo, branch, validName);
 
       request(url, function (err, resp, content) {

--- a/test/services/corporate.js
+++ b/test/services/corporate.js
@@ -26,8 +26,10 @@ describe('getting pages from GitHub', function () {
     var md = "*emphasis* on **this** [link](boom.com)",
         html = '<p><em>emphasis</em> on <strong>this</strong> <a href="boom.com">link</a></p>\n';
 
+
+    var branch = (new Date() > new Date("2015-04-14T03:30:00-07:00")) ? "master" : "prerelease";
     var mock = nock("https://raw.githubusercontent.com/")
-        .get('/npm/static-pages/master/boom.md')
+        .get('/npm/static-pages/' + branch + '/boom.md')
         .reply(200, md);
 
     server.methods.corp.getPage('boom', function (er, content) {


### PR DESCRIPTION
Tuesday, April 14 at 3:30am Pacific:

- banner starts showing up
- https://github.com/npm/static-pages/tree/master starts getting used instead of https://github.com/npm/static-pages/tree/prerelease