### PR TITLE
allows /orgs?join-beta to work as well (fixes #1250)

### DIFF
--- a/routes/public.js
+++ b/routes/public.js
@@ -56,6 +56,20 @@ var publicRoutes = [
       return reply.redirect("/private-modules").code(301);
     }
   }, {
+    // redirect plural forms to singular
+    paths: [
+      "/orgs",
+    ],
+    method: "GET",
+    handler: function(request, reply) {
+
+      if (request.query.hasOwnProperty('join-beta')) {
+        return reply.redirect("/org?join-beta").code(301);
+      }
+
+      return reply.redirect("/org").code(301);
+    }
+  }, {
     path: "/org",
     method: "GET",
     handler: function(request, reply) {
@@ -180,15 +194,6 @@ var publicRoutes = [
     method: "GET",
     handler: function(request, reply) {
       return reply.redirect(fmt("/~%s#packages", request.params.user)).code(301);
-    }
-  }, {
-    // redirect plural forms to singular
-    paths: [
-      "/orgs",
-    ],
-    method: "GET",
-    handler: function(request, reply) {
-      return reply.redirect("/org").code(301);
     }
   }, {
     path: "/browse/userstar/{user}",

--- a/test/handlers/org.js
+++ b/test/handlers/org.js
@@ -85,6 +85,30 @@ describe('getting to the org marketing page', function() {
       done();
     });
   });
+
+  it('redirects from /orgs properly', function(done) {
+    var options = {
+      url: "/orgs"
+    };
+
+    server.inject(options, function(resp) {
+      expect(resp.statusCode).to.equal(301);
+      expect(resp.headers.location).to.equal('/org');
+      done();
+    });
+  });
+
+  it('redirects from /orgs?join-beta properly', function(done) {
+    var options = {
+      url: "/orgs?join-beta"
+    };
+
+    server.inject(options, function(resp) {
+      expect(resp.statusCode).to.equal(301);
+      expect(resp.headers.location).to.equal('/org?join-beta');
+      done();
+    });
+  });
 });
 
 describe('getting an org', function() {


### PR DESCRIPTION
even though the `/orgs` redirect works, it doesn't carry the query parameters along, so we have to be explicit about it.

also: added some tests to ensure no regressions later on.