### PR TITLE
Fixing #1043 by separating static content

### DIFF
--- a/routes/public.js
+++ b/routes/public.js
@@ -278,6 +278,25 @@ var publicRoutes = [
     }
   },{
     method: '*',
+    path: '/private-modules',
+    handler: function(request, reply) {
+      var route = request.path.substr(1, request.path.length);
+      var loggedInUser = request.loggedInUser;
+      var isPaid = loggedInUser && loggedInUser.isPaid;
+      var opts = { };
+      opts.isPaid = isPaid;
+
+      request.server.methods.corp.getPage(route, function(er, content) {
+
+        if (content) {
+          opts.md = content;
+          return reply.view('company/private-modules', opts);
+        }
+
+      });
+    }
+  },{
+    method: '*',
     path: '/{p*}',
     handler: require("../handlers/fallback")
   }

--- a/templates/company/private-modules.hbs
+++ b/templates/company/private-modules.hbs
@@ -1,0 +1,21 @@
+<div class="tablet-width markdown container">
+<hgroup>
+  <h1>npm Private Modules</h1>
+  <h2>create and share unlimited private modules for $7/month</h2>
+</hgroup>
+
+{{#if isPaid}}
+<p>When you pay for private modules, you can:</p>
+
+<ul>
+  <li>Host as many private packages as you want</li>
+  <li>Give read access or read-write access for those packages to any other paid user</li>
+  <li>Install and use any packages that other paid users have given you read access to</li>
+  <li>Collaborate on any packages that other paid users have given you write access to</li>
+</ul>
+
+<a data-event-trigger="click" data-event-name="billing-via-private-modules-page" class="button" href="https://www.npmjs.com/settings/billing">sign up</a>
+{{/if}}
+
+  {{{md}}}
+</div>

--- a/templates/company/private-modules.hbs
+++ b/templates/company/private-modules.hbs
@@ -4,18 +4,9 @@
   <h2>create and share unlimited private modules for $7/month</h2>
 </hgroup>
 
-{{#if isPaid}}
-<p>When you pay for private modules, you can:</p>
-
-<ul>
-  <li>Host as many private packages as you want</li>
-  <li>Give read access or read-write access for those packages to any other paid user</li>
-  <li>Install and use any packages that other paid users have given you read access to</li>
-  <li>Collaborate on any packages that other paid users have given you write access to</li>
-</ul>
-
-<a data-event-trigger="click" data-event-name="billing-via-private-modules-page" class="button" href="https://www.npmjs.com/settings/billing">sign up</a>
-{{/if}}
+{{#unless isPaid}}
+  {{{benefits}}}
+{{/unless}}
 
   {{{md}}}
 </div>


### PR DESCRIPTION
Fix #1043 

Add new route for `/private-modules` - have it async grab the benefits (plus sign-up button) of private-modules + the private-modules copy separately and then only display the benefits + sign-up button if the user hasn't paid.