### PR TITLE
adds alias to point /orgs to HubSpot form page

### DIFF
--- a/routes/public.js
+++ b/routes/public.js
@@ -56,6 +56,12 @@ var publicRoutes = [
       return reply.redirect("/private-modules").code(301);
     }
   },{
+    path: "/orgs",
+    method: "GET",
+    handler: function(request, reply) {
+      return reply.redirect("http://info.npmjs.com/test-orgs").code(301);
+    }
+  },{
     path: "/contact",
     method: "GET",
     handler: require('../facets/company/show-contact')


### PR DESCRIPTION
similar to PR of 2015-08-04, but new URL of destination reflecting pointing a CNAME (info.npmjs.com) to HubSpot pages for improved user peace-of-mind