### PR TITLE
fixes homepage editing bug

### DIFF
--- a/presenters/user.js
+++ b/presenters/user.js
@@ -41,6 +41,8 @@ var sanitizers = {
 
     // Not-fully-qualified URL
     if (isURL("http://"+input)) { return "http://"+input; }
+
+    return '';
   },
 
   twitter: function(input) {

--- a/test/fixtures/users.js
+++ b/test/fixtures/users.js
@@ -62,7 +62,8 @@ exports.bobUpdateBody = {
     "fullname": "Big Bob",
     "github": "bob",
     "twitter": "bobby",
-    "mustChangePass": "true"
+    "mustChangePass": "true",
+    "homepage": ""
   },
   "created": "2014-11-21T20:05:05.423Z",
   "updated": "2015-01-24T00:08:41.269Z",

--- a/test/presenters/user.js
+++ b/test/presenters/user.js
@@ -105,7 +105,7 @@ describe("resource", function () {
           homepage: "kate"
         }
       });
-      expect(user.resource.homepage).to.not.exist();
+      expect(user.resource.homepage).to.equal("");
       done();
     });
   });


### PR DESCRIPTION
non-ending if-tree resulted in `undefined` homepage when user tried to delete homepage from profile, which made user-acl angry and resulted in a non-deletion of the homepage :-/

but now it's all fixed, so yay! :-D