### PR TITLE
encourages password change after password reset, fixes #798

### DIFF
--- a/facets/user/show-forgot.js
+++ b/facets/user/show-forgot.js
@@ -60,7 +60,9 @@ function processToken(request, reply) {
         newAuth = {
           name: name,
           password: newPass,
-          mustChangePass: true
+          resource: {
+            mustChangePass: 'true' // must be a string, as per user-acl
+          }
         };
 
     request.logger.warn('About to change password', { name: name });

--- a/facets/user/show-login.js
+++ b/facets/user/show-login.js
@@ -85,7 +85,7 @@ module.exports = function login (request, reply) {
               return reply.view('errors/internal', opts).code(500);
             }
 
-            if (user && user.mustChangePass) {
+            if (user && user.resource.mustChangePass) {
               request.timing.page = 'login-must-change-pass';
 
               request.metrics.metric({name: 'login-must-change-pass'});

--- a/facets/user/show-password.js
+++ b/facets/user/show-password.js
@@ -37,8 +37,14 @@ module.exports = function (request, reply) {
 
       request.logger.warn('Changing password', { name: loggedInUser.name });
 
-      var newAuth = { name: loggedInUser.name, password: data.new };
-      newAuth.mustChangePass = false;
+      var newAuth = {
+        name: loggedInUser.name,
+        password: data.new,
+        resource: {
+          mustChangePass: null
+        }
+      };
+
       User.save(newAuth, function (er, data) {
         if (er) {
           request.logger.warn('Failed to change password; user=' + newAuth.name);

--- a/test/fixtures/users.js
+++ b/test/fixtures/users.js
@@ -86,11 +86,11 @@ exports.bobUpdated = {
     github: 'bob',
     twitter: 'bobby',
     homepage: '',
-    freenode: ''
+    freenode: '',
+    mustChangePass: 'true'
   },
   created: '2014-11-21T20:05:05.423Z',
   updated: '2015-01-24T00:08:41.269Z',
-  mustChangePass: true,
   deleted: null
 };
 

--- a/test/handlers/user/password.js
+++ b/test/handlers/user/password.js
@@ -25,7 +25,13 @@ before(function (done) {
     .reply(200, users.bob)
     .post("/user/" + users.bob.name + "/login", {password: 'abcde'})
     .reply(200, users.bob)
-    .post("/user/" + users.bob.name, {"name":"bob","password":"abcde","mustChangePass":false})
+    .post("/user/" + users.bob.name, {
+      "name":"bob",
+      "password":"abcde",
+      "resource": {
+        "mustChangePass":null
+      }
+    })
     .reply(200, users.bob);
 
   require('../../mocks/server')(function (obj) {


### PR DESCRIPTION
The key was to put the `mustChangePass` directive into the resource section, as it wasn't getting saved to user-acl.

Due to some user-acl limitations, we have to use a string instead of a usual boolean - fortunately we can nullify it, so `if user.resource.mustChangePass` still works just fine :-)