### PR TITLE
Fixed issue #43: www sessions are not correctly expired in redis on logout

### DIFF
--- a/adapters/bonbon.js
+++ b/adapters/bonbon.js
@@ -39,6 +39,8 @@ exports.register = function(server, options, next) {
     if (request.auth && request.auth.credentials && !request.path.match(/static\//)) {
       UserModel.new(request).get(request.auth.credentials.name, function(err, user) {
         if (err) { request.logger.warn(err); }
+        user = user || {};
+        user.sid = request.auth.credentials.sid;
         request.loggedInUser = user;
         request.customer = user && new CustomerModel(user.name);
         completePreHandler();

--- a/adapters/bonbon.js
+++ b/adapters/bonbon.js
@@ -39,8 +39,7 @@ exports.register = function(server, options, next) {
     if (request.auth && request.auth.credentials && !request.path.match(/static\//)) {
       UserModel.new(request).get(request.auth.credentials.name, function(err, user) {
         if (err) { request.logger.warn(err); }
-        user = user || {};
-        user.sid = request.auth.credentials.sid;
+        if (user) { user.sid = request.auth.credentials.sid; }
         request.loggedInUser = user;
         request.customer = user && new CustomerModel(user.name);
         completePreHandler();


### PR DESCRIPTION
Hang the session id field onto the `loggedInUser` object so the value is available later on when attempting to act on the session in redis.

No tests yet, because the login/logout code has no existing tests to build on, and shaving that yak is a task for another day.