### PR TITLE
Disallow private toggle for unpaid users

### DIFF
--- a/assets/scripts/package-access.js
+++ b/assets/scripts/package-access.js
@@ -1,143 +1,146 @@
 var template = require("../../templates/partials/collaborator.hbs");
-var formToRequestObject = require("./form-to-request-object")
+var formToRequestObject = require("./form-to-request-object");
 
 module.exports = function() {
-  $(updateInputsAndHandlers)
-}
+  $(updateInputsAndHandlers);
+};
 
 var updateInputsAndHandlers = function() {
   $('#add-collaborator')
     .unbind("submit", addCollaborator)
-    .bind("submit", addCollaborator)
+    .bind("submit", addCollaborator);
 
   $('.update-collaborator input')
     .unbind("change", updateCollaborator)
-    .bind("change", updateCollaborator)
+    .bind("change", updateCollaborator);
 
   $('.remove-collaborator')
     .unbind("submit", removeCollaborator)
-    .bind("submit", removeCollaborator)
+    .bind("submit", removeCollaborator);
 
   $('#package-access-toggle')
     .unbind("change", togglePackageAccess)
-    .bind("change", togglePackageAccess)
+    .bind("change", togglePackageAccess);
 
   // enable/disable permission togglers
   $("input[type=radio][name='collaborator.permissions']")
-    .attr('disabled', !$("#collaborators").data("enablePermissionTogglers"))
+    .attr('disabled', !$("#collaborators").data("enablePermissionTogglers"));
 
   // Reveal delete links
   if ($("#collaborators").data("enableDeletion")) {
-    $("form.remove-collaborator").css({visibility: "visible"})
+    $("form.remove-collaborator").css({visibility: "visible"});
   }
 
   // If there's only one collaborator, disallow removal or demotion
   if ($(".collaborator").length === 1) {
-    $("form.remove-collaborator").css({visibility: "hidden"})
+    $("form.remove-collaborator").css({visibility: "hidden"});
     $("input[type=radio][name='collaborator.permissions']")
-      .attr('disabled', true)
+      .attr('disabled', true);
   }
 
   // Set default permissions for new collaborators based on package publicity
   // private: default is read-only
   // public: default is read-write
-  var private = $("#package-access-toggle").prop("checked")
+  var private = $("#package-access-toggle").prop("checked");
   $("#add-collaborator input[name='collaborator.permissions']")
-    .val(private ? "read" : "write")
+    .val(private ? "read" : "write");
 
   // Clear the 'add' input
-  $("#add-collaborator input[name='collaborator.name']").val("")
-}
+  $("#add-collaborator input[name='collaborator.name']").val("");
+};
 
 var addCollaborator = function(e) {
-  e.preventDefault()
+  e.preventDefault();
   $.ajax(formToRequestObject($(this)))
     .done(function(data){
-      console.log("done", data)
       if (data.collaborator) {
-        $("tr.collaborator:last").after(template(data.collaborator))
-        updateInputsAndHandlers()
+        $("tr.collaborator:last").after(template(data.collaborator));
+        updateInputsAndHandlers();
       }
     })
-    .fail(errorHandler)
-}
+    .fail(errorHandler);
+};
 
 var updateCollaborator = function(e) {
-  e.preventDefault()
-  var $form = $(this).parents("form")
-  var opts = formToRequestObject($form)
+  e.preventDefault();
+  var $form = $(this).parents("form");
+  var opts = formToRequestObject($form);
 
   // make it hard for users to demote themselves to read-only access
   if (
-    opts.data.collaborator.permissions === "read"
-    && opts.data.collaborator.name === $("[data-user-name]").data('userName')
+    opts.data.collaborator.permissions === "read" && opts.data.collaborator.name === $("[data-user-name]").data('userName')
   ) {
-    var confirmation = "Are you sure you want to set your own access level to read-only?"
+    var confirmation = "Are you sure you want to set your own access level to read-only?";
     if (!confirm(confirmation)) {
-      $form.find("input[value='write']").prop("checked", true)
+      $form.find("input[value='write']").prop("checked", true);
       return false;
     }
   }
 
   $.ajax(opts)
     .done(updateInputsAndHandlers)
-    .fail(errorHandler)
-}
+    .fail(errorHandler);
+};
 
 var removeCollaborator = function(e) {
-  e.preventDefault()
-  var $form = $(this)
+  e.preventDefault();
+  var $form = $(this);
 
   // make it hard for users to remove themselves
-  var removingSelf = $("[data-user-name]").data('userName') === $form.data('collaboratorName')
-  var confirmation = "Are you sure you want to remove yourself from this package?"
-  if (removingSelf && !confirm(confirmation)) return false;
+  var removingSelf = $("[data-user-name]").data('userName') === $form.data('collaboratorName');
+  var confirmation = "Are you sure you want to remove yourself from this package?";
+  if (removingSelf && !confirm(confirmation)) {
+    return false;
+  }
 
   // hide the element right away for that snappy feel
-  $form.parents(".collaborator").remove()
+  $form.parents(".collaborator").remove();
 
   $.ajax(formToRequestObject($form))
     .done(function(){
       if (removingSelf) {
-        return window.location = $form.data('packageUrl') + "?removed-self-from-collaborators"
+        window.location = $form.data('packageUrl') + "?removed-self-from-collaborators";
+        return;
       }
-      updateInputsAndHandlers()
+      updateInputsAndHandlers();
     })
-    .fail(errorHandler)
-}
+    .fail(errorHandler);
+};
 
 var togglePackageAccess = function(e) {
-  e.preventDefault()
-  var $checkbox = $(this)
-  var $form = $checkbox.parents("form")
-  var private = $checkbox.prop("checked")
+  e.preventDefault();
+  var $checkbox = $(this);
+  var $form = $checkbox.parents("form");
+  var private = $checkbox.prop("checked");
 
   if (!private) {
-    var confirmation = "This will make your package world-readable"
-    var $readOnlyInputs = $("[type=radio][name='collaborator.permissions'][value='read']:checked")
-    if ($readOnlyInputs.length) confirmation += " and will remove the read-only collaborators"
-    confirmation += ". Are you sure?"
+    var confirmation = "This will make your package world-readable";
+    var $readOnlyInputs = $("[type=radio][name='collaborator.permissions'][value='read']:checked");
+    if ($readOnlyInputs.length) {
+      confirmation += " and will remove the read-only collaborators";
+    }
+    confirmation += ". Are you sure?";
 
     if (!confirm(confirmation)) {
-      $checkbox.prop("checked", true)
-      return false
+      $checkbox.prop("checked", true);
+      return false;
     }
 
-    $readOnlyInputs.parents(".collaborator").remove()
+    $readOnlyInputs.parents(".collaborator").remove();
   }
 
-  var opts = formToRequestObject($form)
-  opts.data.package = {private: private}
+  var opts = formToRequestObject($form);
+  opts.data.package = {private: private};
 
-  $("#collaborators").data("enablePermissionTogglers", private)
+  $("#collaborators").data("enablePermissionTogglers", private);
 
-  updateInputsAndHandlers()
+  updateInputsAndHandlers();
   $.ajax(opts)
     .done(updateInputsAndHandlers)
-    .fail(errorHandler)
-}
+    .fail(errorHandler);
+};
 
  var errorHandler = function(xhr, status, error) {
-   console.error(xhr, status, error)
-   $("p.error").text(xhr.responseJSON.message || error).show()
- }
+   console.error(xhr, status, error);
+   $("p.error").text(xhr.responseJSON.message || error).show();
+ };

