### PR TITLE
allows feature flags to be set via user's resource

### DIFF
--- a/adapters/bonbon.js
+++ b/adapters/bonbon.js
@@ -45,6 +45,15 @@ exports.register = function(server, options, next) {
         }
         if (user) {
           user.sid = request.auth.credentials.sid;
+          Object.keys(user.resource || [])
+            .filter(function(key) {
+              return key.match(/^feature_/i)
+            })
+            .forEach(function(key) {
+              if (user.resource[key] === 't') {
+                request.features[key.replace(/^feature_/i, "").toLowerCase()] = true;
+              }
+            });
         }
         request.loggedInUser = user;
         request.customer = user && new CustomerModel(user.name);

--- a/adapters/bonbon.js
+++ b/adapters/bonbon.js
@@ -45,7 +45,7 @@ exports.register = function(server, options, next) {
         }
         if (user) {
           user.sid = request.auth.credentials.sid;
-          Object.keys(user.resource || [])
+          Object.keys(user.resource || {})
             .filter(function(key) {
               return key.match(/^feature_/i)
             })

--- a/adapters/bonbon.js
+++ b/adapters/bonbon.js
@@ -14,17 +14,6 @@ exports.register = function(server, options, next) {
 
   server.ext('onPreHandler', function(request, reply) {
 
-    // Add feature flags to request
-    request.features = {};
-    Object.keys(process.env)
-      .filter(function(key) {
-        return key.match(/^feature_/i)
-      })
-      .forEach(function(key) {
-        key = key.replace(/^feature_/i, "").toLowerCase();
-        request.features[key] = featureFlag(key, request);
-      });
-
     // Generate `request.packageName` for global and scoped package requests
     if (request.params.package || request.params.scope) {
       request.packageName = request.params.package ||
@@ -45,15 +34,6 @@ exports.register = function(server, options, next) {
         }
         if (user) {
           user.sid = request.auth.credentials.sid;
-          Object.keys(user.resource || {})
-            .filter(function(key) {
-              return key.match(/^feature_/i)
-            })
-            .forEach(function(key) {
-              if (user.resource[key] === 't') {
-                request.features[key.replace(/^feature_/i, "").toLowerCase()] = true;
-              }
-            });
         }
         request.loggedInUser = user;
         request.customer = user && new CustomerModel(user.name);
@@ -64,6 +44,9 @@ exports.register = function(server, options, next) {
     }
 
     function completePreHandler() {
+
+      // Add feature flags to request
+      request.features = featureFlag.getFeatures(request);
 
       if (request.method !== "post") {
         return reply.continue();

--- a/lib/feature-flags.js
+++ b/lib/feature-flags.js
@@ -19,7 +19,7 @@ var groups = {
 var featureCache = {};
 
 function calculate(feature) {
-  var setting = process.env['FEATURE_' + feature.replace(/^feature_/i, "").toUpperCase()]
+  var setting = process.env['FEATURE_' + feature.replace(/^feature_/i, "").toUpperCase()];
   if (!setting || !setting.length || setting.toLowerCase() === 'false') {
     featureCache[feature] = false;
   } else if (setting.toLowerCase() === 'true') {
@@ -45,10 +45,18 @@ function calculate(feature) {
   }
 }
 
+var filterFeatures = function filterFeatures(features) {
+  return _.pick(features, function(val, key) {
+    return key.match(/^feature_/i);
+  });
+};
+
 var isFeatureEnabled = module.exports = function isFeatureEnabled(feature, request) {
+
   if (!featureCache.hasOwnProperty(feature)) {
     calculate(feature);
   }
+
   var value = featureCache[feature];
   if (_.isBoolean(value)) {
     return value;
@@ -57,12 +65,33 @@ var isFeatureEnabled = module.exports = function isFeatureEnabled(feature, reque
   if (Array.isArray(value) && request && request.auth && request.auth.credentials) {
     var name = request.auth.credentials.name;
     return value.some(function(potentialUser) {
-      return potentialUser === request.auth.credentials.name || typeof potentialUser.test === 'function' && potentialUser.test(name);
+      return potentialUser === request.auth.credentials.name ||
+        typeof potentialUser.test === 'function' && potentialUser.test(name);
     });
   }
 
   return false;
 };
 
+var getFeatures = function getFeatures(request) {
+  var features = {};
+
+  var envFeatures = filterFeatures(process.env);
+  var userFeatures = filterFeatures(request.loggedInUser && request.loggedInUser.resource);
+
+  _.forEach(envFeatures, function(val, key) {
+    key = key.replace(/^feature_/i, "").toLowerCase();
+    features[key] = isFeatureEnabled(key, request);
+  });
+
+  _.forEach(userFeatures, function(val, key) {
+    key = key.replace(/^feature_/i, "").toLowerCase();
+    features[key] = val === 't';
+  });
+
+  return features;
+};
+
 isFeatureEnabled.calculate = calculate;
 isFeatureEnabled.cache = featureCache;
+isFeatureEnabled.getFeatures = getFeatures;

--- a/lib/feature-flags.js
+++ b/lib/feature-flags.js
@@ -45,12 +45,6 @@ function calculate(feature) {
   }
 }
 
-var filterFeatures = function filterFeatures(features) {
-  return _.pick(features, function(val, key) {
-    return key.match(/^feature_/i);
-  });
-};
-
 var isFeatureEnabled = module.exports = function isFeatureEnabled(feature, request) {
 
   if (!featureCache.hasOwnProperty(feature)) {
@@ -71,6 +65,12 @@ var isFeatureEnabled = module.exports = function isFeatureEnabled(feature, reque
   }
 
   return false;
+};
+
+var filterFeatures = function filterFeatures(features) {
+  return _.pick(features, function(val, key) {
+    return key.match(/^feature_/i);
+  });
 };
 
 var getFeatures = function getFeatures(request) {
@@ -95,3 +95,4 @@ var getFeatures = function getFeatures(request) {
 isFeatureEnabled.calculate = calculate;
 isFeatureEnabled.cache = featureCache;
 isFeatureEnabled.getFeatures = getFeatures;
+isFeatureEnabled.filterFeatures = filterFeatures;

--- a/test/adapters/bonbon.js
+++ b/test/adapters/bonbon.js
@@ -160,6 +160,37 @@ describe("bonbon", function() {
       });
     });
 
+    it('gives users with `feature_org_billing` in their resource object access to orgs', function(done) {
+
+      var userMock = nock("https://user-api-example.com")
+        .get('/user/bob')
+        .reply(200, fixtures.users.bigcoadmin);
+
+      var licenseMock = nock('https://license-api-example.com')
+        .get('/customer/bob/stripe')
+        .reply(404);
+
+
+      var options = {
+        url: '/~boborg',
+        credentials: fixtures.users.bigcoadmin
+      };
+
+      server.inject(options, function(resp) {
+        userMock.done();
+        licenseMock.done();
+        var context = resp.request.response.source.context;
+        expect(context.features).to.deep.equal({
+          stealth: false,
+          alpha: false,
+          beta: true,
+          common: true,
+          org_billing: true
+        });
+        done();
+      });
+    });
+
   });
 
   it('allows logged-in npm employees to request the view context with a `json` query param', function(done) {

--- a/test/feature-flags.js
+++ b/test/feature-flags.js
@@ -5,7 +5,7 @@ var expect = require('code').expect,
   beforeEach = lab.beforeEach,
   afterEach = lab.afterEach,
   it = lab.test,
-  feature = require('../lib/feature-flags')
+  feature = require('../lib/feature-flags');
 
 var requests = {
   sindresorhus: {
@@ -65,146 +65,194 @@ var requests = {
     }
   },
   anonymous: {}
-}
+};
 
 describe('feature flags', function() {
   // Delete all process.env.FEATURE_* vars before each test
   afterEach(function(done) {
     Object.keys(process.env).forEach(function(key) {
       if (key.match(/^FEATURE_/i)) {
-        delete process.env[key]
+        delete process.env[key];
       }
-    })
-    done()
-  })
+    });
+    done();
+  });
 
   describe('enabled', function() {
     it("returns true if variable is 'true'", function(done) {
-      process.env.FEATURE_SNACK_TIME = 'true'
-      expect(feature('SNACK_TIME')).to.be.true()
-      done()
-    })
+      process.env.FEATURE_SNACK_TIME = 'true';
+      expect(feature('SNACK_TIME')).to.be.true();
+      done();
+    });
 
     it("returns true if variable is 'TRUE'", function(done) {
-      process.env.FEATURE_SNACK_TIME = 'TRUE'
-      expect(feature('SNACK_TIME')).to.be.true()
-      done()
-    })
+      process.env.FEATURE_SNACK_TIME = 'TRUE';
+      expect(feature('SNACK_TIME')).to.be.true();
+      done();
+    });
 
     it('allows lowercase values', function(done) {
-      process.env.FEATURE_SNAKE_TIME = 'true'
-      expect(feature('snake_time')).to.be.true()
-      done()
-    })
+      process.env.FEATURE_SNAKE_TIME = 'true';
+      expect(feature('snake_time')).to.be.true();
+      done();
+    });
 
     it('allows feature name to include `feature_` prefix', function(done) {
-      process.env.FEATURE_SNAKE_TIME = 'true'
-      expect(feature('feature_snake_time')).to.be.true()
-      done()
-    })
-  })
+      process.env.FEATURE_SNAKE_TIME = 'true';
+      expect(feature('feature_snake_time')).to.be.true();
+      done();
+    });
+  });
 
   describe('disabled', function() {
     it('returns false if variable does not exist', function(done) {
-      expect(feature('nonexistent')).to.be.false()
-      done()
-    })
+      expect(feature('nonexistent')).to.be.false();
+      done();
+    });
 
     it('returns false if variable is an empty string', function(done) {
-      process.env.FEATURE_NONEXISTENT = ''
-      expect(feature('nonexistent')).to.be.false()
-      done()
-    })
+      process.env.FEATURE_NONEXISTENT = '';
+      expect(feature('nonexistent')).to.be.false();
+      done();
+    });
 
     it("returns false if variable is 'false'", function(done) {
-      process.env.FEATURE_NONEXISTENT = 'false'
-      expect(feature('nonexistent')).to.be.false()
-      done()
-    })
+      process.env.FEATURE_NONEXISTENT = 'false';
+      expect(feature('nonexistent')).to.be.false();
+      done();
+    });
 
     it("returns false if variable is 'FALSE'", function(done) {
-      process.env.FEATURE_NONEXISTENT = 'FALSE'
-      expect(feature('nonexistent')).to.be.false()
-      done()
-    })
-  })
+      process.env.FEATURE_NONEXISTENT = 'FALSE';
+      expect(feature('nonexistent')).to.be.false();
+      done();
+    });
+  });
 
   describe('whitelisted users', function() {
 
     beforeEach(function(done) {
-      process.env.FEATURE_RAINBOWS = 'maxogden, sindresorhus,somebody-else'
-      done()
-    })
+      process.env.FEATURE_RAINBOWS = 'maxogden, sindresorhus,somebody-else';
+      done();
+    });
 
     it('returns true for whitelisted users', function(done) {
-      expect(feature('rainbows', requests.sindresorhus)).to.be.true()
-      expect(feature('rainbows', requests.maxogden)).to.be.true()
-      done()
-    })
+      expect(feature('rainbows', requests.sindresorhus)).to.be.true();
+      expect(feature('rainbows', requests.maxogden)).to.be.true();
+      done();
+    });
 
     it('returns false for users not in whitelist', function(done) {
-      expect(feature('rainbows', requests.cat)).to.be.false()
-      done()
-    })
+      expect(feature('rainbows', requests.cat)).to.be.false();
+      done();
+    });
 
     it('returns false for anonymous users', function(done) {
-      expect(feature('rainbows', requests.anonymous)).to.be.false()
-      done()
-    })
+      expect(feature('rainbows', requests.anonymous)).to.be.false();
+      done();
+    });
 
     it('returns false if request object is absent', function(done) {
-      expect(feature('rainbows')).to.be.false()
-      done()
-    })
-  })
+      expect(feature('rainbows')).to.be.false();
+      done();
+    });
+  });
 
   describe('whitelisted groups', function() {
 
     beforeEach(function(done) {
-      process.env.FEATURE_UNICORN_PAGE = 'group:npm-humans, group:friends,cat,somebody-else, regex:match-\\d+'
-      done()
-    })
+      process.env.FEATURE_UNICORN_PAGE = 'group:npm-humans, group:friends,cat,somebody-else, regex:match-\\d+';
+      done();
+    });
 
     it('returns true for npm humans', function(done) {
-      expect(feature('unicorn_page', requests.rockbot)).to.be.true()
-      done()
-    })
+      expect(feature('unicorn_page', requests.rockbot)).to.be.true();
+      done();
+    });
 
     it('returns true for friends', function(done) {
-      expect(feature('unicorn_page', requests.smikes)).to.be.true()
-      done()
-    })
+      expect(feature('unicorn_page', requests.smikes)).to.be.true();
+      done();
+    });
 
     it('returns true for one-off users', function(done) {
-      expect(feature('unicorn_page', requests.cat)).to.be.true()
-      done()
-    })
+      expect(feature('unicorn_page', requests.cat)).to.be.true();
+      done();
+    });
 
     it('returns true for regex matches', function(done) {
-      expect(feature('unicorn_page', requests.match)).to.be.true()
-      done()
-    })
+      expect(feature('unicorn_page', requests.match)).to.be.true();
+      done();
+    });
 
     it('returns false for regex mis-matches', function(done) {
-      expect(feature('unicorn_page', requests.nomatch)).to.be.false()
-      done()
-    })
+      expect(feature('unicorn_page', requests.nomatch)).to.be.false();
+      done();
+    });
 
     it('returns false for usernames that are potentially regex matches for list entries', function(done) {
-      expect(feature('unicorn_page', requests.rockbotnomatch)).to.be.false()
-      done()
-    })
+      expect(feature('unicorn_page', requests.rockbotnomatch)).to.be.false();
+      done();
+    });
 
     it('returns false for users not in whitelist', function(done) {
-      expect(feature('unicorn_page', requests.sindresorhus)).to.be.false()
-      done()
-    })
+      expect(feature('unicorn_page', requests.sindresorhus)).to.be.false();
+      done();
+    });
 
     it('returns false if request object is absent', function(done) {
-      expect(feature('unicorn_page')).to.be.false()
-      done()
-    })
-  })
+      expect(feature('unicorn_page')).to.be.false();
+      done();
+    });
+  });
 
