### PR TITLE
tweak Constructor.io background color

### DIFF
--- a/assets/styles/_header.styl
+++ b/assets/styles/_header.styl
@@ -284,7 +284,7 @@ nav
   border-color greigh5
 
 #powered-by-constructor-io
-  background-color white
+  background-color #EAEAEA
 
 #user-info
   position absolute

--- a/assets/styles/_header.styl
+++ b/assets/styles/_header.styl
@@ -284,7 +284,7 @@ nav
   border-color greigh5
 
 #powered-by-constructor-io
-  background-color #EAEAEA
+  background-color greigh6
 
 #user-info
   position absolute


### PR DESCRIPTION
Hi guys,

We're glad to hear the autocomplete is working out great!  We're really excited to be providing the service.

We showed the branding edit you guys made to some people, and they didn’t notice our name, so we'd like to suggest one small tweak to make it slightly more prominent.  If we match the background color to the gray in your heading, we get something like this:

![image](https://cloud.githubusercontent.com/assets/171131/7995301/ba5da7da-0ae2-11e5-87cc-a760e22df443.png)

Is that cool?