### PR TITLE
[WIP] CSP for Twitter conversion tracking

### DIFF
--- a/lib/csp.js
+++ b/lib/csp.js
@@ -4,6 +4,7 @@ csp.default = {
   defaultSrc: 'self',
   scriptSrc: [
     'self',
+    'unsafe-inline',
 
     // Hubspot
     'https://forms.hubspot.com/uploads/form/v2/419727/9a2b4ac5-ef09-43e6-854a-d82c92347c9d',


### PR DESCRIPTION
In #913, the URL for Twitter was added to the CSP. However, the CSP is blocking execution.

![csp](https://cloud.githubusercontent.com/assets/105464/7446833/5afac5e0-f1b3-11e4-8f8c-32711b1455ab.png)

The error specifies multiple ways to fix this. I have done it the easiest way... however, we probably DO NOT want to do it this way. It would be much better to use nonces. There is an open issue to add nonce support to blankie, nlf/blankie#3.