### PR TITLE
packages with the searched name are definitely at the top now

### DIFF
--- a/facets/registry/show-search.js
+++ b/facets/registry/show-search.js
@@ -23,7 +23,7 @@ module.exports = function (request, reply) {
       size : perPage,
       "query" : {
         "dis_max": {
-          "tie_breaker": 0.7,
+          "tie_breaker": 0.9,
           "boost": 1.2,
           "queries": [
             {
@@ -52,7 +52,7 @@ module.exports = function (request, reply) {
                   {"match_phrase": {"readme": request.query.q} }
                 ],
                 "minimum_should_match": 1,
-                "boost": 50
+                "boost": 30
               }
             },
           ]

--- a/facets/registry/show-search.js
+++ b/facets/registry/show-search.js
@@ -22,22 +22,41 @@ module.exports = function (request, reply) {
       from: (page - 1) * perPage,
       size : perPage,
       "query" : {
-          "bool": {
-            "should": [
-                { "match": {
-                  "name" : {
-                    "query" : request.query.q,
-                    "type" : "phrase",
-                    "operator" : "and",
-                    boost: 20
+        "dis_max": {
+          "tie_breaker": 0.7,
+          "boost": 1.2,
+          "queries": [
+            {
+              "function_score": {
+                "query": {
+                  "match": {
+                    "name.untouched": request.query.q
                   }
-              }},
-              {"match_phrase": {"keywords": request.query.q} },
-              {"match_phrase": {"description": request.query.q} },
-              {"match_phrase": {"readme": request.query.q} }
-            ],
-            "minimum_should_match": 1
-          }
+                },
+                "boost_factor": 100
+              }
+            },
+            {
+              "bool": {
+                "should": [
+                  { "match": {
+                    "name" : {
+                      "query" : request.query.q,
+                      "type" : "phrase",
+                      "operator" : "and",
+                      boost: 20
+                    }}
+                  },
+                  {"match_phrase": {"keywords": request.query.q} },
+                  {"match_phrase": {"description": request.query.q} },
+                  {"match_phrase": {"readme": request.query.q} }
+                ],
+                "minimum_should_match": 1,
+                "boost": 50
+              }
+            },
+          ]
+        }
       }
     }
   };

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "cheerio": "^0.17.0",
     "chunk": "0.0.2",
     "crumb": "^4.0.3",
-    "elasticsearch": "^2.4.3",
+    "elasticsearch": "^5.0.0",
     "github-url-to-object": "^1.5.0",
     "gravatar": "^1.2.0",
     "handlebars": "^2.0.0",


### PR DESCRIPTION
fixes #1029 and #1066 

when we updated search we forgot to push the exact-name matches to the top. this is now fixed :-)
