### PR TITLE
homepage: move 'getting started' above the fold

### DIFF
--- a/assets/styles/layout.styl
+++ b/assets/styles/layout.styl
@@ -169,31 +169,29 @@ ul.columnar
       @extend .red-on-hover
       font-weight 400
 
-
 .package-widget-with-logo
+  padding-left:60px;
 
   .package-logo
-    display block
-    text-align center
-    height packageWidgetLogoHeight
-    line-height packageWidgetLogoHeight
+    margin-left:-60px;
+    margin-bottom:-50px;
+    width:50px;
+    height:50px;
+    position:relative;
+    display:block;
+    overflow:hidden;
+    vertical-align:middle;
+    text-align:center;
+
     img
-      display inline-block
-      max-width 80%
-      max-height 100%
-      vertical-align middle
+      max-width: 50px;
+      max-height: 50px;
 
   .package-details
-    margin-top 20px
-    h3,p
-      text-align center
-
-  a.name
-    &:before
-      content none
-
-  p
-    padding-left 0
+    a.name:before
+      display:none;
+    p
+      padding-left:0;
 
 .box
   margin 0

--- a/templates/homepage.hbs
+++ b/templates/homepage.hbs
@@ -45,24 +45,6 @@
   {{/each}}
 </ul>
 
-<h2 id="recent" class="centered ruled">
-  <a href="/browse/updated">recently updated packages</a>
-</h2>
-<ul class="columnar">
-  {{#each modified.results}}
-    <li>{{> package-widget}}</li>
-  {{/each}}
-</ul>
-
-<h2 id="depended" class="centered ruled">
-  <a href="/browse/depended">most depended-upon packages</a>
-</h2>
-<ul class="columnar packages">
-  {{#each dependents.results}}
-    <li>{{> package-widget}}</li>
-  {{/each}}
-</ul>
-
 <h2 id="getting-started" class="centered ruled">
   <a href="#getting-started">getting started</a>
 </h2>
@@ -92,6 +74,25 @@
     <h3><a href="/whoshiring">get a job</a></h3>
     <div class="hiring-container" data-template="vanilla"></div>
   </li>
+</ul>
+
+
+<h2 id="recent" class="centered ruled">
+  <a href="/browse/updated">recently updated packages</a>
+</h2>
+<ul class="columnar">
+  {{#each modified.results}}
+    <li>{{> package-widget}}</li>
+  {{/each}}
+</ul>
+
+<h2 id="depended" class="centered ruled">
+  <a href="/browse/depended">most depended-upon packages</a>
+</h2>
+<ul class="columnar packages">
+  {{#each dependents.results}}
+    <li>{{> package-widget}}</li>
+  {{/each}}
 </ul>
 
 <script type="application/ld+json">


### PR DESCRIPTION
This patch moves the "getting started" bits from the bottom to just below the "things people install a lot" bit, and reduces the logo bunch so that they take up a lot less space.

I'm a bit out of practice with doing frontend stuff, and especially there's probably some stylus stuff that should be done differently.  But it seems like this sorta works?  I guess?

Review welcome, and deployment not at all urgent.  This is just something that's been bugging me for a while :)