### PR TITLE
Link to policies page so we can add N additional policies

### DIFF
--- a/templates/layouts/default.hbs
+++ b/templates/layouts/default.hbs
@@ -136,7 +136,7 @@
             <li><a href="/policies/npm-license">npm License</a></li>
             <li><a href="/policies/privacy">Privacy Policy</a></li>
             <li><a href="/policies/receiving-reports">Reporting Abuse</a></li>
-            <li><a href="/policies/trademark">Trademark Policy</a></li>
+            <li><a href="/policies/">Other policies</a></li>
           </ul>
         </li>
       </ul>


### PR DESCRIPTION
1. We added the recruitment policy
2. Adding an extra link messes up the symmetry of the footer
3. We'll probably want to add extra policies
4. It's okay if the trademark policy is 1 click further away

Conclusion: this PR.