### PR TITLE
Metrics tweaks.

### DIFF
--- a/adapters/bonbon.js
+++ b/adapters/bonbon.js
@@ -117,9 +117,8 @@ exports.register = function(server, options, next) {
 
     var latency = Date.now() - request.timing.start;
     metrics.metric({
-      name:  'latency',
+      name:  'latency.page',
       value: latency,
-      type:  request.timing.type || 'pageload',
       page:  request.timing.page,
     });
 

--- a/facets/company/show-policy.js
+++ b/facets/company/show-policy.js
@@ -15,8 +15,6 @@ module.exports = function (request, reply) {
     opts.md = content;
 
     request.timing.page = 'policy-' + policy;
-    request.metrics.metric({name: 'policy-' + policy});
-
     return reply.view('company/corporate', opts);
   });
 };

--- a/facets/company/show-static.js
+++ b/facets/company/show-static.js
@@ -1,12 +1,8 @@
 module.exports = function (type, text) {
   return function (request, reply) {
     var opts = { };
-
     opts.text = text;
-
     request.timing.page = 'static-' + type;
-    request.metrics.metric({name: 'static-' + type});
-
     reply.view('static', opts);
   };
 };

--- a/facets/company/show-whoshiring-payments.js
+++ b/facets/company/show-whoshiring-payments.js
@@ -48,7 +48,7 @@ module.exports = function (request, reply) {
       currency: "usd",
       card: token.id, // obtained with Stripe.js
       description: "Charge for " + token.email
-    }, function(err, charge) {
+    }, function(err) {
       if (err) {
         request.logger.error('internal stripe error; token amount is ', token.amount);
         request.logger.error(err);
@@ -56,13 +56,11 @@ module.exports = function (request, reply) {
       }
 
       request.metrics.metric({
-        name:  'latency',
+        name:  'latency.stripe',
         value: Date.now() - stripeStart,
-        type:  'stripe'
       });
 
-      request.timing.page = 'whoshiring-paymentProcessed';
       return reply('Stripe charge successful').code(200);
     });
   });
-}
+};

--- a/facets/company/show-whoshiring.js
+++ b/facets/company/show-whoshiring.js
@@ -1,10 +1,6 @@
 module.exports = function (request, reply) {
-  var timer = { start: Date.now() };
-
   var opts = { };
 
   request.timing.page = 'whoshiring';
-  request.metrics.metric({name: 'whoshiring'});
-
   reply.view('company/whoshiring', opts);
 };

--- a/facets/enterprise/buy-license.js
+++ b/facets/enterprise/buy-license.js
@@ -104,15 +104,12 @@ module.exports = function (request, reply) {
         }
 
         request.metrics.metric({
-          name: 'latency',
+          name: 'latency.stripe',
           value: Date.now() - stripeStart,
-          type: 'stripe'
         });
 
         request.logger.info('Stripe customer created: ', stripeCustomer);
-
         request.timing.page = 'enterprise-license-paymentProcessed';
-        request.metrics.metric({name: request.timing.page});
 
         // license purchased! We need to update the customer record with their stripe customer ID
         updateCustomer(customer.id, { stripe_customer_id: stripeCustomer.id }, function(er) {
@@ -146,15 +143,12 @@ module.exports = function (request, reply) {
             }
 
             request.metrics.metric({
-              name: 'latency',
+              name: 'latency.licenseCreation',
               value: Date.now() - licenseStart,
-              type: 'licenseCreation'
             });
 
             request.logger.info('Successful license creation: ', license);
-
             request.timing.page = 'enterprise-license-created';
-            request.metrics.metric({name: request.timing.page});
 
             // now email them the generated license
             var sendEmail = request.server.methods.email.send;

--- a/facets/enterprise/find-license.js
+++ b/facets/enterprise/find-license.js
@@ -126,8 +126,6 @@ module.exports = function(request,reply) {
             })
             .then(function () {
               request.timing.page = 'npmEconfirmEmail';
-              request.metrics.metric({ name: 'npmEconfirmEmail' });
-
               // everything is a-ok!
               return reply.view('enterprise/check-email');
             });

--- a/facets/enterprise/show-index.js
+++ b/facets/enterprise/show-index.js
@@ -4,6 +4,5 @@ module.exports = function npmE (request, reply) {
   };
 
   request.timing.page = 'enterprise';
-  request.metrics.metric({name: 'enterprise'});
   return reply.view('enterprise/index', opts);
 };