+  describe('getFeatures', function() {
+    it('finds all the environmental and user-resourced feature flags', function(done) {
+      process.env.FEATURE_BOOM = 'true';
+      process.env.FEATURE_TADA = 'group:npm-humans';
+      process.env.SANDWICH = 'something-important-probably';
 
-})
+      var request = {
+        loggedInUser: {
+          resource: {
+            feature_lala: 't',
+            feature_nope: 'blah',
+            twitter: '@user'
+          }
+        }
+      };
+
+      var features = feature.getFeatures(request);
+
+      expect(features).to.deep.equal({
+        boom: true,
+        tada: false,
+        lala: true,
+        nope: false
+      });
+
+      delete process.env.FEATURE_BOOM;
+      delete process.env.FEATURE_TADA;
+      delete process.env.SANDWICH;
+      done();
+    });
+  });
+
+  describe('filterFeatures', function() {
+    it('takes an object and filters out the feature flags', function(done) {
+      var obj = {
+        feature_something: 'stuff',
+        feature_grand_master: 't',
+        nothing_special: 'ta',
+        nope_feature_thing: 'false'
+      };
+
+      var filtered = feature.filterFeatures(obj);
+      expect(filtered).to.deep.equal({
+        feature_something: 'stuff',
+        feature_grand_master: 't'
+      });
+      done();
+    });
+  });
+});

--- a/test/fixtures/users.js
+++ b/test/fixtures/users.js
@@ -203,7 +203,8 @@ exports.bigcoadmin = {
     github: 'bob',
     twitter: 'twob',
     homepage: 'http://boom.me',
-    freenode: 'bobob'
+    freenode: 'bobob',
+    "feature_org_billing": 't'
   },
   created: '2014-11-21T20:05:05.423Z',
   updated: '2015-01-24T00:08:41.269Z',


### PR DESCRIPTION
there's some repeated code in bonbon.js - L19-26 and L48-56 - but I'm not sure what the best way to DRY that up is... thoughts, @jefflembeck, @aredridel ?

In particular, do we keep some of that logic in adapters/bonbon.js or move it into lib/feature-flags.js?