### PR TITLE
fix includeSubdomains typo

### DIFF
--- a/lib/startup.js
+++ b/lib/startup.js
@@ -24,7 +24,7 @@ function makeServer(config) {
           security: {
             hsts: {
               maxAge: 1000 * 60 * 60 * 24 * 30,
-              includeSubdomains: true
+              includeSubDomains: true
             },
             xframe: true
           }


### PR DESCRIPTION
Looks like this should be `includeSubDomains` (http://hapijs.com/api)