### PR TITLE
copy variation on npmE licensing clickthru

### DIFF
--- a/templates/enterprise/clickThroughAgreement.hbs
+++ b/templates/enterprise/clickThroughAgreement.hbs
@@ -26,7 +26,7 @@
   <section>
     <h2>Option 2: Start a conversation</h2>
 
-    <p>If you have further questions before beginning your trial, or your company has different licensing requirements, click the button below and we'll contact you by email within 1 working day.</p>
+    <p>If you have further questions before beginning your trial, we’re here to help. Click here to drop us a line; we’ll be in touch within a day.</p>
 
     <form accept-charset="UTF-8" action="/enterprise-contact-me" method="POST">
       <input type="hidden" id="contact_customer_email" name="contact_customer_email" value="{{customer_email}}">


### PR DESCRIPTION
marketing + sales experiment to observe whether npmE sales meets less resistance if copy does not pre-emptively expect users to take issue with licensing text