### PR TITLE
Remove check for `version` property in Package presenter

### DIFF
--- a/presenters/package.js
+++ b/presenters/package.js
@@ -22,10 +22,6 @@ module.exports = function(pkg) {
   pkg.scoped = pkg.name.charAt(0) === "@";
   pkg.encodedName = pkg.name.replace("/", "%2F");
 
-  if (pkg.versions && pkg.versions.indexOf(pkg.version) === -1) {
-    return Error('invalid pkg: ' + pkg.name);
-  }
-
   pkg.license = normalizeLicenseData(pkg.license);
   if (!pkg.license) {
     delete pkg.license;


### PR DESCRIPTION
We seem to default to the latest release in the UI.

An example URL that is affected by this is `/package/formula` which
claims an error with this check and displays fine with a correct version
as the latest release without it.

Fixes #1342.