### PR TITLE
Change status code being listened for to 409

### DIFF
--- a/models/customer.js
+++ b/models/customer.js
@@ -290,7 +290,7 @@ Customer.prototype.acceptSponsorship = function(verificationKey, callback) {
         return reject(err);
       }
 
-      if (resp.statusCode === 500) {
+      if (resp.statusCode === 409) {
         err = Error('user is already sponsored');
         err.statusCode = 403;
         return reject(err);

--- a/test/handlers/org.js
+++ b/test/handlers/org.js
@@ -486,7 +486,7 @@ describe('updating an org', function() {
             "verified": null
           })
           .post("/sponsorship/f56dffef-b136-429a-97dc-57a6ef035829")
-          .reply(500, "duplicate key value violates unique constraint \"sponsorships_npm_user\"")
+          .reply(409, "duplicate key value violates unique constraint \"sponsorships_npm_user\"")
           .get("/sponsorship/1")
           .reply(200, fixtures.orgs.bigcoSponsorships);
 

--- a/test/models/customer.js
+++ b/test/models/customer.js
@@ -569,7 +569,7 @@ describe("Customer", function() {
       var Customer = new CustomerModel('bob');
       var customerMock = nock(Customer.host)
         .post('/sponsorship/' + verification_key)
-        .reply(500, "duplicate key value violates unique constraint \"sponsorships_npm_user\"");
+        .reply(409, "duplicate key value violates unique constraint \"sponsorships_npm_user\"");
 
       Customer.acceptSponsorship(verification_key, function(err, verifiedUser) {
         customerMock.done();


### PR DESCRIPTION
Accepting a sponsorship specifically returns a 409 in the case that a
user is already sponsored (and no longer returns a 500).

Fixes #1294 