### PR TITLE
replace deprecated hgroup elements

### DIFF
--- a/assets/styles/_header.styl
+++ b/assets/styles/_header.styl
@@ -386,20 +386,6 @@ body>nav
     display inline-block
     max-width 140px
 
-  hgroup
-    display block
-    margin 0 0 30px 0
-    h2,h3
-      text-align center
-    h2
-      color white
-      font-size 36px
-      font-weight 600
-    h3
-      @extend .featherweight-heading
-      font-size 24px
-      color rgba(white, 0.8)
-
   a.button
     color rgba(background-color, 0.8)
     background-color darken(npmred, 10%)

--- a/assets/styles/reset.styl
+++ b/assets/styles/reset.styl
@@ -5,7 +5,7 @@ small, sub, sup, var, b, i, dl, dt, dd, ol, ul, li,
 fieldset, form, label, legend,
 table, caption, tbody, tfoot, thead, tr, th, td,
 article, aside, canvas, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section, summary,
+footer, header, menu, nav, section, summary,
 time, mark, audio, video
   margin 0
   padding 0
@@ -15,7 +15,7 @@ time, mark, audio, video
   vertical-align baseline
 
 article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section
+footer, header, menu, nav, section
   display block
 
 hr

--- a/assets/styles/typography.styl
+++ b/assets/styles/typography.styl
@@ -68,26 +68,6 @@ h2
     a
       font-weight 600
 
-hgroup
-  margin 25px 0
-
-  h1,h2
-    margin 0
-    padding 0
-    text-align center
-    a
-      color greigh1
-      text-decoration none
-      &:hover
-        text-decoration underline
-
-  h2
-    font-weight 300
-    line-height 1.2
-    a
-      font-weight 300
-
-
 h3
   display block
   margin 0

--- a/templates/company/contact.hbs
+++ b/templates/company/contact.hbs
@@ -1,10 +1,10 @@
    <div class="content-column">
 
     <div id="readme">
-    <hgroup>
+    <header>
       <h1>Contact Us</h1>
       <h2>We're building a bunch of awesome products. If you're interested in working with us, or have a burning feature request you want to talk about, then let us know.</h2>
