### PR TITLE
Silence the cache logging in normal operations.

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -128,7 +128,7 @@ Cache.get = function get(opts, callback)
             return callback(null, value);
         }
 
-        Cache.logger.info('get: ' + opts.url);
+        Cache.logger.debug('get: ' + opts.url);
 
         Request(opts, function(err, response, data)
         {
@@ -167,7 +167,7 @@ Cache.setKey = function setKey(key, ttl, data, callback)
         }
         else
         {
-          Cache.logger.info('cached ' + key);
+          Cache.logger.debug('cached ' + key);
         }
 
         if (callback) { callback(err, unused); }
@@ -182,17 +182,19 @@ Cache.getKey = function getKey(key, callback)
         return;
     }
 
+    var cacheKey = this._fingerprint(key);
+
     assert(_.isObject(redis), 'you must configure the redis client before using the cache.');
-    redis.get(this._fingerprint(key), function(err, value)
+    redis.get(cacheKey, function(err, value)
     {
         if (err)
         {
-            Cache.logger.error('problem getting ' + key + ' from redis @ ' + options.redis);
+            Cache.logger.error('problem getting ' + cacheKey + ' from redis @ ' + options.redis);
             Cache.logger.error(err);
         }
         else
         {
-            Cache.logger.info('retrieved ' + value + ' from ' + key);
+            Cache.logger.debug('retrieved ' + value + ' from ' + cacheKey);
         }
 
         callback(err, value);

--- a/test/cache.js
+++ b/test/cache.js
@@ -186,7 +186,7 @@ describe('lib/cache.js', function()
         it('makes a request using the options argument if redis has no value', function(done)
         {
           sinon.stub(cache.redis, 'get').yields(null);
-          sinon.spy(cache.logger, 'info');
+          sinon.spy(cache.logger, 'debug');
 
           var opts = {
             method: 'get',
@@ -200,9 +200,9 @@ describe('lib/cache.js', function()
           cache.get(opts, function(err, data)
           {
               expect(cache.redis.get.calledOnce).to.equal(true);
-              expect(cache.logger.info.calledWithMatch(/get: /i)).to.equal(true);
+              expect(cache.logger.debug.calledWithMatch(/get: /i)).to.equal(true);
               cache.redis.get.restore();
-              cache.logger.info.restore();
+              cache.logger.debug.restore();
               mock.done();
               done();
           });


### PR DESCRIPTION
Those info lines are now debug lines, so we don't spew a lot of logging on every cache operation. Also, we no longer uselessly log `[object Object]` as the cache key in those lines.

Updated the test that looked for the info log.