### PR TITLE
move twitter signup tracking code

### DIFF
--- a/templates/user/billing.hbs
+++ b/templates/user/billing.hbs
@@ -18,7 +18,7 @@
   {{/if}}
 
   {{#if updated}}
-    {{> twitter-tracking pid='l5xz2'}}
+    {{> twitter-tracking pid='l5xyy'}}
 
     <p class="notice update-notice">
       You have successfully updated your billing information.
@@ -88,7 +88,7 @@
   {{> errors}}
 
   {{#if user.email_verified}}
-    {{> twitter-tracking pid='l5xyy'}}
+    {{> twitter-tracking pid='l5xz2'}}
 
     <p class="error billing-error" style="display:none;"></p>
 

--- a/templates/user/billing.hbs
+++ b/templates/user/billing.hbs
@@ -19,7 +19,7 @@
 
   {{#if updated}}
     {{> twitter-tracking pid='l5xz2'}}
-    
+
     <p class="notice update-notice">
       You have successfully updated your billing information.
       <br/><br/>
@@ -88,6 +88,8 @@
   {{> errors}}
 
   {{#if user.email_verified}}
+    {{> twitter-tracking pid='l5xyy'}}
+
     <p class="error billing-error" style="display:none;"></p>
 
     <form method="POST" id="payment-form" data-stripe-public-key="{{stripePublicKey}}" {{#if customer}}style="display:none;"{{/if}}>

--- a/templates/user/email-confirmed.hbs
+++ b/templates/user/email-confirmed.hbs
@@ -1,3 +1,5 @@
+{{> twitter-tracking pid='l5ybn'}}
+
 {{> profile-secondary-nav}}
 
 <div class="container narrow">

--- a/templates/user/profile.hbs
+++ b/templates/user/profile.hbs
@@ -109,5 +109,3 @@
 </div>
 
 {{/with}}
-
-{{> twitter-tracking pid='l5xyy'}}

--- a/test/handlers/customer.js
+++ b/test/handlers/customer.js
@@ -92,7 +92,7 @@ describe('GET /settings/billing', function () {
     });
   });
 
-  it('renders a twitter tracking card after successful update', function (done) {
+  it("renders a twitter tracking snippet for 'private modules purchase'", function (done) {
     var options = {
       method: "get",
       url: "/settings/billing?updated=1",
@@ -101,13 +101,13 @@ describe('GET /settings/billing', function () {
 
     server.inject(options, function (resp) {
       var $ = cheerio.load(resp.result);
-      expect($("script[src='//platform.twitter.com/oct.js'][data-twitter-pid='l5xz2']").length).to.equal(1);
-      expect($("noscript img[src^='//t.co/i/adsct?txn_id=l5xz2']").length).to.equal(1);
+      expect($("script[src='//platform.twitter.com/oct.js'][data-twitter-pid='l5xyy']").length).to.equal(1);
+      expect($("noscript img[src^='//t.co/i/adsct?txn_id=l5xyy']").length).to.equal(1);
       done();
     });
   });
 
-  it('does not render a twitter by default', function (done) {
+  it("renders a twitter tracking snippet for 'private modules billing signup page'", function (done) {
     var options = {
       method: "get",
       url: "/settings/billing",
@@ -116,8 +116,8 @@ describe('GET /settings/billing', function () {
 
     server.inject(options, function (resp) {
       var $ = cheerio.load(resp.result);
-      expect($("script[src='//platform.twitter.com/oct.js']").length).to.equal(0);
-      expect($("noscript img[src*='//t.co']").length).to.equal(0);
+      expect($("script[src='//platform.twitter.com/oct.js'][data-twitter-pid='l5xz2']").length).to.equal(1);
+      expect($("noscript img[src^='//t.co/i/adsct?txn_id=l5xz2']").length).to.equal(1);
       done();
     });
   });

--- a/test/handlers/user/confirm-email.js
+++ b/test/handlers/user/confirm-email.js
@@ -139,4 +139,32 @@ describe('Confirming an email address', function () {
       });
     });
   });
+
+  it('renders a twitter tracking snippet', function (done) {
+
+    var mock = nock("https://user-api-example.com")
+      .get("/user/bob")
+      .reply(200, users.bob)
+      .post("/user/bob/verify", { verification_key: users.bob.verification_key })
+      .reply(200);
+
+    var boom = JSON.stringify({
+          name: 'bob',
+          email: 'boom@bang.com',
+          token: '12345'
+        });
+
+    var opts = {url: '/confirm-email/12345'};
+
+    client.set('email_confirm_8cb2237d0679ca88db6464eac60da96345513964', boom, function () {
+
+      server.inject(opts, function (resp) {
+        mock.done();
+        expect(resp.statusCode).to.equal(200);
+        expect(resp.result).to.include("platform.twitter.com/oct.js");
+        done();
+      });
+    });
+  });
+
 });

--- a/test/handlers/user/profile.js
+++ b/test/handlers/user/profile.js
@@ -85,12 +85,6 @@ describe('GET /~bob for a user other than bob', function () {
     done();
   });
 
-  it('renders a twitter tracking card', function (done) {
-    expect($("script[src='//platform.twitter.com/oct.js'][data-twitter-pid='l5xyy']").length).to.equal(1);
-    expect($("noscript img[src^='//t.co/i/adsct?txn_id=l5xyy']").length).to.equal(1);
-    done();
-  });
-
 });
 
 describe('GET /~bob for logged-in bob', function () {


### PR DESCRIPTION
It was on the profile page. Now it's on the billing page. So the following actions will presumably satisfy the conversion requirements:

1. sign up (as an npm user)
1. confirm email
1. go to billing page
