### PR TITLE
Overzealous regex was logging people out

### DIFF
--- a/adapters/bonbon.js
+++ b/adapters/bonbon.js
@@ -35,7 +35,7 @@ exports.register = function(server, options, next) {
       start: Date.now(),
     };
 
-    if (request.auth && request.auth.credentials && !request.path.match(/static/)) {
+    if (request.auth && request.auth.credentials && !request.path.match(/static\//)) {
       UserModel.new(request).get(request.auth.credentials.name, function(err, user) {
         if (err) { request.logger.warn(err); }
         request.loggedInUser = user;


### PR DESCRIPTION
If a package had 'static' in the name, the url wasn't being
authenticated against. We'd like to not go through the process of
AUTHing requests for static files, but of course don't want to log
people out because they look at a package that has 'static' as part of
the title.

Fixes #1032