### PR TITLE
Fixed bug #894: search is using OR instead of AND

### DIFF
--- a/facets/registry/show-search.js
+++ b/facets/registry/show-search.js
@@ -24,7 +24,14 @@ module.exports = function (request, reply) {
       "query" : {
           "bool": {
             "should": [
-              {"match_phrase": {"name": request.query.q} },
+                { "match": {
+                  "name" : {
+                    "query" : request.query.q,
+                    "type" : "phrase",
+                    "operator" : "and",
+                    boost: 20
+                  }
+              }},
               {"match_phrase": {"keywords": request.query.q} },
               {"match_phrase": {"description": request.query.q} },
               {"match_phrase": {"readme": request.query.q} }

--- a/facets/registry/show-search.js
+++ b/facets/registry/show-search.js
@@ -8,7 +8,7 @@ module.exports = function (request, reply) {
 
   // Redirect /search/foo to /search/?foo
   if (request.params && request.params.q) {
-    return reply.redirect('/search?q='+request.params.q)
+    return reply.redirect('/search?q='+request.params.q);
   }
 
   if (!request.query || !request.query.q) {
@@ -22,62 +22,15 @@ module.exports = function (request, reply) {
       from: (page - 1) * perPage,
       size : perPage,
       "query" : {
-        "dis_max": {
-          "tie_breaker": 0.7,
-          "boost": 1.2,
-          "queries": [
-            {
-              "function_score": {
-                "query": {
-                  "match": {
-                    "name.untouched": request.query.q
-                    /*"name.untouched":{
-                      "query": request.query.q,
-                      "operator": "and"
-                    }*/
-                  }
-                },
-                "boost_factor": 100
-              }
-            },
-            {
-              "bool": {
-                "should": [
-                {"match_phrase": {"name": request.query.q} },
-                {"match_phrase": {"keywords": request.query.q} },
-                {"match_phrase": {"description": request.query.q} },
-                {"match_phrase": {"readme": request.query.q} }
-                ],
-                "minimum_should_match": 1,
-                "boost": 50
-              }
-            },
-            {
-              "function_score": {
-                "query": {
-                  "multi_match": {
-                    "query": request.query.q,
-                    "fields": ["name^4", "keywords", "description", "readme"]
-                  }
-                },
-                "functions": [
-                  {
-                    "script_score": {
-                      "script": "(doc['dlScore'].isEmpty() ? 0 : doc['dlScore'].value)"
-                    }
-                  },
-                  {
-                    "script_score": {
-                      "script": "doc['stars'].isEmpty() ? 0 : doc['stars'].value"
-                    }
-                  }
-                ],
-                "score_mode": "sum",
-                "boost_mode": "multiply"
-              }
-            }
-          ]
-        }
+          "bool": {
+            "should": [
+              {"match_phrase": {"name": request.query.q} },
+              {"match_phrase": {"keywords": request.query.q} },
+              {"match_phrase": {"description": request.query.q} },
+              {"match_phrase": {"readme": request.query.q} }
+            ],
+            "minimum_should_match": 1
+          }
       }
     }
   };
@@ -95,6 +48,7 @@ module.exports = function (request, reply) {
 
     if (error) {
       request.logger.warn('elasticsearch failed searching ' + request.query.q);
+      request.logger.error(error);
       return reply.view('errors/internal', opts).code(500);
     }
 
@@ -113,7 +67,7 @@ module.exports = function (request, reply) {
     });
 
     if (opts.prevPage || opts.nextPage) {
-      opts.pages = {}
+      opts.pages = {};
       if (opts.prevPage) {
         opts.pages.prev = "/search?q=" + opts.q + "&page=" + opts.prevPage;
       }
@@ -124,4 +78,4 @@ module.exports = function (request, reply) {
 
     return reply.view('registry/search', opts);
   });
-}
+};


### PR DESCRIPTION
Brutal simplification of the ElasticSearch query produces results that are a lot more like what you'd expect for searches like "hash ring", "leveldb cluster", and "regexp escape". ES now does all the result relevance work.

While I was there, fixed jshint complaints.