### PR TITLE
Update Stripe config in CSP

### DIFF
--- a/lib/csp.js
+++ b/lib/csp.js
@@ -43,7 +43,8 @@ csp.default = {
   // objectSrc: Values for the object-src directive,
   // mediaSrc: Values for the media-src directive,
   frameSrc: [
-    'https://checkout.stripe.com'
+    'https://checkout.stripe.com',
+    'https://js.stripe.com',
   ],
   // sandbox: Values for the sandbox directive,
   reportUri: '/-/csplog'

--- a/lib/csp.js
+++ b/lib/csp.js
@@ -42,7 +42,7 @@ csp.default = {
   ],
   // objectSrc: Values for the object-src directive,
   // mediaSrc: Values for the media-src directive,
-  frameSrc: [
+  childSrc: [
     'https://checkout.stripe.com',
     'https://js.stripe.com',
   ],

--- a/lib/csp.js
+++ b/lib/csp.js
@@ -16,7 +16,7 @@ csp.default = {
 
     'https://api.stripe.com',
     'https://checkout.stripe.com/checkout.js',
-    'https://js.stripe.com/v2/',
+    'https://js.stripe.com',
 
     'https://www.google-analytics.com',
     'https://fonts.googleapis.com',

--- a/lib/csp.js
+++ b/lib/csp.js
@@ -42,7 +42,7 @@ csp.default = {
   ],
   // objectSrc: Values for the object-src directive,
   // mediaSrc: Values for the media-src directive,
-  childSrc: [
+  frameSrc: [
     'https://checkout.stripe.com',
     'https://js.stripe.com',
   ],

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "accept-language-parser": "^1.0.2",
     "async": "^0.9.0",
-    "blankie": "^1.0.0",
+    "blankie": "^1.1.0",
     "bluebird": "^2.6.4",
     "bole": "~1.0.0",
     "boom": "^2.6.1",

--- a/test/csp.js
+++ b/test/csp.js
@@ -41,19 +41,19 @@ describe("csp (content security policy)", function () {
       })
     })
 
-    describe("childSrc", function(){
+    describe("frameSrc", function(){
       it("has two allowances", function (done) {
-        expect(csp.default.childSrc.length).to.equal(2)
+        expect(csp.default.frameSrc.length).to.equal(2)
         done();
       })
 
       it("allows checkout.stripe.com", function (done) {
-        expect(csp.default.childSrc).to.include('https://checkout.stripe.com');
+        expect(csp.default.frameSrc).to.include('https://checkout.stripe.com');
         done();
       })
 
       it("allows js.stripe.com", function (done) {
-        expect(csp.default.childSrc).to.include('https://js.stripe.com');
+        expect(csp.default.frameSrc).to.include('https://js.stripe.com');
         done();
       })
     })

--- a/test/csp.js
+++ b/test/csp.js
@@ -41,14 +41,19 @@ describe("csp (content security policy)", function () {
       })
     })
 
-    describe("frameSrc", function(){
-      it("only has one allowance", function (done) {
-        expect(csp.default.frameSrc.length).to.equal(1)
+    describe("childSrc", function(){
+      it("has two allowances", function (done) {
+        expect(csp.default.childSrc.length).to.equal(2)
         done();
       })
 
       it("allows checkout.stripe.com", function (done) {
-        expect(csp.default.frameSrc).to.include('https://checkout.stripe.com');
+        expect(csp.default.childSrc).to.include('https://checkout.stripe.com');
+        done();
+      })
+
+      it("allows js.stripe.com", function (done) {
+        expect(csp.default.childSrc).to.include('https://js.stripe.com');
         done();
       })
     })


### PR DESCRIPTION
This is a fix for https://github.com/npm/newww/issues/885

Not sure why we weren't seeing this until now, but the stripe code currently expects to be able to use an iframe. 

When adding stripe to the `frameSrc` whitelist, I noticed that [frame-src is deprecated](https://developer.mozilla.org/en-US/docs/Web/Security/CSP/CSP_policy_directives#child-src), so I updated the CSP to use `child-src` instead.

This is up on staging now for testing.