### PR TITLE
adds vendor.min.js to versioned, cache-busting workflow

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -131,7 +131,7 @@ gulp.task('lint', function() {
 });
 
 gulp.task('rev', ['browserify', 'styles'], function() {
-  return gulp.src(['static/js/index.js', 'static/js/index.min.js', 'static/css/index.css'])
+  return gulp.src(['static/js/index.js', 'static/js/index.min.js', 'static/css/index.css', 'static/js/vendor.min.js'])
     .pipe(revAll.revision())
     .pipe(gulp.dest('static'))
     .pipe(revAll.manifestFile())

--- a/templates/layouts/default.hbs
+++ b/templates/layouts/default.hbs
@@ -164,7 +164,7 @@
 
   </footer>
   {{#if devEnv}}<script defer async src="/static/js/tota11y.min.js"></script>{{/if}}
-  <script defer src="/static/js/vendor.min.js"></script>
+  <script defer src="/static/{{m "js/vendor.min.js"}}"></script>
 </body>
 </html>
 


### PR DESCRIPTION
when we update vendor scripts, they get concatenated into vendor.min.js. It turns out we're caching vendor.min.js as well, so this PR lets us avoid the manually-nuke-the-cache issue.