### PR TITLE
Emit latency metrics for all external requests.

### DIFF
--- a/lib/external-request.js
+++ b/lib/external-request.js
@@ -1,13 +1,25 @@
-var Request = require('request');
 var bole = require('bole');
 var clf = require('../lib/utils').toCommonLogFormat;
+var emitter = require('../adapters/metrics')();
 var logger = bole('EXTERNAL');
+var Request = require('request');
 
 var externalRequest = function externalRequest (opts, cb) {
 
+  var start = Date.now();
   Request(opts, function (err, resp, body) {
 
     if (resp) {
+      var hostname = '';
+      if (resp.request && resp.request.uri && resp.request.uri.host) {
+        hostname = resp.request.uri.host.replace('.internal.npmjs.com', '');
+      }
+      emitter.metric({
+        name: 'latency.external',
+        value: Date.now() - start,
+        source: hostname
+      });
+
       logger.info(clf(resp));
     }
 
@@ -18,7 +30,6 @@ var externalRequest = function externalRequest (opts, cb) {
 
     return cb(err, resp, body);
   });
-
 };
 
 externalRequest.get = function (opts, cb) {


### PR DESCRIPTION
The hostname is sent in the `source` field, with any trailing `.internal.npmjs.com` stripped off.