### PR TITLE
Adds a negative margin to the constructor.io ad (round 2)

### DIFF
--- a/assets/styles/_header.styl
+++ b/assets/styles/_header.styl
@@ -285,6 +285,8 @@ nav
 
 #powered-by-constructor-io
   background-color greigh6
+  margin-left -8px
+  border-color greigh5
 
 #user-info
   position absolute


### PR DESCRIPTION
We are changing how the constructor-autocomplete widget works, so this
will be necessary to get the ad to line up properly after.

Without the PR, with our change to the widget:
![without_pr](https://cloud.githubusercontent.com/assets/1364952/9282302/42cc1974-4280-11e5-9501-90254c37d3b8.png)

With the PR, with our change to the widget:
![with_pr](https://cloud.githubusercontent.com/assets/1364952/9282309/57882a56-4280-11e5-90f6-ee13f70373d7.png)

We made an abortive PR two hours ago, but this one is the actual PR