### PR TITLE
adds list of org packages on org overview tab (fixes #1155)

### DIFF
--- a/agents/org.js
+++ b/agents/org.js
@@ -47,6 +47,7 @@ Org.prototype.create = function(name, callback) {
 Org.prototype.get = function(name, callback) {
   assert(_.isString(name), "name must be a string");
 
+  var self = this;
   var orgUrl = USER_HOST + '/org/' + name;
   var userUrl = USER_HOST + '/org/' + name + '/user';
   var packageUrl = USER_HOST + '/org/' + name + '/package';
@@ -56,7 +57,10 @@ Org.prototype.get = function(name, callback) {
 
       Request({
         url: url,
-        json: true
+        json: true,
+        headers: {
+          bearer: self.bearer
+        }
       }, function(err, resp, body) {
         if (err) {
           return cb(err);

--- a/assets/styles/org.styl
+++ b/assets/styles/org.styl
@@ -17,6 +17,10 @@
       text-align center
       width 10%
 
+    &:only-child
+      text-align left
+      width 100%
+
   tbody tr:last-child
     td:last-child
       text-align left
@@ -42,6 +46,12 @@
     border 0
     background none
     cursor pointer
+
+.org-packages
+  .icon-lock
+    position relative
+    top 3px
+    color greigh3
 
 .org-user-add
   input[type=text],

--- a/templates/org/info.hbs
+++ b/templates/org/info.hbs
@@ -18,6 +18,35 @@
     <div id="org-info-tab-1" class="tab tab-1">
       <h2>Overview</h2>
 
+      <h3>{{org.packages.count}} Packages</h3>
+      {{#if org.packages.count}}
+      <table class="org-table org-packages">
+        <thead>
+          <tr>
+            <th>Packages</th>
+          </tr>
+        </thead>
+        <tbody>
+        {{#each org.packages.items}}
+          <tr>
+            <td>
+              <div>
+                {{#if private}}
+                  <i class="icon-lock"></i>
+                {{!-- {{else}}
+                  <i class="icon-public"></i> --}}
+                {{/if}}
+                <span class="name">
+                  <a class="packagename" href="/package/{{name}}">{{name}}</a>
+                </span><!--/.name-->
+              </div>
+            </td>
+          </tr>
+        {{/each}}
+        </tbody>
+      </table>
+      {{/if}}
+
       <h3>{{org.users.count}} Users</h3>
       {{#if org.users.items}}
       <table class="org-table org-users">


### PR DESCRIPTION
It now looks like this:

<img width="1144" alt="screen shot 2015-08-21 at 4 42 23 pm" src="https://cloud.githubusercontent.com/assets/954269/9421172/a3131b9a-4823-11e5-99c4-17ff598ffaf2.png">

