### PR TITLE
removes urls that aren't actually urls

### DIFF
--- a/presenters/package.js
+++ b/presenters/package.js
@@ -80,6 +80,14 @@ module.exports = function(pkg) {
     delete pkg.homepage;
   }
 
+  if (pkg.repository && pkg.repository.url && !isUrl(pkg.repository.url)) {
+    delete pkg.repository;
+  }
+
+  if (pkg.bugs && pkg.bugs.url && !isUrl(pkg.bugs.url)) {
+    delete pkg.bugs;
+  }
+
   // homepage: discard if github repo URL
   if (pkg.homepage && url.parse(pkg.homepage).hostname.match(/^(www\.)?github\.com/i)) {
     delete pkg.homepage;

--- a/test/presenters/package.js
+++ b/test/presenters/package.js
@@ -335,6 +335,26 @@ describe("different types of deps", function() {
 });
 
 describe("repo url", function() {
+  it("is removed if the url is not a url at all", function(done) {
+    present({
+      "versions": ["1.3.0"],
+      "name": "hello",
+      "repository": {
+        "type": "git",
+        "url": "javascript:alert(1)"
+      },
+      "publisher": {
+        "name": "ohai",
+        "email": "ohai@email.com"
+      },
+      "version": "1.3.0",
+      "lastPublishedAt": "2013-06-11T09:36:32.285Z"
+    }).then(function(pkg) {
+      expect(pkg.repository).to.not.exist();
+      done();
+    });
+  });
+
   it("doesn't change if it's not a GH url", function(done) {
     present({
       "versions": ["1.3.0"],
@@ -395,6 +415,28 @@ describe("repo url", function() {
     });
   });
 
+});
+
+describe("bugs url", function() {
+  it("is removed if it is not a real url", function(done) {
+    present({
+      "versions": ["1.3.0"],
+      "name": "hello",
+      "bugs": {
+        "type": "git",
+        "url": "javascript:alert(1)"
+      },
+      "publisher": {
+        "name": "ohai",
+        "email": "ohai@email.com"
+      },
+      "version": "1.3.0",
+      "lastPublishedAt": "2013-06-11T09:36:32.285Z"
+    }).then(function(pkg) {
+      expect(pkg.bugs).to.not.exist();
+      done();
+    });
+  });
 });
 
 describe("readme", function() {


### PR DESCRIPTION
in general, urls that execute javascript (for example) _should_ be caught by the CSP, but in case they aren't, this PR should add another level of protection.