### PR TITLE
License name is strong.

### DIFF
--- a/templates/package/show.hbs
+++ b/templates/package/show.hbs
@@ -86,7 +86,7 @@
         {{#if license.url}}
           <a href="{{license.url}}">{{license.name}}</a>
         {{else}}
-          {{license.name}}
+          <strong>{{license.name}}</strong>
         {{/if}}
         <span> license</span>
       </li>


### PR DESCRIPTION
Hi npm!

No license (or a license lacking a url, though I haven't come across any of those yet) currently looks like:

![screen_shot_2015-06-29_at_8_55_02_pm](https://cloud.githubusercontent.com/assets/606772/8423680/0b1a0eca-1ea2-11e5-9495-a48b1800df64.png)

For consistency with the other fields, it could look like:

![screen_shot_2015-06-29_at_8_55_22_pm](https://cloud.githubusercontent.com/assets/606772/8423683/15a9e7c0-1ea2-11e5-9c82-8e0d720805d4.png)

Not a big deal, but happened to notice it as I was poking around. :)