--- a/templates/package/access.hbs
+++ b/templates/package/access.hbs
@@ -45,14 +45,6 @@
     data-enable-permission-togglers="{{enablePermissionTogglers}}"
     data-enable-deletion="{{userHasWriteAccessToPackage}}">
 
-    <thead>
-      <tr>
-        <th>&nbsp;</th>
-        <th>User</th>
-        <th>Access</th>
-        <th>Revoke</th>
-      </tr>
-    </thead>
     <tbody>
 
       {{#each package.collaborators}}

--- a/templates/package/access.hbs
+++ b/templates/package/access.hbs
@@ -11,23 +11,30 @@
 
   {{#unless user}}
     <p class="notice please-log-in">
-      Are you an admin of this package? 
+      Are you an admin of this package?
       Please <a href="/login?done={{canonicalURL}}">log in</a> to manage access.
     </p>
   {{/unless}}
 
-  {{#if package.scoped}}
-    <form class="centered" method="POST" action="/package/{{package.name}}">
-      <input
-        type="checkbox"
-        class="toggle"
-        name="package.private"
-        id="package-access-toggle"
-        value="true"
-        {{#unless userHasWriteAccessToPackage}}disabled="disabled"{{/unless}}
-        {{#if package.private}}checked="checked"{{/if}} >
-      <label for="package-access-toggle"><span></span></label>
-    </form>
+  {{#if paymentRequiredToTogglePrivacy}}
+    <p class="notice pay-to-restrict-access">
+      To make this package private, you'll need to
+      <a href="/settings/billing">sign up for private modules</a>.
+    </p>
+  {{else}}
+    {{#if package.scoped}}
+      <form class="centered" method="POST" action="/package/{{package.name}}">
+        <input
+          type="checkbox"
+          class="toggle"
+          name="package.private"
+          id="package-access-toggle"
+          value="true"
+          {{#unless userHasWriteAccessToPackage}}disabled="disabled"{{/unless}}
+          {{#if package.private}}checked="checked"{{/if}} >
+        <label for="package-access-toggle"><span></span></label>
+      </form>
+    {{/if}}
   {{/if}}
 
   <p class="error" style="display:none"></p>

--- a/templates/package/access.hbs
+++ b/templates/package/access.hbs
@@ -18,7 +18,7 @@
 
   {{#if paymentRequiredToTogglePrivacy}}
     <p class="notice pay-to-restrict-access">
-      To make this package private, you'll need to
+      To restrict access to this package, you'll need to
       <a href="/settings/billing">sign up for private modules</a>.
     </p>
   {{else}}


### PR DESCRIPTION
It is currently possible for an unpaid user to toggle their public package to private, effectively locking themselves out of the package until they become a paying customer. This PR addresses that problem.

When all of the following criteria are met...

- package is scoped
- package is public
- user is logged in
- user has write permissions to package
- user is not a paying customer

...then the public/private toggle is hidden and replaced with a notice:

![screen shot 2015-04-22 at 8 59 37 pm](https://cloud.githubusercontent.com/assets/2289/7290433/8d66a4be-e933-11e4-8f70-a544b66cf14e.png)

If the user is a paying customer, they see the private/public toggler:

![screen shot 2015-04-22 at 9 00 02 pm](https://cloud.githubusercontent.com/assets/2289/7290459/209869a2-e934-11e4-908c-5ac5a26028e0.png)


