### PR TITLE
fills in missing form actions (fixes #1358)

### DIFF
--- a/templates/enterprise/find-license.hbs
+++ b/templates/enterprise/find-license.hbs
@@ -10,7 +10,7 @@
     <p>Thanks for choosing to license npm On-Site. To get started, enter the email address you
       wish to use for billing.</p>
 
-    <form method="post">
+    <form action="/enterprise/license" method="post">
       Billing email: <input type="text" name="email" placeholder="billing@mycompany.com">
       <input type="submit" class="full-width" value="Verify billing email">
       {{> form_security}}

--- a/templates/user/login.hbs
+++ b/templates/user/login.hbs
@@ -7,7 +7,7 @@
 
   {{> errors}}
 
-  <form action='' method='post'>
+  <form action='/login' method='post'>
     <label for="name">{{t "user.login.form.username"}}</label>
     <input type="text" id="name" name="name" required="required" tabindex=2 autocorrect="off" autocapitalize="off" autofocus/>
 

--- a/templates/user/signup-form.hbs
+++ b/templates/user/signup-form.hbs
@@ -7,7 +7,7 @@
 
   {{> errors}}
 
-  <form action="" method="post">
+  <form action="/signup" method="post">
     <label for="name">{{t "user.signup.form.username"}}</label>
     <input type="text" id="name" name="name" autocorrect="off" autocapitalize="off" value="{{userInput.name}}" />
     <p class="help-text">{{t "user.signup.form.nameHelp"}}</p>


### PR DESCRIPTION
Microsoft Edge (their latest browser) doesn't like empty `action` attributes on forms, which was why users were unable to login or signup on our website.

This PR fixes that (and other missing action attributes) :-)