### PR TITLE
normalize package data, and use URLs with known schemes for homepage and repositories

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "node-zendesk": "^1.1.2",
     "nodemailer-ses-transport": "^1.2.0",
     "normalize-license-data": "^1.0.1",
+    "normalize-package-data": "^2.3.1",
     "npm-email-templates": "^1.4.1",
     "npm-expansions": "^2.2.0",
     "npm-explicit-installs": "^2.0.0",

--- a/test/presenters/package.js
+++ b/test/presenters/package.js
@@ -395,6 +395,23 @@ describe("repo url", function() {
     });
   });
 
+  it("cleans up shorthands", function(done) {
+    present({
+      "versions": ["1.3.0"],
+      "name": "hello",
+      "repository": "github:someone/ohai",
+      "publisher": {
+        "name": "ohai",
+        "email": "ohai@email.com"
+      },
+      "version": "1.3.0",
+      "lastPublishedAt": "2013-06-11T09:36:32.285Z"
+    }).then(function(pkg) {
+      expect(pkg.repository.url).to.equal('https://github.com/someone/ohai');
+      done();
+    });
+  });
+
   it("converts git:// URLS to https so they can be linked to", function(done) {
     present({
       "versions": ["1.3.0"],


### PR DESCRIPTION
This brings in [`normalize-package-data`](https://github.com/npm/normalize-package-data#readme) and then picks specifically acceptable things out of what it presents.