### PR TITLE
Fixes test/models/user.js to be runnable twice in rapid succession

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -5,6 +5,7 @@ var _ = require('lodash'),
   P = require('bluebird'),
   Redis = require('redis-url'),
   Request = require('../lib/external-request'),
+  debug = require('debuglog')('newww:cache'),
   safeparse = require('../lib/utils').safeJsonParse;
 
 var redis, DEFAULT_TTL, KEY_PREFIX, options;
@@ -77,10 +78,13 @@ Cache._fingerprint = function _fingerprint(key) {
     .update(key)
     .digest('hex');
 
+  debug("Cache._fingerprint(%j) -> %j", key, KEY_PREFIX + hash);
+
   return KEY_PREFIX + hash;
 };
 
 Cache.drop = function drop(opts, callback) {
+  debug("Cache.drop(%j)", opts);
   if (process.env.USE_CACHE !== 'true') {
     return callback();
   }
@@ -108,6 +112,7 @@ Cache._getNoCache = function _getNoCache(opts, callback) {
 };
 
 Cache.get = function get(opts, callback) {
+  debug("Cache.get(%j)", opts);
   if (process.env.USE_CACHE !== 'true') {
     return Cache._getNoCache(opts, callback);
   }
@@ -141,6 +146,8 @@ Cache.get = function get(opts, callback) {
 };
 
 Cache.setKey = function setKey(key, ttl, data, callback) {
+  debug("Cache.setKey(%j, %s, %j)", key, ttl, data);
+
   if (process.env.USE_CACHE !== 'true') {
     if (callback) {
       callback();
@@ -166,6 +173,7 @@ Cache.setKey = function setKey(key, ttl, data, callback) {
 };
 
 Cache.getKey = function getKey(key, callback) {
+  debug("Cache.getKey(%j)", key);
   if (process.env.USE_CACHE !== 'true') {
     callback();
     return;
@@ -187,6 +195,7 @@ Cache.getKey = function getKey(key, callback) {
 };
 
 Cache.dropKey = function dropKey(key, callback) {
+  debug("Cache.dropKey(%j)", key);
   if (process.env.USE_CACHE !== 'true') {
     if (callback) {
       callback();
@@ -194,13 +203,17 @@ Cache.dropKey = function dropKey(key, callback) {
     return;
   }
 
-  redis.del(this._fingerprint(key), function(err) {
+  var cacheKey = this._fingerprint(key);
+
+  redis.del(cacheKey, function(err) {
+    debug("Dropped %j", cacheKey);
     if (err) {
+      debug("Error: %s", err);
       Cache.logger.error('problem deleting ' + key + ' from redis @ ' + options.redis);
       Cache.logger.error(err);
     }
     if (callback) {
-      callback();
+      callback(err);
     }
   });
 };

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "cheerio": "^0.17.0",
     "chunk": "0.0.2",
     "crumb": "^4.0.3",
+    "debuglog": "^1.0.1",
     "elasticsearch": "^5.0.0",
     "github-url-to-object": "^1.5.0",
     "gravatar": "^1.2.0",

--- a/test/models/user.js
+++ b/test/models/user.js
@@ -129,15 +129,18 @@ describe("User", function() {
         .get('/customer/bob/stripe')
         .reply(404);
 
-      User.get(fixtures.users.bob.name, function(err, body) {
-        userMock.done();
-        licenseMock.done();
-        expect(err).to.be.null();
-        expect(body).to.exist();
-        expect(body.name).to.equal("bob");
-        expect(body.email).to.exist();
-        expect(body.isPaid).to.be.false();
-        done();
+      User.dropCache(fixtures.users.bob.name, function(err) {
+        expect(err).to.not.exist();
+        User.get(fixtures.users.bob.name, function(err, body) {
+          userMock.done();
+          licenseMock.done();
+          expect(err).to.be.null();
+          expect(body).to.exist();
+          expect(body.name).to.equal("bob");
+          expect(body.email).to.exist();
+          expect(body.isPaid).to.be.false();
+          done();
+        });
       });
     });
 
@@ -166,8 +169,7 @@ describe("User", function() {
         // .get('/customer/bob/stripe/subscription')
         // .reply(200, fixtures.customers.bob_subscriptions);
 
-      User.dropCache(fixtures.users.bob.name, function() {
-
+      User.dropCache(fixtures.users.bob.name, function(err) {
         User.get(fixtures.users.bob.name, function(err, body) {
           expect(err).to.be.null();
           expect(body.name).to.equal("bob");
@@ -200,21 +202,25 @@ describe("User", function() {
     });
 
     it("does not require a bearer token", function(done) {
-      var userMock = nock(User.host, {
-        reqheaders: {}
-      })
-        .get('/user/hermione')
-        .reply(200);
-      var licenseMock = nock('https://license-api-example.com')
-        .get('/customer/hermione/stripe')
-        .reply(404);
+      User.dropCache('hermione', function(err) {
+        expect(err).to.not.exist();
 
-      User.get('hermione', function(err, body) {
-        expect(err).to.be.null();
-        expect(body).to.exist();
-        userMock.done();
-        licenseMock.done();
-        done();
+        var userMock = nock(User.host, {
+          reqheaders: {}
+        })
+          .get('/user/hermione')
+          .reply(200);
+        var licenseMock = nock('https://license-api-example.com')
+          .get('/customer/hermione/stripe')
+          .reply(404);
+
+        User.get('hermione', function(err, body) {
+          expect(err).to.be.null();
+          expect(body).to.exist();
+          userMock.done();
+          licenseMock.done();
+          done();
+        });
       });
     });
   });


### PR DESCRIPTION
It does this by clearing the cached item before the tests that use it.

Also, adds debuglog calls that can be enabled with `NODE_DEBUG=newww:cache`
to show what's going on in the cache layer at runtime for diagnosing these
sorts of issues.