### PR TITLE
Remove optional `type` attributes from templates

### DIFF
--- a/templates/layouts/default.hbs
+++ b/templates/layouts/default.hbs
@@ -21,9 +21,9 @@
   {{> touch-icons}}
 
   <link rel="canonical" href="{{canonicalURL}}">
-  <link type="text/css" rel="stylesheet" media="all" href="/static/css/index.css">
+  <link rel="stylesheet" media="all" href="/static/css/index.css">
   <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="npm">
-  <link href='//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700' rel='stylesheet' type='text/css'>
+  <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700">
 
   <script defer src="/static/js/index.js"></script>
   <script defer src="/static/js/vendor.min.js"></script>

--- a/templates/user/billing.hbs
+++ b/templates/user/billing.hbs
@@ -144,4 +144,4 @@
 
 </div>
 
-<script type="text/javascript" src="https://js.stripe.com/v2/"></script>
+<script src="https://js.stripe.com/v2/"></script>


### PR DESCRIPTION
HTML5 specifies default values for the `type` attribute for [`<script>`](http://www.w3.org/TR/html5/scripting-1.html#attr-script-type), [`<style>`](http://www.w3.org/TR/html5/document-metadata.html#attr-style-type), and [`<link>`](http://www.w3.org/TR/html5/document-metadata.html#concept-link-type-sniffing) elements so, unless a different value is needed, the default can be omitted.