### PR TITLE
we don't use the npm2es depdendency in the www codebase

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "npm-package-arg": "^3.1.1",
     "npm-tips": "^1.1.0",
     "npm-user-validate": "^0.1.1",
-    "npm2es": "git://github.com/npm/npm2es",
     "numbat-emitter": "~1.1.3",
     "numbat-process": "^2.0.6",
     "number-grouper": "0.0.1",


### PR DESCRIPTION
as far as I can tell, we don't use the npm2es dependency in newww (this service is deployed separately, and has its own operational concerns). The git dependency causes issues for the Alpine server I'm building newww on (CC: @aredridel).