--- a/facets/registry/show-search.js
+++ b/facets/registry/show-search.js
@@ -45,10 +45,8 @@ module.exports = function (request, reply) {
   var start = Date.now();
   client.search(searchQuery, function (error, response) {
     request.metrics.metric({
-      name: 'latency',
+      name: 'latency.elasticsearch',
       value: Date.now() - start,
-      type: 'elasticsearch',
-      query: request.query.q
     });
 
     var opts = { };
@@ -60,7 +58,6 @@ module.exports = function (request, reply) {
     }
 
     request.timing.page = 'search';
-    request.metrics.metric({ name: 'search', search: request.query.q });
 
     merge(opts, {
       title: 'results for ',

--- a/facets/user/show-confirm-email.js
+++ b/facets/user/show-confirm-email.js
@@ -66,8 +66,6 @@ module.exports = function confirmEmail (request, reply) {
             }
 
             request.timing.page = 'email-confirmed';
-
-            request.metrics.metric({ name: 'email-confirmed' });
             return reply.view('user/email-confirmed', opts);
           });
         });

--- a/handlers/star.js
+++ b/handlers/star.js
@@ -23,7 +23,7 @@ module.exports = function (request, reply) {
     Package.star(pkg)
       .then(function () {
         request.timing.page = 'star';
-        request.metrics.metric({ name: 'star', package: pkg });
+        request.metrics.metric({ name: 'star', package: pkg, value: 1 });
         return reply(username + ' starred ' + pkg).code(200);
       })
       .catch(function (err) {
@@ -37,7 +37,7 @@ module.exports = function (request, reply) {
     Package.unstar(pkg)
       .then(function () {
         request.timing.page = 'unstar';
-        request.metrics.metric({ name: 'unstar', package: pkg });
+        request.metrics.metric({ name: 'unstar', package: pkg, value: 1 });
 
         return reply(username + ' unstarred ' + pkg).code(200);
       })

--- a/server.js
+++ b/server.js
@@ -1,8 +1,6 @@
-require("./lib/environment")()
+require("./lib/environment")();
 
-var _         = require('lodash'),
-    URL       = require("url"),
-    Hapi      = require('hapi'),
+var Hapi      = require('hapi'),
     replify   = require('replify'),
     bole      = require('bole'),
     TWO_WEEKS = 14 * 24 * 60 * 60 * 1000;
@@ -14,7 +12,7 @@ bole.output({
 });
 
 var redisConfig = require("redis-url")
-  .parse(process.env.REDIS_URL)
+  .parse(process.env.REDIS_URL);
 
 var server = new Hapi.Server({
   cache: {
@@ -42,14 +40,14 @@ var server = new Hapi.Server({
 var connection = {
   host: process.env.HOST || "localhost",
   port: process.env.PORT || "15443"
-}
+};
 
 if (process.env.NODE_ENV === 'dev') {
   connection.tls = {
     ca: [],
     key: "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA1IYcqR58TLSk1SCMlkXI/DmEDYZZarFUuB5L5cBYjU+uY62W\nAuRR8bVfVzNCRHA9pOt8fp+Ghu9U2L094jidSlLSE4p9XXw1VdOI5UZI+dlLBpc7\n+Jgt4awBulhWpojMo44iqyan+iSTnK9oqlRiMOTBGyxpSJfBftx1prUy7N06D8dI\nUiw2tzhizYNbvZ7GBXBDs2w4swfkZ16+HsMArc2yNDEDsgNCw1DyGMU/L3llaG2T\n70N3Ls+Fn/7KTkgtcyY2m7N4PIX5tvsH4zjm7OZrWXNFpHi8ElQ09+/Z9VPgLDGL\nwxNqZ3E8mobGciQTJ5KXk+S7R3X9OFuB91zkZwIDAQABAoIBAQCj2W35WT6d6Nv4\nUSrypITrKPDNeJoxrtxRQ1JipOPgtuENioRQYHVo89u4oBVkLGDqaH/II/eUyqpQ\nm749Tka+SZIbbLdwvtVkAT3W/lQ/BK9aOnkLFVCyX2nJoFfV9zxGkMvbxmbVbSO9\nNmNshrhZV9QlvhzB0fZld1ThnWvQvuoO5Vee6VJPcaKVX92LRtFph8bZzA8QRbqg\nBoSckVTsPlmNZINEK/ubrG7njc3ljPfhCgL8aftdR6M40yGgk0APUyyxe8+fOc3Z\n9/wd8iEF1pzoi4XbQexm+XF1gU2PF/QVAtisTW3Cq7gxOhUGvY2lmt0UWEWmJfC1\nq4ci2h8BAoGBAP4CNQrXtpKSNjEo9HTyKmJ2b04fhByBTv5tOCRuTuAqjnyCs5HQ\nnlewsSARSHdng4yb7XfH2dcR3bZmbzD4jWNmQGp88tvg3hMbQ1Hpt5ykwqALCLQM\njBEuP8n+xXl9uKrM7hfBM3+tPSMcp9aYY2LZm4o5PuWRpy2Fx+6i7SXnAoGBANYw\npTERqEFgozxQIZcQ595OKRRqTNwyQ/OfbCgM0//vxaXb5alTaWNbBAEg31/FrQ2J\neZbRt2DqgvrsAoHSgWBdASL5Nh6uThw0Mp2uPpqP7Nu7Pp/EDkAsd48RaRDFzn8s\nIG3qoOxvLhIuTGzA1liv48FNq6LW48cSNRG5bX2BAoGBAKUb+i6aGWsc72z1GjIK\nV9K4+ZDmm5GL3DU1+ZB0w4CjKQt2ShM2cDa/++LEWT6EYtY7ZRi/J7LNQjkWTKCg\ncAd0p9qQbazPdosk5ZWRPnDsCDbP9VBT95gTYBOFMAfQ2QDtRLbcNwV/LoZsUg0D\n8VaH7LrkiyXej7TfiR5teYlxAoGAM6NWsBXJsrlRoWDQOFNjEz1Uug9GqG+V4k41\nDRLKqZFs3Se+nqv1ZHa06HC8aaKGrhTOs4Wr6Dmhik0L7bCKcGj7tSrP2WW8fyA2\nc71mamz4daEW3/2sUdxmlp9j7R9DQXWp+9XtJhNH0CpJUo7LHmaJSjkngAK+t2e0\nU6mYtAECgYA0OvYSDF5OYSyqSHeAbXIqfJo58jcCmnZgN7NCvka1CF+PLDTXOQrn\ndm/vlzbD8/ftfZ3y5EGbLlHpnDnK5wpu+lF/gyauWliQ5RypQfakSYDu+WtK7tv1\nx8zpFXCHl9tya5lq1Op1dPjpRkQBBX6fsNh7imtB/O+IP5HzE6AgtA==\n-----END RSA PRIVATE KEY-----\n",
     cert: "-----BEGIN CERTIFICATE-----\nMIIDfjCCAmYCCQCfeUuTLMk3YzANBgkqhkiG9w0BAQUFADCBhzELMAkGA1UEBhMC\nVVMxCzAJBgNVBAgTAkNBMRAwDgYDVQQHEwdPYWtsYW5kMQwwCgYDVQQKEwNucG0x\nIjAgBgNVBAsTGW5wbSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxDjAMBgNVBAMTBW5w\nbUNBMRcwFQYJKoZIhvcNAQkBFghpQGl6cy5tZTAeFw0xMjA3MTIyMDEzMThaFw0y\nMjA3MTAyMDEzMThaMHoxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJDQTEQMA4GA1UE\nBxMHT2FrbGFuZDEMMAoGA1UEChMDbnBtMREwDwYDVQQLEwhyZWdpc3RyeTESMBAG\nA1UEAxMJbG9jYWxob3N0MRcwFQYJKoZIhvcNAQkBFghpQGl6cy5tZTCCASIwDQYJ\nKoZIhvcNAQEBBQADggEPADCCAQoCggEBANSGHKkefEy0pNUgjJZFyPw5hA2GWWqx\nVLgeS+XAWI1PrmOtlgLkUfG1X1czQkRwPaTrfH6fhobvVNi9PeI4nUpS0hOKfV18\nNVXTiOVGSPnZSwaXO/iYLeGsAbpYVqaIzKOOIqsmp/okk5yvaKpUYjDkwRssaUiX\nwX7cdaa1MuzdOg/HSFIsNrc4Ys2DW72exgVwQ7NsOLMH5Gdevh7DAK3NsjQxA7ID\nQsNQ8hjFPy95ZWhtk+9Ddy7PhZ/+yk5ILXMmNpuzeDyF+bb7B+M45uzma1lzRaR4\nvBJUNPfv2fVT4Cwxi8MTamdxPJqGxnIkEyeSl5Pku0d1/Thbgfdc5GcCAwEAATAN\nBgkqhkiG9w0BAQUFAAOCAQEADE/+NC2MwMJZoyZpaIY+Jy27WGsT6KOPEiWjOks6\nu2pNOmtXwTsAC92Tr0bgGPRmDLfsYX9aQ/iRjakLmhtV5TsaAdLNF0zKhrhpYjAl\nPTcrlPUxK+MZmbQQ2WGF/9AhS2Pnke1cFkiv8ORen1rkcynbSBpuKuraYz4FYoCy\ndqGovkN8bAjrSkOkuBpT93gyBEVWbG924b3QQS4dPwN2V+DfteB2TUh3SvpzyaXv\nDAt46X6rAjfDfcLle9gEkVDfAo2u6Sff2QqtZO9XrpYh7AX5JAb7pMy9dRn36kH2\neXZq9JXHgxFTGnLy2lEoaUzc532d4qxlP9jnXsZ4bM/JDA==\n-----END CERTIFICATE-----\n"
-  }
+  };
 }
 
 server.connection(connection);
@@ -64,8 +62,8 @@ server.views({
   layout: 'default'
 });
 
-server.stamp = require("./lib/stamp")()
-server.gitHead = require("./lib/git-head")()
+server.stamp = require("./lib/stamp")();
+server.gitHead = require("./lib/git-head")();
 
 // configure metrics as a side effect
 var metrics = require('./adapters/metrics')();
@@ -75,7 +73,7 @@ require("./lib/cache").configure({
     redis: process.env.REDIS_URL,
     ttl: 500,
     prefix: "cache:"
-})
+});
 
 server.register(require('hapi-auth-cookie'), function (err) {
   if (err) { throw err; }
@@ -123,8 +121,9 @@ server.register(require('hapi-auth-cookie'), function (err) {
 
     server.start(function() {
       metrics.metric({
-        env: process.env.NODE_ENV,
-        name: 'server.start'
+        env:   process.env.NODE_ENV,
+        name:  'server.start',
+        value: 1
       });
 
       log.info('Hapi server started @ ' + server.info.uri);

--- a/services/downloads/methods/getAllDownloads.js
+++ b/services/downloads/methods/getAllDownloads.js
@@ -1,10 +1,7 @@
 var
     async = require('async'),
-    Hapi = require('hapi'),
-    log = require('bole')('downloads'),
     makeDownloadFetchFunc = require('./getDownloads'),
-    metrics = require('../../../adapters/metrics')(),
-    timer = {};
+    metrics = require('../../../adapters/metrics')();
 
 module.exports = function getAllDownloads (url) {
   return function (package, next) {
@@ -16,9 +13,7 @@ module.exports = function getAllDownloads (url) {
     }
 
     var getDownloads = makeDownloadFetchFunc(url);
-
-    var n = 3,
-        dls = {};
+    var dls = {};
 
     var tasks = {
       day:   function(cb) { getDownloads('last-day', 'point', package, cb); },
@@ -33,10 +28,9 @@ module.exports = function getAllDownloads (url) {
       }
 
       metrics.metric({
-        name: 'latency',
+        name: 'latency.downloads',
         value: Date.now() - start,
-        type: 'downloads',
-        action: 'all downloads' + (package ? ' for ' + package : '')
+        package: package
       });
 
       dls.day = results.day || 0;
@@ -45,5 +39,5 @@ module.exports = function getAllDownloads (url) {
 
       next(null, dls);
     });
-  }
-}
+  };
+};

--- a/services/user/methods/sessions.js
+++ b/services/user/methods/sessions.js
@@ -16,15 +16,14 @@ module.exports = {
         if (err) {
           request.logger.error(Boom.internal('there was an error setting the cache'));
 
-          metrics.metric({name: 'setSessionError'});
+          metrics.metric({name: 'setSessionError', value: 1});
           return next(err);
         }
 
         timer.end = Date.now();
         metrics.metric({
-          name: 'latency',
+          name: 'latency.redis',
           value: timer.end - timer.start,
-          type: 'redis',
           action: 'setSession'
         });
 
@@ -47,13 +46,12 @@ module.exports = {
         if (err) {
           request.logger.error(Boom.internal('there was an error clearing the cache'));
           request.logger.error(err);
-          metrics.metric({name: 'delSessionError'});
+          metrics.metric({name: 'delSessionError', value: 1 });
         }
 
         metrics.metric({
-          name: 'latency',
+          name: 'latency.redis',
           value: Date.now() - start,
-          type: 'redis',
           action: 'delSession'
         });
 


### PR DESCRIPTION
Changed all names to graphite style dot-delimited strings. In particular, all the latency metrics are now things like `latency.page` and `latency.redis`.
Added a `value` field to all metrics.
Removed metrics that are redundant since we're already emitting a latency metric with the page name in it.
Fixed all jshint complaints while I was there.

The web site now emits the following metrics:

| name | value | additional fields |
| --- | --- | --- |
| 'server.start' | 1 | env |
| 'latency.page' | latency in ms | page |
| 'latency.stripe' | latency in ms |  |
| 'latency.licenseCreation' | latency in ms |  |
| 'latency.elasticsearch' | latency in ms |  |
| 'latency.downloads' | latency in ms | package |
| 'latency.redis' | latency in ms | action='setSession' |
| 'latency.redis' | latency in ms | action='delSession' |
| 'delSessionError' | 1 | |
| 'setSessionError' | 1 | |
| 'star' | 1 | package |
| 'unstar' | 1 | package |
| 'cache.readme.hit' | 1 | package |
| 'cache.readme.miss' | 1 | package |
