### PR TITLE
allows starring of scoped packages (fixes #879)

### DIFF
--- a/models/package.js
+++ b/models/package.js
@@ -112,8 +112,9 @@ Package.prototype.count = function() {
 };
 
 Package.prototype.star = function (package) {
+
   var _this = this;
-  var url = fmt("%s/package/%s/star", _this.host, package);
+  var url = fmt("%s/package/%s/star", _this.host, encodeURIComponent(package));
   var opts = {
     url: url,
     json: true,
@@ -140,8 +141,9 @@ Package.prototype.star = function (package) {
 };
 
 Package.prototype.unstar = function (package) {
+
   var _this = this;
-  var url = fmt("%s/package/%s/star", _this.host, package);
+  var url = fmt("%s/package/%s/star", _this.host, encodeURIComponent(package));
   var opts = {
     url: url,
     json: true,


### PR DESCRIPTION
Not sure if this is the best solution, but essentially we were passing `@scope/package`, which was breaking the url we use to send the star to the user-acl. Instead, we should be sending `@scope%2fpackage` so that it doesn't seem like we're sending to a different url.

Using `encodeURIComponent(package)` would result in `%40scope%2Ffpackage`... would that work better?