### PR TITLE
Website now sends email from website@npmjs.com

### DIFF
--- a/services/email/methods/send.js
+++ b/services/email/methods/send.js
@@ -7,7 +7,7 @@ var log = require('bole')('email-send'),
 var send = module.exports = function send (template, data, redis) {
 
   var mailOpts = _.extend({}, {
-    from: "support@npmjs.com",
+    from: "website@npmjs.com",
     host: process.env.CANONICAL_HOST
   }, data);
 


### PR DESCRIPTION
This is to avoid confusing Zendesk, which doesn't like that the from: and to: fields are the same right now.