### PR TITLE
Improve Stylus' build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The [assets](assets) directory contains all the frontend stuff: JavaScript, styl
 
 We're using Stylus, a CSS preprocessor with clean syntax and all the bells and whistles one would expect from a CSS preprocessor like variables, mixins, color manipulation functions, autoprefixing, etc. It's less of a hassle than Sass because it doesn't have C or Ruby dependencies.
 
-[assets/styles/index.styl](assets/styles/index.styl) is the master stylesheet, which is converted by the  [gulp process](gulpfile.js) to [static/styles/index.css](static/styles/index.css).
+[assets/styles/index.styl](assets/styles/index.styl) is the master stylesheet, which is converted by the  [gulp process](gulpfile.js) to static/styles/index.css.
 
 For more information, see the [style guide](assets/styles/README.md).
 


### PR DESCRIPTION
There isn't any "static" folder in this repo (cause it's being ignored in .gitignore file), so a link to this folder is actually a broken link.