### PR TITLE
add Twitter tracking codes

### DIFF
--- a/templates/user/billing.hbs
+++ b/templates/user/billing.hbs
@@ -137,3 +137,10 @@
 </div>
 
 <script type="text/javascript" src="https://js.stripe.com/v2/"></script>
+
+<script src="//platform.twitter.com/oct.js" type="text/javascript"></script>
+<script type="text/javascript">
+twttr.conversion.trackPid('l5xz2', { tw_sale_amount: 0, tw_order_quantity: 0 });</script>
+<noscript>
+<img height="1" width="1" style="display:none;" alt="" src="https://analytics.twitter.com/i/adsct?txn_id=l5xz2&p_id=Twitter&tw_sale_amount=0&tw_order_quantity=0" />
+<img height="1" width="1" style="display:none;" alt="" src="//t.co/i/adsct?txn_id=l5xz2&p_id=Twitter&tw_sale_amount=0&tw_order_quantity=0" /></noscript>

--- a/templates/user/profile.hbs
+++ b/templates/user/profile.hbs
@@ -108,4 +108,11 @@
 
 </div>
 
+<script src="//platform.twitter.com/oct.js" type="text/javascript"></script>
+<script type="text/javascript">
+twttr.conversion.trackPid('l5xyy', { tw_sale_amount: 0, tw_order_quantity: 0 });</script>
+<noscript>
+<img height="1" width="1" style="display:none;" alt="" src="https://analytics.twitter.com/i/adsct?txn_id=l5xyy&p_id=Twitter&tw_sale_amount=0&tw_order_quantity=0" />
+<img height="1" width="1" style="display:none;" alt="" src="//t.co/i/adsct?txn_id=l5xyy&p_id=Twitter&tw_sale_amount=0&tw_order_quantity=0" /></noscript>
+
 {{/with}}


### PR DESCRIPTION
This adds twitter tracking codes so we can track conversions based on tweets.

There is one on the profile page. This should only be used if the person has completed their purchase, and should only be shown once, but I couldn't figure out where the thank you message was generated.