### PR TITLE
update marky-markdown with colspan fix and rust syntax support

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "leven": "^1.0.1",
     "mailchimp-api": "^2.0.7",
     "malarkey": "^1.1.0",
-    "marky-markdown": "^5.0.2",
+    "marky-markdown": "^5.3.0",
     "moment": "^2.9.0",
     "moment-tokens": "^1.0.0",
     "month": "^1.0.0",


### PR DESCRIPTION
This allows `td` and `th` elements to have `rowspan` and `colspan` attributes, a fix made a while back but only recently published.

https://twitter.com/nebrius/status/595270714623561728

Also, Rust syntax support. `¯\_(ツ)_/¯`


