### PR TITLE
Move <meta> charset tag to the top, above <title>

### DIFF
--- a/templates/layouts/default.hbs
+++ b/templates/layouts/default.hbs
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
 <head>
+  <meta charset="utf-8">
   <title>{{#if title}}{{title}}{{#if q}}{{q}}{{/if}}{{else}}npm{{/if}}</title>
 
   {{#if package}}
@@ -11,7 +12,6 @@
     <meta name="twitter:description" content="{{package.description}}">
   {{/if}}
 
-  <meta charset="utf-8">
   <meta http-equiv="cleartype" content="on" />
 
   <meta name="apple-mobile-web-app-capable" content="no">


### PR DESCRIPTION
This should be at the top of the document per HTML5 spec. Well, not exactly at the top, but in [first 1024 bytes](http://www.w3.org/TR/html5/document-metadata.html#charset) (Mozzilla somewhy [says that first 512 bytes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-charset)).

And you have user-controlled `<title>` of indefinite length above it now (tested ~3KiB). The same for `twitter:description` (didn't test length).