### PR TITLE
Add titles for browse pages

### DIFF
--- a/facets/registry/show-search.js
+++ b/facets/registry/show-search.js
@@ -63,7 +63,7 @@ module.exports = function (request, reply) {
     request.metrics.metric({ name: 'search', search: request.query.q });
 
     merge(opts, {
-      title: 'results for ',
+      title: 'results for '+request.query.q,
       page: page,
       q: request.query.q,
       results: response.hits.hits,

--- a/handlers/browse.js
+++ b/handlers/browse.js
@@ -14,6 +14,7 @@ browse.packagesByKeyword = function(request, reply) {
   }
   var options = {
     keyword: context.keyword,
+    title: 'packages with keyword \'' + context.keyword + '\'',
     count: defaultCount,
     offset: Math.abs(parseInt(request.query.offset, 10)) || 0
   }
@@ -31,6 +32,7 @@ browse.mostDependedUponPackages = function(request, reply) {
   var context = {}
   var options = {
     sort: 'dependents',
+    title: 'most depended upon packages',
     count: defaultCount,
     offset: Math.abs(parseInt(request.query.offset)) || 0
   }
@@ -50,6 +52,7 @@ browse.packageDependents = function(request, reply) {
   }
   var options = {
     dependency: context.package,
+    title: 'packages depending on ' + context.package,
     count: defaultCount,
     offset: Math.abs(parseInt(request.query.offset)) || 0
   }
@@ -67,6 +70,7 @@ browse.mostStarredPackages = function(request, reply) {
   var context = {}
   var options = {
     sort: 'stars',
+    title: 'most starred packages',
     count: defaultCount,
     offset: Math.abs(parseInt(request.query.offset)) || 0
   }
@@ -84,6 +88,7 @@ browse.recentlyUpdatedPackages = function(request, reply) {
   var context = {}
   var options = {
     sort: 'modified',
+    title: 'recently updated packages',
     count: defaultCount,
     offset: Math.abs(parseInt(request.query.offset)) || 0
   }
@@ -101,6 +106,7 @@ browse.recentlyCreatedPackages = function(request, reply) {
   var context = {}
   var options = {
     sort: 'created',
+    title: 'recently created packages',
     count: defaultCount,
     offset: Math.abs(parseInt(request.query.offset)) || 0
   }

--- a/templates/layouts/default.hbs
+++ b/templates/layouts/default.hbs
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <title>{{#if title}}{{title}}{{#if q}}{{q}}{{/if}}{{else}}npm{{/if}}</title>
+  <title>{{#if title}}{{title}}{{else}}npm{{/if}}</title>
 
   {{#if package}}
     <meta name="description" content="{{package.description}}">


### PR DESCRIPTION
I opened a few tabs and couldn't keep them straight. Here are proposed page titles for "/browse/keyword/{keyword}", "/browse/depended", "/browse/depended/{package}", "/browse/star", "/browse/updated", and "/browse/created" pages.

This also removes a search results page-specific way of displaying search queries in template logic in favor of building the title earlier.

Since #761 is still open this was done blind 🙀, but think I got 'i's dotted and 't's crossed