### PR TITLE
updates the codebase to hapi 9.x

### DIFF
--- a/adapters/plugins.js
+++ b/adapters/plugins.js
@@ -8,6 +8,8 @@ module.exports = [
     }
   },
   require('scooter'),
+  require('inert'),
+  require('vision'),
   {
     register: require('blankie'),
     options: require('../lib/csp').default

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     ]
   },
   "dependencies": {
+    "@soldair/marky-markdown": "^6.0.0",
     "accept-language-parser": "^1.0.2",
     "async": "^0.9.0",
     "blankie": "^1.1.0",
@@ -42,13 +43,14 @@
     "gravatar": "^1.2.0",
     "handlebars": "^2.0.0",
     "handlebars-helper-pluralize": "^1.0.3",
-    "hapi": "^8.4.0",
+    "hapi": "^9.0.0",
     "hapi-auth-cookie": "2.0.0",
     "hapi-common-log": "^1.1.0",
     "hapi-stateless-notifications": "^1.1.0",
     "hashchange": "^1.0.0",
     "hbsfy": "^2.2.1",
     "hoek": "^2.13.0",
+    "inert": "^3.0.1",
     "is-url": "^1.2.0",
     "joi": "^5.1.0",
     "jquery": "^2.1.4",
@@ -56,7 +58,6 @@
     "lodash": "^3.8.0",
     "mailchimp-api": "^2.0.7",
     "malarkey": "^1.2.0",
-    "@soldair/marky-markdown": "^6.0.0",
     "moment": "^2.10.2",
     "moment-tokens": "^1.0.0",
     "month": "^1.0.0",
@@ -98,7 +99,8 @@
     "token-facilitator": "^2.2.0",
     "truncate": "^1.0.4",
     "validate-npm-package-name": "^2.2.0",
-    "verror": "^1.6.0"
+    "verror": "^1.6.0",
+    "vision": "^3.0.0"
   },
   "devDependencies": {
     "bistre": "^1.0.0",

--- a/server.js
+++ b/server.js
@@ -52,18 +52,6 @@ if (process.env.NODE_ENV === 'dev') {
 
 server.connection(connection);
 
-server.views({
-  engines: {
-    hbs: require('handlebars')
-  },
-  relativeTo: __dirname,
-  path: './templates',
-  helpersPath: './templates/helpers',
-  layoutPath: './templates/layouts',
-  partialsPath: './templates/partials',
-  layout: 'default'
-});
-
 server.stamp = require("./lib/stamp")();
 server.gitHead = require("./lib/git-head")();
 
@@ -125,6 +113,18 @@ server.register(require('hapi-auth-cookie'), function(err) {
       name: 'www-' + process.env.PORT
     }, server);
     log.info('server repl socket at /tmp/rpl/www-' + process.env.PORT + '.sock');
+
+    server.views({
+      engines: {
+        hbs: require('handlebars')
+      },
+      relativeTo: __dirname,
+      path: './templates',
+      helpersPath: './templates/helpers',
+      layoutPath: './templates/layouts',
+      partialsPath: './templates/partials',
+      layout: 'default'
+    });
 
     try {
       server.route(require('./routes/index'));

--- a/services/corporate/index.js
+++ b/services/corporate/index.js
@@ -6,14 +6,16 @@ exports.register = function(server, options, next) {
   server.method('corp.getPage', require('./methods/getPage').static, {
     cache: {
       expiresIn: 5 * MINUTE,
-      segment: '##staticpage'
+      segment: '##staticpage',
+      generateTimeout: false,
     }
   });
 
   server.method('corp.getPolicy', require('./methods/getPage').policy, {
     cache: {
       expiresIn: 5 * MINUTE,
-      segment: '##staticpolicy'
+      segment: '##staticpolicy',
+      generateTimeout: false,
     }
   });
 

--- a/services/downloads/index.js
+++ b/services/downloads/index.js
@@ -10,7 +10,8 @@ exports.register = function Downloads(server, options, next) {
     cache: {
       staleTimeout: 1 * SECOND, // don't wait more than a second for fresh data
       staleIn: 60 * 60 * SECOND, // refresh after an hour
-      segment: '##packagedownloads'
+      segment: '##packagedownloads',
+      generateTimeout: false,
     }
   });
 
@@ -18,7 +19,8 @@ exports.register = function Downloads(server, options, next) {
     cache: {
       staleTimeout: 1 * SECOND, // don't wait more than a second for fresh data
       staleIn: 60 * 60 * SECOND, // refresh after an hour
-      segment: '##packagedownloadsall'
+      segment: '##packagedownloadsall',
+      generateTimeout: false,
     }
   });
 
@@ -26,7 +28,8 @@ exports.register = function Downloads(server, options, next) {
     cache: {
       staleTimeout: 1 * SECOND, // don't wait more than a second for fresh data
       staleIn: 60 * 60 * SECOND, // refresh after an hour
-      segment: '##alldownloads'
+      segment: '##alldownloads',
+      generateTimeout: false,
     }
   });
 

--- a/test/mocks/server.js
+++ b/test/mocks/server.js
@@ -7,18 +7,6 @@ module.exports = function(done) {
   var server = new Hapi.Server();
   server.connection();
 
-  server.views({
-    engines: {
-      hbs: require('handlebars')
-    },
-    relativeTo: path.resolve(__dirname, "..", ".."),
-    path: './templates',
-    helpersPath: './templates/helpers',
-    layoutPath: './templates/layouts',
-    partialsPath: './templates/partials',
-    layout: 'default'
-  });
-
   server.stamp = require("../../lib/stamp")()
   server.gitHead = require("../../lib/git-head")()
   server.methods = require('./server-methods')(server);
@@ -38,18 +26,37 @@ module.exports = function(done) {
       redirectTo: '/login'
     });
 
-    server.register([{
-      register: require('crumb'),
-      options: {
-        cookieOptions: {
-          isSecure: true
+    server.register([
+      {
+        register: require('crumb'),
+        options: {
+          cookieOptions: {
+            isSecure: true
+          }
         }
-      }
-    },
+      },
+      require('inert'),
+      require('vision'),
       require('../../adapters/bonbon'),
       hackishMockRedis,
       require('hapi-stateless-notifications')
     ], function(err) {
+      if (err) {
+        throw err;
+      }
+
+      server.views({
+        engines: {
+          hbs: require('handlebars')
+        },
+        relativeTo: path.resolve(__dirname, "..", ".."),
+        path: './templates',
+        helpersPath: './templates/helpers',
+        layoutPath: './templates/layouts',
+        partialsPath: './templates/partials',
+        layout: 'default'
+      });
+
       try {
         server.route(require('../../routes/index'));
       } catch (e) {


### PR DESCRIPTION
a few API changes, as per the [9.0.0 Release Notes](https://github.com/hapijs/hapi/issues/2682). This PR will set us up for [hapi 10.x](https://github.com/hapijs/hapi/issues/2764), which has zero API changes, but will allow us to transition to Node 4.

if I've learned anything from this PR, it's that I look forward to the day when we no longer need `mocks/server.js`, which is a huge pain and leaves `server.js` completely untested.