-    </hgroup>
+    </header>
 
     {{#if sent}}
       <p>Thanks for reaching out! One of us will get back to you as soon as possible.</p>

--- a/templates/company/payments.hbs
+++ b/templates/company/payments.hbs
@@ -1,8 +1,8 @@
 <div class="container narrow">
 
-  <hgroup>
+  <header>
     <h1>Listing on npm's Who's Hiring</h1>
-  </hgroup>
+  </header>
 
   <section class="payment">
 

--- a/templates/company/private-modules.hbs
+++ b/templates/company/private-modules.hbs
@@ -1,8 +1,8 @@
 <div class="tablet-width markdown container">
-<hgroup>
+<header>
   <h1>npm Private Modules</h1>
   <h2>create and share unlimited private modules for $7/month</h2>
-</hgroup>
+</header>
 
 {{#unless isPaid}}
   {{{benefits}}}

--- a/templates/company/whoshiring.hbs
+++ b/templates/company/whoshiring.hbs
@@ -1,7 +1,7 @@
-<hgroup>
+<header>
   <h1>{{t "company.whoshiring.title"}}</h1>
   <h2>{{t "company.whoshiring.subtitle"}}</h2>
-</hgroup>
+</header>
 
 <div class="hiring-container" data-template="full"></div>
 

--- a/templates/enterprise/check-email.hbs
+++ b/templates/enterprise/check-email.hbs
@@ -1,8 +1,8 @@
 <div class="container tablet-width">
-  <hgroup>
+  <header>
     <h1>npm On-Site</h1>
     <h2>time to check your email</h2>
-  </hgroup>
+  </header>
 
   <p>
     A verification link has been sent to your email. Click the link in the

--- a/templates/enterprise/clickThroughAgreement.hbs
+++ b/templates/enterprise/clickThroughAgreement.hbs
@@ -1,9 +1,9 @@
 <div class="container tablet-width">
 
-  <hgroup>
+  <header>
     <h1>npm On-Site</h1>
     <h2>Two ways to get started</h2>
-  </hgroup>
+  </header>
 
   <section>
     <h2>Option 1: Download now</h2>

--- a/templates/enterprise/complete.hbs
+++ b/templates/enterprise/complete.hbs
@@ -1,9 +1,9 @@
 <div class="container tablet-width">
 
-  <hgroup>
+  <header>
     <h1>npm On-Site</h1>
     <h2>Signup complete. Time to install!</h2>
-  </hgroup>
+  </header>
 
   <p>Thank you for trying out npm On-Site. To get started, make sure you have a fresh machine that meets the
     <a href="{{requirementsUrl}}">installation requirements</a>, then

--- a/templates/enterprise/contact-me.hbs
+++ b/templates/enterprise/contact-me.hbs
@@ -1,8 +1,8 @@
 <div class="container tablet-width">
-  <hgroup>
+  <header>
     <h1>npm On-Site</h1>
     <h2>We'll be in touch!</h2>
-  </hgroup>
+  </header>
 
   <p>Thanks for your interest in npm On-Site. We'll be in touch by email in the next working day.</p>
 </div>

--- a/templates/enterprise/find-license.hbs
+++ b/templates/enterprise/find-license.hbs
@@ -1,9 +1,9 @@
 <div class="container tablet-width">
 
-  <hgroup>
+  <header>
     <h1>npm On-Site</h1>
     <h2>Licensing</h2>
-  </hgroup>
+  </header>
 
   <section>
     <h2>Step 1: confirm your email address</h2>

--- a/templates/enterprise/index.hbs
+++ b/templates/enterprise/index.hbs
@@ -1,9 +1,9 @@
 <div class="container tablet-width">
 
-  <hgroup>
+  <header>
     <h1>npm On-Site</h1>
     <h2>Run your own on-premises npm registry</h2>
-  </hgroup>
+  </header>
 
 {{#unless errors}}
 

--- a/templates/enterprise/invalid-license.hbs
+++ b/templates/enterprise/invalid-license.hbs
@@ -1,8 +1,8 @@
 <div class="container tablet-width">
 
-  <hgroup>
+  <header>
     <h1>npm On-Site</h1>
-  </hgroup>
+  </header>
 
   <section>
     <h2>Sorry</h2>

--- a/templates/enterprise/license-error.hbs
+++ b/templates/enterprise/license-error.hbs
@@ -1,8 +1,8 @@
 <div class="container tablet-width">
 
-  <hgroup>
+  <header>
     <h1>npm On-Site</h1>
-  </hgroup>
+  </header>
 
   <section>
     <h2>Sorry</h2>

--- a/templates/enterprise/license-options.hbs
+++ b/templates/enterprise/license-options.hbs
@@ -1,9 +1,9 @@
 <div class="container tablet-width">
 
-  <hgroup>
+  <header>
     <h1>npm On-Site</h1>
     <h2>Licensing options</h2>
-  </hgroup>
+  </header>
 
   <section>
     <h2>Starter pack: $25/month for up to 5 seats</h2>

--- a/templates/enterprise/license-paid.hbs
+++ b/templates/enterprise/license-paid.hbs
@@ -1,8 +1,8 @@
 <div class="container tablet-width">
 
-  <hgroup>
+  <header>
     <h1>npm On-Site</h1>
-  </hgroup>
+  </header>
 
   <section>
     <h2>Thanks for your payment</h2>

--- a/templates/enterprise/thanks.hbs
+++ b/templates/enterprise/thanks.hbs
@@ -1,8 +1,8 @@
 <div class="container tablet-width">
-  <hgroup>
+  <header>
     <h1>npm On-Site</h1>
     <h2>time to check your email</h2>
-  </hgroup>
+  </header>
 
   <p>
     A verification link has been sent to your email. Click the link in the

--- a/templates/errors/internal.hbs
+++ b/templates/errors/internal.hbs
@@ -1,9 +1,9 @@
 <div class="container narrow">
 
-  <hgroup>
+  <header>
     <h1>{{t "errors.generic.title"}}</h1>
     <h2>{{t "errors.generic.subtitle"}}</h2>
-  </hgroup>
+  </header>
 
   <p>
     If you feel this error is the result of a bug, please

--- a/templates/errors/not-found.hbs
+++ b/templates/errors/not-found.hbs
@@ -1,10 +1,10 @@
 <div class="container">
-  <hgroup>
+  <header>
     <h1>not found</h1>
     <h2>
       {{canonicalURL}} does not exist. time to go outside.
     </h2>
-  </hgroup>
+  </header>
 </div>
 
 <div class="container narrow">

--- a/templates/errors/package-not-found.hbs
+++ b/templates/errors/package-not-found.hbs
@@ -1,5 +1,5 @@
 <div class="container">
-  <hgroup>
+  <header>
     <h1>{{t "package.not_found.title"}}</h1>
     <h2>
       {{#if package.available}}
@@ -16,7 +16,7 @@
         {{/if}}
       {{/if}}
     </h2>
-  </hgroup>
+  </header>
 </div>
 
 <div class="container narrow">

--- a/templates/errors/token-expired.hbs
+++ b/templates/errors/token-expired.hbs
@@ -1,9 +1,9 @@
 <div class="container narrow">
 
-  <hgroup>
+  <header>
     <h1>{{t "errors.token_expired.title"}}</h1>
     <h2>{{t "errors.token_expired.subtitle"}}</h2>
-  </hgroup>
+  </header>
 
   <p>
     The email you received has a one-time-use-only link.

--- a/templates/errors/user-not-found.hbs
+++ b/templates/errors/user-not-found.hbs
@@ -1,9 +1,9 @@
 <div class="container narrow">
 
-  <hgroup>
+  <header>
     <h1>{{name}}?</h1>
     <h2>{{t "user.profile.not_found.subtitle"}}</h2>
-  </hgroup>
+  </header>
 
   <p>
     If you believe that this is a bug, please

--- a/templates/layouts/default.hbs
+++ b/templates/layouts/default.hbs
@@ -46,7 +46,7 @@
   {{#unless features.npmo}}
     <div id="notification-banner" class="hidden">
       <div class="container">
-        <hgroup>
+        <header>
           <a href="/private-modules"
             data-event-trigger="click"
             data-event-name="private-modules-banner-signup-via-wombat">
@@ -54,7 +54,7 @@
           </a>
           <h2>private npm is here.</h2>
           <h3>publish unlimited private modules for just $7/month</h3>
-        </hgroup>
+        </header>
         <a class="button" href="/private-modules"
           data-event-trigger="click"
           data-event-name="private-modules-banner-signup">sign up</a>

--- a/templates/org/info.hbs
+++ b/templates/org/info.hbs
@@ -1,8 +1,8 @@
 <div class="container">
 
-  <hgroup>
+  <header>
     <h1 class="billing-header">{{org.info.name}}</h1>
-  </hgroup>
+  </header>
 
   <div class="tabs">
     <div class="tab-nav-container">

--- a/templates/user/billing.hbs
+++ b/templates/user/billing.hbs
@@ -2,7 +2,7 @@
 
 <div class="container{{#unless features.org_billing}} narrow{{/unless}}">
 
-  <hgroup>
+  <header>
     {{#if features.org_billing}}
       <h1>Subscriptions</h1>
     {{else}}
@@ -12,7 +12,7 @@
       <h1>sign up for private modules</h1>
       {{/if}}
     {{/if}}
-  </hgroup>
+  </header>
 
   {{> email-verify-nag}}
 

--- a/templates/user/email-confirmed.hbs
+++ b/templates/user/email-confirmed.hbs
@@ -4,10 +4,10 @@
 
 <div class="container narrow">
 
-  <hgroup>
+  <header>
     <h1>hi again</h1>
     <h2>thanks for verifying your email address</h2>
-  </hgroup>
+  </header>
 
   <p>
     Now that you've cleared that up, you might want to

--- a/templates/user/email-edit.hbs
+++ b/templates/user/email-edit.hbs
@@ -2,9 +2,9 @@
 
 <div class="container narrow">
 
-  <hgroup>
+  <header>
     <h1>edit email address</h1>
-  </hgroup>
+  </header>
 
   {{#unless submitted}}
 

--- a/templates/user/login.hbs
+++ b/templates/user/login.hbs
@@ -1,9 +1,9 @@
 <div class="container narrow">
 
-  <hgroup>
+  <header>
     <h1>{{t "user.login.title"}}</h1>
     <h2>{{t "user.login.subtitle"}}</h2>
-  </hgroup>
+  </header>
 
   {{> errors}}
 

--- a/templates/user/password-recovery-form.hbs
+++ b/templates/user/password-recovery-form.hbs
@@ -1,9 +1,9 @@
 <div class="container narrow">
 
-  <hgroup>
+  <header>
     <h1>{{t "user.password.title"}}</h1>
     <h2>{{t "user.password.subtitle"}}</h2>
-  </hgroup>
+  </header>
 
   {{#if sent}}
     <p class="center">{{t "user.password.emailed"}}</p>

--- a/templates/user/password.hbs
+++ b/templates/user/password.hbs
@@ -1,9 +1,9 @@
 {{> profile-secondary-nav}}
 
 <div class="container narrow">
-  <hgroup>
+  <header>
     <h1>change password</h1>
-  </hgroup>
+  </header>
 
   <form data-tab="password" method="post" action="/password">
 

--- a/templates/user/profile-edit.hbs
+++ b/templates/user/profile-edit.hbs
@@ -2,9 +2,9 @@
 
 <div class="container narrow">
 
-  <hgroup>
+  <header>
     <h1>edit your profile</h1>
-  </hgroup>
+  </header>
 
   {{#if showWelcomeMessage}}
     <p class="notice">

--- a/templates/user/signup-form.hbs
+++ b/templates/user/signup-form.hbs
@@ -1,9 +1,9 @@
 <div class="container narrow">
 
-  <hgroup>
+  <header>
     <h1>{{t "user.signup.title"}}</h1>
     <h2>{{t "user.signup.subtitle"}}</h2>
-  </hgroup>
+  </header>
 
   {{> errors}}
 


### PR DESCRIPTION
This PR replaces the deprecated `hgroup` elements with `header` elements.

Fixes #845 