### PR TITLE
Re-add dependents count to package sidebar

### DIFF
--- a/templates/package/show.hbs
+++ b/templates/package/show.hbs
@@ -186,7 +186,7 @@
   </p>
 
   {{#if dependents.results}}
-    <h3><a href="/browse/depended/{{name}}">Dependents</a></h3>
+    <h3><a href="/browse/depended/{{name}}">Dependents ({{dependentCount}})</a></h3>
     <p class="list-of-links dependents">
       {{#each dependents.results}}
         {{#if @last}}


### PR DESCRIPTION
It seems as the fix from #812 has been lost in some refactoring of the templates. This fix re-adds the dependents count to the sidebar.

Couldn't verify the fix as I'm unable to run the dev server locally (#761).