### PR TITLE
let github tell the contribution story

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,9 +1,0 @@
-# Wombats at npm
-Raquel Vélez <raquel@rckbt.me>
-Laurie Voss <github@seldo.com>
-Faiq Raza <faiqrazarizvi@yahoo.com>
-Zeke Sikelianos <zeke@sikelianos.com>
-
-# Other awesome people who may or may not personally identify as wombats
-Robert Kowalski <rok@kowalski.gd>
-herenow <leonardoshiro@gmail.com>

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,1 @@
+For an up-to-date list of [npmjs.com](https://www.npmjs.com)'s contributors, see [github.com/npm/newww/graphs/contributors](https://github.com/npm/newww/graphs/contributors).


### PR DESCRIPTION
There are [many tools](https://www.npmjs.com/search?q=contributors) on npm for assembling a contributor list from git/hub. I tried about five of them, but none of them fit my requirements: Some didn't work at all, others didn't have a CLI, some produced tons of crazy HTML output, some put the contributors list in package.json...

So I spent a few minutes working on rolling my own: a little script that hits the github API, stuff the contents into a handlebars template, etc. But today is not a yak-shaving day. It's a day to get things done and move on.

I present a minimalist fix for https://github.com/npm/newww/issues/901
