### PR TITLE
Co-brand a bit with On-site users to make npmo stand out

### DIFF
--- a/adapters/bonbon.js
+++ b/adapters/bonbon.js
@@ -77,6 +77,7 @@ exports.register = function(server, options, next) {
       stamp: request.server.stamp,
       features: request.features,
       devEnv: (process.env.NODE_ENV === 'dev'),
+      env: process.env,
     };
 
     if (request.response && request.response.variety && request.response.variety.match(/view|plain/)) {

--- a/assets/scripts/vendor/constructor-io.js
+++ b/assets/scripts/vendor/constructor-io.js
@@ -1,19 +1,25 @@
 $(function() {
 
-  var searchWidth = $('#npm-search').outerWidth() - $('#site-search-submit').outerWidth();
+  var searchWidth;
 
+  var style = document.createElement('style');
+  document.head.appendChild(style);
+
+  $(window).resize(init);
+
+  init();
   $.getScript("//cnstrc.com/js/ac.js", function() {
+
     $('#site-search').constructorAutocomplete({
       key: 'CD06z4gVeqSXRiDL2ZNK',
       directResults: true,
-      maxHeight: 400,
-      width: searchWidth
+      maxHeight: 400
     });
   });
 
-  $(window).resize(function() {
+  function init() {
     searchWidth = $('#npm-search').outerWidth() - $('#site-search-submit').outerWidth();
-    $('.autocomplete-suggestions').outerWidth(searchWidth);
-  });
+    style.innerHTML = ".autocomplete-container, .autocomplete-suggestions, #powered-by-constructor-io { width: " + searchWidth + "px !important }";
+  }
 });
 

--- a/assets/styles/_footer.styl
+++ b/assets/styles/_footer.styl
@@ -23,6 +23,26 @@ footer
         &:hover
           text-decoration underline
 
+  .cobrand-footer
+    background greigh6
+    padding 0.5em
+    display table
+    width 100%
+    text-align: center
+
+    > :first-child
+      text-align left
+
+    > *
+      display table-cell
+
+    > :last-child
+      text-align right
+
+    #npm-expansions
+      font-weight bold
+
+
 #npm-loves-you
   margin-top 80px
   display inline-block

--- a/assets/styles/_header.styl
+++ b/assets/styles/_header.styl
@@ -174,9 +174,19 @@ nav
   margin-right 7%
 
   img
-    display block
+    vertical-align middle
     width 125px
     height 49px
+
+  .cobrand
+    font-weight bold
+
+  .cobrand::before
+    content "♥︎"
+    font-size 150%
+    color npmred
+    vertical-align middle
+    padding 0 0.5em
 
   @media only screen and (max-width: mobileMaxWidth)
     margin 0

--- a/assets/styles/_header.styl
+++ b/assets/styles/_header.styl
@@ -3,29 +3,6 @@ header
   border-bottom 1px solid lightgrey
   background greigh6
 
-  h1
-    clear left
-    padding 20px 0 0 0
-    line-height 1.4
-    font-weight 400
-    width 100%
-    @extend .ellipsis
-
-    em
-      color npmred
-      font-style normal
-
-    @media only screen and (max-width: mobileMaxWidth)
-      font-weight 400
-      font-size 28px
-      line-height 46px
-      letter-spacing -1px
-
-      &:before
-        float left
-        margin-right 4px
-        margin-top 6px
-
 nav
   height 38px
   color background-color

--- a/assets/styles/_header.styl
+++ b/assets/styles/_header.styl
@@ -1,7 +1,34 @@
 body>header
-  padding 28px 0 20px
+  padding 14px 20px 10px
   border-bottom 1px solid lightgrey
   background greigh6
+  display -webkit-flex
+  display flex
+  -webkit-align-items center
+  align-items center
+  text-align center
+
+  @media only screen and (max-width: mobileMaxWidth)
+    display block
+    text-align left
+
+  >*
+    flex-grow 0
+
+  #npm-search
+    flex-grow 1
+
+  >nav
+    order 3
+    display block
+    height 47px
+    font-weight bold
+    padding 10px 14px 14px
+    @media only screen and (max-width: mobileMaxWidth)
+      display inline-block
+
+    a+a
+      margin-left 1em
 
 body>nav
   height 38px
@@ -170,9 +197,7 @@ body>nav
       color greigh2
 
 #npm-logo
-  float left
-  margin-right 7%
-
+  padding 10px 14px 14px
   img
     vertical-align middle
     width 125px
@@ -189,26 +214,31 @@ body>nav
     padding 0 0.5em
 
   @media only screen and (max-width: mobileMaxWidth)
+
+    display inline-block
     margin 0
     img
       width 80px
 
 #npm-search
-  float left
   position relative
-  width 53%
   height 47px
   padding 0
-  margin 0
+  margin 10px 1em 14px
   border 1px solid greigh5
   border-radius 2px
   background background-color
+  text-align left
   &:hover
     border 1px solid greigh4
 
-  @media only screen and (max-width: mobileMaxWidth)
+  @media only screen and (max-width: smallScreenMaxWidth)
     margin-top 20px
     width 100%
+    float none
+    clear both
+    box-sizing border-box
+
 
 #site-search-container
   margin: 7px 80px 0 7px
@@ -275,13 +305,7 @@ body>nav
   border-color greigh5
 
 #user-info
-  position absolute
-  top 0
-  right 20px
-  float none
-  clear both
-  width 50%
-
+  order 3
   img
     float right
     display block
@@ -304,9 +328,9 @@ body>nav
         vertical-align top
 
   @media only screen and (max-width: mobileMaxWidth)
-    width auto
-    margin-top 0
-    margin-right 0
+
+    display inline-block
+
     ul
       li
         display block

--- a/assets/styles/_header.styl
+++ b/assets/styles/_header.styl
@@ -1,9 +1,9 @@
-header
+body>header
   padding 28px 0 20px
   border-bottom 1px solid lightgrey
   background greigh6
 
-nav
+body>nav
   height 38px
   color background-color
   font-size 14px

--- a/templates/layouts/default.hbs
+++ b/templates/layouts/default.hbs
@@ -64,22 +64,20 @@
     </div>
   {{/unless}}
 
-  <nav>
-    <div class="container">
-      <a href="#" id="npm-expansions" data-event-trigger="click" data-event-name="npm-expansions">node package manager</a>
-      {{#unless features.npmo}}
+  {{#unless features.npmo}}
+    <nav>
+      <div class="container">
+        <a href="#" id="npm-expansions" data-event-trigger="click" data-event-name="npm-expansions">node package manager</a>
         <a href="/private-modules" data-event-trigger="click" data-event-name="private-modules-nav-link">npm private modules</a>
         <a href="/enterprise">npm for the Enterprise</a>
-      {{/unless}}
-      <a href="https://docs.npmjs.com">documentation</a>
-      {{#unless features.npmo}}
+        <a href="https://docs.npmjs.com">documentation</a>
         <a href="http://blog.npmjs.org/">blog</a>
         <a href="/npm-weekly">npm weekly</a>
         <a href="/jobs">jobs</a>
         <a href="/support">support</a>
-      {{/unless}}
-    </div>
-  </nav>
+      </div>
+    </nav>
+  {{/unless}}
 
   <header>
     <div class="container">

--- a/templates/layouts/default.hbs
+++ b/templates/layouts/default.hbs
@@ -80,58 +80,57 @@
   {{/unless}}
 
   <header>
-    <div class="container">
-      <div id='npm-logo'>
-        <a href="/"><img src="/static/images/npm-logo.svg" alt="npm logo" /></a>
+    <div id='npm-logo'>
+      <a href="/"><img src="/static/images/npm-logo.svg" alt="npm logo" /></a>
 
-        {{#if env.NPMO_COBRAND}}
-          <span class="cobrand">{{env.NPMO_COBRAND}}</span>
+      {{#if env.NPMO_COBRAND}}
+        <span class="cobrand">{{env.NPMO_COBRAND}}</span>
+      {{/if}}
+    </div>
+
+    {{#if features.npmo}}
+
+      <nav>
+        <a href="https://docs.npmjs.com">docs</a>
+        <a href="/support">support</a>
+      </nav>
+
+    {{else}}
+
+      <div id="user-info" class={{#if user}}"logged-in"{{else}}"anonymous"{{/if}}>
+        {{#if user}}
+          <a data-user-name="{{user.name}}"
+              data-is-paid="{{#if user.isPaid}}true{{/if}}"
+              href="/~{{user.name}}">
+              <img alt="" src="{{user.avatar.small}}" />
+          </a>
+          <ul>
+              <li class="username"><a href="/~{{user.name}}">{{user.name}}</a></li>
+              <li class="logout"><form method="POST" action="/logout">{{> form_security }}<button type="submit" class="subdued">log out</button></form></li>
+          </ul>
+        {{else}}
+          <a href="/login"><img alt="" src="/static/images/wombat-avatar-small.png" /></a>
+          <ul class="single">
+              <li><a href="/signup">sign up</a> or <a href="/login">log in</a></li>
+          </ul>
+
         {{/if}}
       </div>
 
-      {{#unless features.npmo}}
-        <div id="user-info" class={{#if user}}"logged-in"{{else}}"anonymous"{{/if}}>
-          {{#if user}}
-            <a data-user-name="{{user.name}}"
-                data-is-paid="{{#if user.isPaid}}true{{/if}}"
-                href="/~{{user.name}}">
-                <img alt="" src="{{user.avatar.small}}" />
-            </a>
-            <ul>
-                <li class="username"><a href="/~{{user.name}}">{{user.name}}</a></li>
-                <li class="logout"><form method="POST" action="/logout">{{> form_security }}<button type="submit" class="subdued">log out</button></form></li>
-            </ul>
-          {{else}}
-            <a href="/login"><img alt="" src="/static/images/wombat-avatar-small.png" /></a>
-            <ul class="single">
-                <li><a href="/signup">sign up</a> or <a href="/login">log in</a></li>
-            </ul>
+    {{/if}}
 
-          {{/if}}
-        </div>
-      {{/unless}}
+    <form id="npm-search" action="/search" method="get" itemprop="potentialAction" itemscope itemtype="http://schema.org/SearchAction">
+      <meta itemprop="target" content="{{env.CANONICAL_HOST}}/search?q={q}">
+      <div id="site-search-container">
+        {{#if features.npmo}}
+          <input name="q" value="{{q}}" type="search" id="site-search" placeholder="find on-site packages" tabindex="1" autocorrect="off" autocapitalize="off" itemprop="query-input" />
+        {{else}}
+          <input name="q" value="{{q}}" type="search" id="site-search" placeholder="find packages" tabindex="1" autocorrect="off" autocapitalize="off" itemprop="query-input" />
+        {{/if}}
+      </div>
+      <input type="submit" id="site-search-submit" />
+    </form>
 
-      <form id="npm-search" action="/search" method="get" itemprop="potentialAction" itemscope itemtype="http://schema.org/SearchAction">
-        <meta itemprop="target" content="{{env.CANONICAL_HOST}}/search?q={q}">
-        <div id="site-search-container">
-          {{#if features.npmo}}
-            <input name="q" value="{{q}}" type="search" id="site-search" placeholder="find on-site packages" tabindex="1" autocorrect="off" autocapitalize="off" itemprop="query-input" />
-          {{else}}
-            <input name="q" value="{{q}}" type="search" id="site-search" placeholder="find packages" tabindex="1" autocorrect="off" autocapitalize="off" itemprop="query-input" />
-          {{/if}}
-        </div>
-        <input type="submit" id="site-search-submit" />
-      </form>
-
-        <nav>
-          <ul class="links">
-            <li><a href="https://docs.npmjs.com">documentation</a></li>
-            <li><a href="/support">Support / Contact Us</a></li>
-          </ul>
-        </nav>
-
-
-    </div>
   </header>
 
   <div class="container content">

--- a/templates/layouts/default.hbs
+++ b/templates/layouts/default.hbs
@@ -123,6 +123,14 @@
         <input type="submit" id="site-search-submit" />
       </form>
 
+        <nav>
+          <ul class="links">
+            <li><a href="https://docs.npmjs.com">documentation</a></li>
+            <li><a href="/support">Support / Contact Us</a></li>
+          </ul>
+        </nav>
+
+
     </div>
   </header>
 
@@ -135,8 +143,9 @@
 
   <footer>
 
-    {{#unless features.npmo}}
-      <div class="container">
+    <div class="container">
+
+      {{#unless features.npmo}}
 
         <ul class="columnar">
           <li>
@@ -176,8 +185,19 @@
           </li>
         </ul>
 
-      </div>
-    {{/unless}}
+      {{else}}
+
+        <div class="cobrand-footer">
+          <a href="#" id="npm-expansions" data-event-trigger="click" data-event-name="npm-expansions">node package manager</a>
+
+          <span>
+            &copy; 2015 npm, Inc. All Rights Reserved.
+          </span>
+        </div>
+
+      {{/unless}}
+
+    </div>
 
     <div class="container centered">
       <a href="/" id="npm-loves-you">

--- a/templates/layouts/default.hbs
+++ b/templates/layouts/default.hbs
@@ -116,7 +116,11 @@
       <form id="npm-search" action="/search" method="get" itemprop="potentialAction" itemscope itemtype="http://schema.org/SearchAction">
         <meta itemprop="target" content="https://www.npmjs.com/search?q={q}">
         <div id="site-search-container">
+          {{#if features.npmo}}
+            <input name="q" value="{{q}}" type="search" id="site-search" placeholder="find on-site packages" tabindex="1" autocorrect="off" autocapitalize="off" itemprop="query-input" />
+          {{else}}
             <input name="q" value="{{q}}" type="search" id="site-search" placeholder="find packages" tabindex="1" autocorrect="off" autocapitalize="off" itemprop="query-input" />
+          {{/if}}
         </div>
         <input type="submit" id="site-search-submit" />
       </form>

--- a/templates/layouts/default.hbs
+++ b/templates/layouts/default.hbs
@@ -114,7 +114,7 @@
       {{/unless}}
 
       <form id="npm-search" action="/search" method="get" itemprop="potentialAction" itemscope itemtype="http://schema.org/SearchAction">
-        <meta itemprop="target" content="https://www.npmjs.com/search?q={q}">
+        <meta itemprop="target" content="{{env.CANONICAL_HOST}}/search?q={q}">
         <div id="site-search-container">
           {{#if features.npmo}}
             <input name="q" value="{{q}}" type="search" id="site-search" placeholder="find on-site packages" tabindex="1" autocorrect="off" autocapitalize="off" itemprop="query-input" />

--- a/templates/layouts/default.hbs
+++ b/templates/layouts/default.hbs
@@ -91,23 +91,23 @@
 
       {{#unless features.npmo}}
         <div id="user-info" class={{#if user}}"logged-in"{{else}}"anonymous"{{/if}}>
-            {{#if user}}
+          {{#if user}}
             <a data-user-name="{{user.name}}"
                 data-is-paid="{{#if user.isPaid}}true{{/if}}"
                 href="/~{{user.name}}">
-                <img src="{{user.avatar.small}}" />
+                <img alt="" src="{{user.avatar.small}}" />
             </a>
             <ul>
                 <li class="username"><a href="/~{{user.name}}">{{user.name}}</a></li>
                 <li class="logout"><form method="POST" action="/logout">{{> form_security }}<button type="submit" class="subdued">log out</button></form></li>
             </ul>
-            {{else}}
-            <a href="/login"><img src="/static/images/wombat-avatar-small.png" /></a>
+          {{else}}
+            <a href="/login"><img alt="" src="/static/images/wombat-avatar-small.png" /></a>
             <ul class="single">
                 <li><a href="/signup">sign up</a> or <a href="/login">log in</a></li>
             </ul>
 
-            {{/if}}
+          {{/if}}
         </div>
       {{/unless}}
 

--- a/templates/layouts/default.hbs
+++ b/templates/layouts/default.hbs
@@ -83,7 +83,13 @@
 
   <header>
     <div class="container">
-      <a href="/" id="npm-logo"><img src="/static/images/npm-logo.svg" alt="npm logo" /></a>
+      <div id='npm-logo'>
+        <a href="/"><img src="/static/images/npm-logo.svg" alt="npm logo" /></a>
+
+        {{#if env.NPMO_COBRAND}}
+          <span class="cobrand">{{env.NPMO_COBRAND}}</span>
+        {{/if}}
+      </div>
 
       {{#unless features.npmo}}
         <div id="user-info" class={{#if user}}"logged-in"{{else}}"anonymous"{{/if}}>


### PR DESCRIPTION
This reworks the top bar for non-npmo web installations (hello public site!) so look at these screen shots.

Before:

<img width="1334" alt="before" src="https://cloud.githubusercontent.com/assets/2876/10379116/c6bcf890-6dda-11e5-92c6-819219298fde.png">

After, not co-branded:

<img width="1326" alt="after unbranded" src="https://cloud.githubusercontent.com/assets/2876/10379118/c6bdc766-6dda-11e5-9a52-061f06b6030d.png">

After, co-branded:

<img width="1324" alt="after co-branded" src="https://cloud.githubusercontent.com/assets/2876/10379117/c6bd4eda-6dda-11e5-949e-065ca5482398.png">


