### PR TITLE
adds list of user's orgs to profile page if they are logged in

### DIFF
--- a/templates/user/profile.hbs
+++ b/templates/user/profile.hbs
@@ -3,6 +3,20 @@
 <div class="content-column">
 
   <h1>{{name}}</h1>
+  {{#if orgs}}
+    <h2 class="undecorated">
+      <a id="orgs" href="#orgs">
+        {{pluralize orgs.length "Organizations" true}}
+      </a>
+    </h2>
+    <ul class="bullet-free organizations">
+      {{#each orgs}}
+        <li>
+          <a href="/org/{{npm_org}}">@{{truncate npm_org 50}}</a>
+        </li>
+      {{/each}}
+    </ul>
+  {{/if}}
 
   {{#if packages}}
     <h2 class="undecorated">

--- a/test/adapters/bonbon.js
+++ b/test/adapters/bonbon.js
@@ -46,7 +46,9 @@ before(function(done) {
     .get('/customer/mikeal/stripe')
     .reply(200, {})
     .get('/customer/seldo/stripe').times(4)
-    .reply(200, {});
+    .reply(200, {})
+    .get('/customer/bob/stripe/subscription').times(2)
+    .reply(404);
 
   done();
 });

--- a/test/fixtures/orgs.js
+++ b/test/fixtures/orgs.js
@@ -133,3 +133,34 @@ exports.bigcoSponsorships = [
     "deleted": null
   }
 ]
+
+exports.bobsorgs = [
+  {
+    "amount": 700,
+    "cancel_at_period_end": false,
+    "current_period_end": 1441391148,
+    "current_period_start": 1438712748,
+    "id": "sub_12346",
+    "interval": "month",
+    "license_id": 17,
+    "npm_org": "bigco",
+    "npm_user": "bob",
+    "product_id": "fb340726-bbcd-4053-9d51-c73498d9b218",
+    "quantity": 2,
+    "status": "active"
+  },
+  {
+    "amount": 700,
+    "cancel_at_period_end": false,
+    "current_period_end": 1442441358,
+    "current_period_start": 1439762958,
+    "id": "sub_12345",
+    "interval": "month",
+    "license_id": 145,
+    "npm_org": "_private-modules-bob",
+    "npm_user": "bob",
+    "product_id": "52051d69-f3fe-46fc-919a-1ef1407ef247",
+    "quantity": 1,
+    "status": "active"
+  }
+];

--- a/test/handlers/user/edit-profile.js
+++ b/test/handlers/user/edit-profile.js
@@ -108,6 +108,9 @@ describe('Modifying the profile', function() {
       .get('/user/' + users.bob.name + '/stars?format=detailed')
       .reply(200, users.stars);
 
+    var licenseMock = nock('https://license-api-example.com')
+      .get('/customer/bob/stripe/subscription')
+      .reply(404);
 
     generateCrumb(server, function(crumb) {
 
@@ -136,6 +139,7 @@ describe('Modifying the profile', function() {
 
         server.inject(options, function(resp) {
           userMock.done();
+          licenseMock.done();
           expect(resp.statusCode).to.equal(200);
           var context = resp.request.response.source.context;
           expect(context.profile.name).to.equal("bob");


### PR DESCRIPTION
Note: this only works if you are logged in, are looking at your profile page, and have created organizations. If you have no orgs, are not logged in, or are looking at someone else's profile page, you will *not* see any org lists.

<img width="485" alt="screen shot 2015-09-02 at 4 21 04 pm" src="https://cloud.githubusercontent.com/assets/954269/9647755/2294ccc2-5195-11e5-8f39-baf91914401b.png">