### PR TITLE
Improve error reporting

### DIFF
--- a/lib/external-request.js
+++ b/lib/external-request.js
@@ -3,6 +3,7 @@ var clf = require('../lib/utils').toCommonLogFormat;
 var emitter = require('../adapters/metrics')();
 var logger = bole('EXTERNAL');
 var Request = require('request');
+var VError = require('verror');
 
 var externalRequest = function externalRequest(opts, cb) {
 
@@ -34,8 +35,20 @@ var externalRequest = function externalRequest(opts, cb) {
       logger.error(err);
     }
 
-    return cb(err, resp, body);
+    return cb(decorateError(err), resp, body);
   });
+
+  function decorateError(err) {
+    if (!err) return err;
+    var e = new VError(err, "Can't access '%s'", opts.url);
+
+    // Copy any added error properties
+    Object.keys(err).forEach(function(k) {
+      e[k] = err[k];
+    });
+
+    return e;
+  }
 };
 
 externalRequest.get = function(opts, cb) {


### PR DESCRIPTION
Extends the error with context (the URL requested) and keeps intact any
custom properties on the original error.