### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ We use the [blankie](https://github.com/nlf/blankie) Hapi plugin to enforce a st
 
 ### Routes
 
-Every route in the application is defined in [routes.js](routes.js).
+Every route in the application is defined in [routes](/routes).
 
 ### Handlers
 


### PR DESCRIPTION
adjusted the documentation for where the routes are located to the folder they now exist in. Reference a .js file that is no longer there (Routes.js).