### PR TITLE
adds messaging to inform user that token has expired (fixes #167)

### DIFF
--- a/facets/user/show-confirm-email.js
+++ b/facets/user/show-confirm-email.js
@@ -26,7 +26,7 @@ module.exports = function confirmEmail (request, reply) {
 
     if (!cached) {
       request.logger.error('Token not found or invalid: ', key);
-      reply.view('errors/not-found', opts).code(404);
+      reply.view('errors/token-expired', opts).code(404);
       return;
     }
 

--- a/facets/user/show-email-edit.js
+++ b/facets/user/show-email-edit.js
@@ -126,7 +126,7 @@ function confirmEmail (request, reply) {
 
     if (!cached) {
       request.logger.error('Token not found or invalid: ' + confKey);
-      reply.view('errors/not-found', opts).code(404);
+      reply.view('errors/token-expired', opts).code(404);
       return;
     }
 
@@ -208,7 +208,7 @@ function revertEmail (request, reply) {
 
     if (!cached) {
       request.logger.error('Token not found or invalid: ' + revKey);
-      reply.view('errors/not-found', opts).code(404);
+      reply.view('errors/token-expired', opts).code(404);
       return;
     }
 

--- a/facets/user/show-forgot.js
+++ b/facets/user/show-forgot.js
@@ -1,7 +1,7 @@
-var UserModel = require('../../models/user'),
-    userValidate = require('npm-user-validate'),
-    utils = require('../../lib/utils'),
-    crypto = require('crypto');
+var crypto      = require('crypto'),
+    UserModel   = require('../../models/user'),
+    userValidate= require('npm-user-validate'),
+    utils       = require('../../lib/utils');
 
 module.exports = function (request, reply) {
   var opts = { };
@@ -43,7 +43,7 @@ function processToken(request, reply) {
 
     if (!cached) {
       request.logger.error('Token not found or invalid: ', pwKey);
-      reply.view('errors/internal', opts).code(500);
+      reply.view('errors/token-expired', opts).code(404);
       return;
     }
 

--- a/locales/en_US/index.js
+++ b/locales/en_US/index.js
@@ -1,13 +1,20 @@
 exports.user = require('./user.js');
-exports.company = require('./company.js')
+
+exports.company = require('./company.js');
+
 exports.package = {
   not_found: {
     title: "not found"
   }
-}
+};
+
 exports.errors = {
   generic: {
     title: "Whoops",
     subtitle: "Something went wrong"
+  },
+  token_expired: {
+    title: "whoops",
+    subtitle: "looks like the token has expired :-("
   }
-}
+};

--- a/templates/errors/token-expired.hbs
+++ b/templates/errors/token-expired.hbs
@@ -1,0 +1,24 @@
+<div class="container narrow">
+
+  <hgroup>
+    <h1>{{t "errors.token_expired.title"}}</h1>
+    <h2>{{t "errors.token_expired.subtitle"}}</h2>
+  </hgroup>
+
+  <p>
+    The email you received has a one-time-use-only link.
+  </p>
+
+  <p>
+    You are seeing this message because you either already clicked on that link, someone else clicked on it for you (silly spam filters), or the link expired.
+  </p>
+
+  <p>
+    If you feel this error is the result of a bug, please <a href="/contact">contact us</a> and reference the following unique error number:
+  </p>
+
+  <pre><code>{{correlationID}}</code></pre>
+
+  <p>Be sure to let us know what you were doing and how you got here so we can help you as quickly as possible!</p>
+
+</div>

--- a/test/handlers/user/confirm-email.js
+++ b/test/handlers/user/confirm-email.js
@@ -58,6 +58,8 @@ describe('Confirming an email address', function () {
 
     server.inject(opts, function (resp) {
       expect(resp.statusCode).to.equal(404);
+      var source = resp.request.response.source;
+      expect(source.template).to.equal('errors/token-expired');
       done();
     });
   });

--- a/test/handlers/user/email-edit.js
+++ b/test/handlers/user/email-edit.js
@@ -269,7 +269,7 @@ describe('Confirming an email change', function () {
       licenseMock.done();
       expect(resp.statusCode).to.equal(404);
       var source = resp.request.response.source;
-      expect(source.template).to.equal('errors/not-found');
+      expect(source.template).to.equal('errors/token-expired');
       done();
     });
   });
@@ -386,7 +386,7 @@ describe('Reverting an email change', function () {
       licenseMock.done();
       expect(resp.statusCode).to.equal(404);
       var source = resp.request.response.source;
-      expect(source.template).to.equal('errors/not-found');
+      expect(source.template).to.equal('errors/token-expired');
       done();
     });
   });


### PR DESCRIPTION
Two tests are missing (in `test/handlers/user/forgot-password.js`)

```
Using a token
  - 14) renders an error if the token does not exist (0 ms)
  - 15) changes the password with a proper token (0 ms)
```

Both of these were commented out some time ago; bringing them back requires some pretty significant rewrites across multiple modules. In essence, we're using three different cache mechanisms and we should really consolidate it down to one. An issue has been created here: https://github.com/npm/newww/issues/1000.

The other tests totally pass, though, and hand-testing seems to work just fine.