### PR TITLE
separates support email from 'from' email (fixes #976)

### DIFF
--- a/services/email/methods/send.js
+++ b/services/email/methods/send.js
@@ -8,7 +8,8 @@ var send = module.exports = function send (template, data, redis) {
 
   var mailOpts = _.extend({}, {
     from: "website@npmjs.com",
-    host: process.env.CANONICAL_HOST
+    host: process.env.CANONICAL_HOST,
+    support_email: "support@npmjs.com",
   }, data);
 
   var mm = new MustacheMailer({
@@ -35,4 +36,4 @@ send.mailConfig = {
     region: "us-west-2"
   }),
   emailFrom: 'support@npmjs.com'
-}
+};

--- a/test/services/email.js
+++ b/test/services/email.js
@@ -13,7 +13,6 @@ var Code = require('code'),
     server,
     MockTransport = require('nodemailer-mock-transport'),
     mock = new MockTransport({boom: 'bam'}),
-    redis = require('redis'),
     spawn = require('child_process').spawn,
     client,
     redisProcess;
@@ -70,6 +69,7 @@ describe('send an email', function () {
       .then(function () {
         var msg = mock.sentMail[0];
         expect(msg.data.to).to.equal('"user" <user@npmjs.com>');
+        expect(msg.data.support_email).to.equal('support@npmjs.com');
         done();
       })
       .catch(function (err) {


### PR DESCRIPTION
should be merged in conjunction with https://github.com/npm/email-templates/pull/7