### PR TITLE
pin hapi-auth-cookie to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "handlebars": "^2.0.0-alpha.2",
     "handlebars-helper-pluralize": "^1.0.2",
     "hapi": "^8.4.0",
-    "hapi-auth-cookie": "^2.0.0",
+    "hapi-auth-cookie": "2.0.0",
     "hapi-common-log": "^1.1.0",
     "hashchange": "^1.0.0",
     "hbsfy": "^2.2.0",


### PR DESCRIPTION
2.1.0 breaks functionality. See hapijs/hapi-auth-cookie#67