### PR TITLE
don’t parse request.payload for CSP report, as it is already JSON

### DIFF
--- a/handlers/ops.js
+++ b/handlers/ops.js
@@ -22,9 +22,9 @@ module.exports = {
   },
 
   csplog: function (request, reply) {
-    var data = utils.safeJsonParse(request.payload);
-
-    request.logger.warn('content-security-policy validation', data);
+    request.logger.warn('csp report');
+    request.logger.warn(request.payload);
     return reply('ok').code(200);
   }
+
 };


### PR DESCRIPTION
A fix for https://github.com/npm/newww/issues/863

When introducing a CSP violation in my dev environment, it appears that Firefox is the only browser that acutually POST to the report endpoint. Chrome and Safari both dump error messages to the browser console, but they don't report. Hmm.
