### PR TITLE
Add support for an Org's "full name"

### DIFF
--- a/agents/org.js
+++ b/agents/org.js
@@ -21,8 +21,8 @@ Org.prototype.create = function(opts, callback) {
   var url = USER_HOST + '/org';
   var resource = {};
 
-  if (opts.fullname) {
-    resource.human_name = opts.fullname;
+  if (opts.human_name) {
+    resource.human_name = opts.human_name;
   }
 
   var data = {

--- a/agents/org.js
+++ b/agents/org.js
@@ -15,19 +15,21 @@ var Org = module.exports = function(bearer) {
   this.bearer = bearer;
 };
 
-Org.prototype.create = function(scope, fullname, callback) {
+Org.prototype.create = function(opts, callback) {
+  opts = opts || {};
+
   var url = USER_HOST + '/org';
   var resource = {};
 
-  if (fullname) {
-    resource.human_name = fullname;
+  if (opts.fullname) {
+    resource.human_name = opts.fullname;
   }
 
-  var opts = {
+  var data = {
     url: url,
     json: true,
     body: {
-      name: scope,
+      name: opts.scope,
       resource: resource
     },
     headers: {
@@ -36,13 +38,13 @@ Org.prototype.create = function(scope, fullname, callback) {
   };
 
   return new P(function(accept, reject) {
-    Request.put(opts, function(err, resp, body) {
+    Request.put(data, function(err, resp, body) {
       if (err) {
         return reject(err);
       }
 
       if (resp.statusCode === 401) {
-        err = Error('no bearer token included in creation of ' + scope);
+        err = Error('no bearer token included in creation of ' + opts.scope);
         err.statusCode = resp.statusCode;
         return reject(err);
       }

--- a/agents/org.js
+++ b/agents/org.js
@@ -21,8 +21,8 @@ Org.prototype.create = function(opts, callback) {
   var url = USER_HOST + '/org';
   var resource = {};
 
-  if (opts.human_name) {
-    resource.human_name = opts.human_name;
+  if (opts.humanName) {
+    resource.human_name = opts.humanName;
   }
 
   var data = {

--- a/agents/org.js
+++ b/agents/org.js
@@ -15,14 +15,20 @@ var Org = module.exports = function(bearer) {
   this.bearer = bearer;
 };
 
-Org.prototype.create = function(name, callback) {
+Org.prototype.create = function(scope, fullname, callback) {
   var url = USER_HOST + '/org';
+  var resource = {};
+
+  if (fullname) {
+    resource.human_name = fullname;
+  }
 
   var opts = {
     url: url,
     json: true,
     body: {
-      name: name
+      name: scope,
+      resource: resource
     },
     headers: {
       bearer: this.bearer
@@ -36,7 +42,7 @@ Org.prototype.create = function(name, callback) {
       }
 
       if (resp.statusCode === 401) {
-        err = Error('no bearer token included in creation of ' + name);
+        err = Error('no bearer token included in creation of ' + scope);
         err.statusCode = resp.statusCode;
         return reject(err);
       }
@@ -126,7 +132,7 @@ Org.prototype.update = function(data, callback) {
     }
   };
 
-  Request.post(opts, function(err, resp, body) {
+  Request.post(opts, function(err, resp, org) {
     if (err) {
       callback(err);
     }
@@ -149,7 +155,7 @@ Org.prototype.update = function(data, callback) {
       return callback(err);
     }
 
-    return callback(null, body);
+    return callback(null, org);
   });
 };
 

--- a/handlers/customer.js
+++ b/handlers/customer.js
@@ -140,7 +140,7 @@ var subscriptionSchema = {
   planType: Joi.string().valid(Object.keys(plans)).required(),
   stripeToken: Joi.string(),
   coupon: Joi.string().optional().allow(''),
-  fullname: Joi.string().optional().allow(''),
+  human_name: Joi.string().optional().allow(''),
   orgScope: Joi.string().when('planType', {
     is: 'orgs',
     then: Joi.required()
@@ -290,7 +290,7 @@ customer.subscribe = function(request, reply) {
             return Org(loggedInUser)
               .create({
                 scope: planData.orgScope,
-                fullname: planData.fullname
+                human_name: planData.human_name
               });
           }
         }).then(function() {
@@ -334,7 +334,7 @@ customer.subscribe = function(request, reply) {
             stripePublicKey: process.env.STRIPE_PUBLIC_KEY,
             inUseError: true,
             orgScope: planData.orgScope,
-            fullname: planData.fullname,
+            human_name: planData.human_name,
             notices: [err]
           });
         } else {

--- a/handlers/customer.js
+++ b/handlers/customer.js
@@ -140,7 +140,7 @@ var subscriptionSchema = {
   planType: Joi.string().valid(Object.keys(plans)).required(),
   stripeToken: Joi.string(),
   coupon: Joi.string().optional().allow(''),
-  human_name: Joi.string().optional().allow(''),
+  "human-name": Joi.string().optional().allow(''),
   orgScope: Joi.string().when('planType', {
     is: 'orgs',
     then: Joi.required()
@@ -290,7 +290,7 @@ customer.subscribe = function(request, reply) {
             return Org(loggedInUser)
               .create({
                 scope: planData.orgScope,
-                human_name: planData.human_name
+                humanName: planData["human-name"]
               });
           }
         }).then(function() {
@@ -334,7 +334,7 @@ customer.subscribe = function(request, reply) {
             stripePublicKey: process.env.STRIPE_PUBLIC_KEY,
             inUseError: true,
             orgScope: planData.orgScope,
-            human_name: planData.human_name,
+            humanName: planData["human-name"],
             notices: [err]
           });
         } else {

--- a/handlers/customer.js
+++ b/handlers/customer.js
@@ -289,7 +289,10 @@ customer.subscribe = function(request, reply) {
               })
           } else {
             return Org(loggedInUser)
-              .create(planInfo.npm_org, planData.fullname);
+              .create({
+                scope: planInfo.npm_org,
+                fullname: planData.fullname
+              });
           }
         }).then(function() {
           return Customer(loggedInUser).createSubscription(planInfo)

--- a/handlers/customer.js
+++ b/handlers/customer.js
@@ -225,7 +225,6 @@ customer.subscribe = function(request, reply) {
     }
 
     function subscribeToOrg() {
-      planInfo.npm_org = planData.orgScope;
 
       var newUser = planData['new-user'];
 
@@ -246,11 +245,11 @@ customer.subscribe = function(request, reply) {
       }
 
       // check if the org name works as a package name
-      var valid = validate('@' + planInfo.npm_org + '/foo');
+      var valid = validate('@' + planData.orgScope + '/foo');
 
       if (!valid.errors) {
         // now check if the org name works on its own
-        valid = validate(planInfo.npm_org);
+        valid = validate(planData.orgScope);
       }
 
       if (valid.errors) {
@@ -262,7 +261,7 @@ customer.subscribe = function(request, reply) {
 
 
       Org(loggedInUser)
-        .get(planInfo.npm_org).then(function() {
+        .get(planData.orgScope).then(function() {
         var err = new Error("Org already exists");
         err.isUserError = true;
         throw err;
@@ -290,11 +289,12 @@ customer.subscribe = function(request, reply) {
           } else {
             return Org(loggedInUser)
               .create({
-                scope: planInfo.npm_org,
+                scope: planData.orgScope,
                 fullname: planData.fullname
               });
           }
         }).then(function() {
+          planInfo.npm_org = planData.orgScope;
           return Customer(loggedInUser).createSubscription(planInfo)
             .tap(function(subscription) {
               if (typeof subscription === 'string') {
@@ -314,7 +314,7 @@ customer.subscribe = function(request, reply) {
           }).then(function(extendedSponsorship) {
             return Customer(loggedInUser).acceptSponsorship(extendedSponsorship.verification_key);
           }).then(function() {
-            return reply.redirect('/org/' + planInfo.npm_org);
+            return reply.redirect('/org/' + planData.orgScope);
           });
         })
           .catch(function(err) {

--- a/handlers/org.js
+++ b/handlers/org.js
@@ -35,17 +35,12 @@ exports.getOrg = function(request, reply) {
 
         org = org || {};
         org.info = org.info || {};
-        var fullname = "";
 
-        if (org.info.human_name) {
-          fullname = org.info.human_name;
-        } else if (org.info.resource && org.info.resource.human_name) {
-          fullname = org.info.resource.human_name;
+        if (org.info.resource && org.info.resource.human_name) {
+          org.info.human_name = org.info.resource.human_name;
         } else {
-          fullname = org.info.name;
+          org.info.human_name = org.info.name;
         }
-
-        org.info.fullname = fullname;
 
         opts.org = org;
         opts.org.users.items = org.users.items.map(function(user) {
@@ -269,7 +264,7 @@ exports.deleteOrg = function(request, reply) {
 };
 
 var orgSubscriptionSchema = {
-  fullname: Joi.string().optional().allow(''),
+  human_name: Joi.string().optional().allow(''),
   orgScope: Joi.string().required()
 };
 
@@ -296,7 +291,7 @@ exports.validateOrgCreation = function(request, reply) {
         param += "&inUseError=true";
         param += opts.inUseByMe ? "&inUseByMe=" + !!opts.inUseByMe : "";
         param += planData.orgScope ? "&orgScope=" + planData.orgScope : "";
-        param += planData.fullname ? "&fullname=" + planData.fullname : "";
+        param += planData.human_name ? "&human_name=" + planData.human_name : "";
 
         url = url + param;
         return reply.redirect(url);
@@ -366,7 +361,7 @@ exports.validateOrgCreation = function(request, reply) {
               .then(reportScopeInUseError)
               .catch(function(err) {
                 if (err.statusCode === 404) {
-                  var url = '/org/create/billing?orgScope=' + planData.orgScope + '&fullname=' + planData.fullname;
+                  var url = '/org/create/billing?orgScope=' + planData.orgScope + '&human_name=' + planData.human_name;
                   return reply.redirect(url);
                 } else {
                   response.logger.error(err);
@@ -429,7 +424,7 @@ exports.getOrgCreationBillingPage = function(request, reply) {
       var url = '/org/transfer-user-name';
       var param = token ? "?notice=" + token : "";
       param += planData.orgScope ? "&orgScope=" + planData.orgScope : "";
-      param += planData.fullname ? "&fullname=" + planData.fullname : "";
+      param += planData.human_name ? "&human_name=" + planData.human_name : "";
 
       url = url + param;
       return reply.redirect(url);
@@ -450,7 +445,7 @@ exports.getOrgCreationBillingPage = function(request, reply) {
             .catch(function(err) {
               if (err.statusCode === 404) {
                 return reply.view('org/billing', {
-                  fullname: request.query.fullname,
+                  human_name: request.query.human_name,
                   orgScope: orgScope,
                   newUser: newUser,
                   stripePublicKey: process.env.STRIPE_PUBLIC_KEY
@@ -467,7 +462,7 @@ exports.getOrgCreationBillingPage = function(request, reply) {
       });
   } else {
     return reply.view('org/billing', {
-      fullname: request.query.fullname,
+      human_name: request.query.human_name,
       orgScope: orgScope,
       stripePublicKey: process.env.STRIPE_PUBLIC_KEY
     });
@@ -496,7 +491,7 @@ exports.getTransferPage = function(request, reply) {
     });
   }
   return reply.view('org/transfer', {
-    fullname: request.query.fullname,
+    human_name: request.query.human_name,
     orgScope: request.query.orgScope
   });
 };

--- a/handlers/org.js
+++ b/handlers/org.js
@@ -33,6 +33,20 @@ exports.getOrg = function(request, reply) {
           }
         }
 
+        org = org || {};
+        org.info = org.info || {};
+        var fullname = "";
+
+        if (org.info.human_name) {
+          fullname = org.info.human_name;
+        } else if (org.info.resource && org.info.resource.human_name) {
+          fullname = org.info.resource.human_name;
+        } else {
+          fullname = org.info.name;
+        }
+
+        org.info.fullname = fullname;
+
         opts.org = org;
         opts.org.users.items = org.users.items.map(function(user) {
           user.sponsoredByOrg = user.sponsored === 'by-org';

--- a/handlers/org.js
+++ b/handlers/org.js
@@ -264,7 +264,7 @@ exports.deleteOrg = function(request, reply) {
 };
 
 var orgSubscriptionSchema = {
-  human_name: Joi.string().optional().allow(''),
+  "human-name": Joi.string().optional().allow(''),
   orgScope: Joi.string().required()
 };
 
@@ -291,7 +291,7 @@ exports.validateOrgCreation = function(request, reply) {
         param += "&inUseError=true";
         param += opts.inUseByMe ? "&inUseByMe=" + !!opts.inUseByMe : "";
         param += planData.orgScope ? "&orgScope=" + planData.orgScope : "";
-        param += planData.human_name ? "&human_name=" + planData.human_name : "";
+        param += planData["human-name"] ? "&human-name=" + planData["human-name"] : "";
 
         url = url + param;
         return reply.redirect(url);
@@ -361,7 +361,7 @@ exports.validateOrgCreation = function(request, reply) {
               .then(reportScopeInUseError)
               .catch(function(err) {
                 if (err.statusCode === 404) {
-                  var url = '/org/create/billing?orgScope=' + planData.orgScope + '&human_name=' + planData.human_name;
+                  var url = '/org/create/billing?orgScope=' + planData.orgScope + '&human-name=' + planData["human-name"];
                   return reply.redirect(url);
                 } else {
                   response.logger.error(err);
@@ -424,7 +424,7 @@ exports.getOrgCreationBillingPage = function(request, reply) {
       var url = '/org/transfer-user-name';
       var param = token ? "?notice=" + token : "";
       param += planData.orgScope ? "&orgScope=" + planData.orgScope : "";
-      param += planData.human_name ? "&human_name=" + planData.human_name : "";
+      param += planData["human-name"] ? "&human-name=" + planData["human-name"] : "";
 
       url = url + param;
       return reply.redirect(url);
@@ -445,7 +445,7 @@ exports.getOrgCreationBillingPage = function(request, reply) {
             .catch(function(err) {
               if (err.statusCode === 404) {
                 return reply.view('org/billing', {
-                  human_name: request.query.human_name,
+                  humanName: request.query["human-name"],
                   orgScope: orgScope,
                   newUser: newUser,
                   stripePublicKey: process.env.STRIPE_PUBLIC_KEY
@@ -462,7 +462,7 @@ exports.getOrgCreationBillingPage = function(request, reply) {
       });
   } else {
     return reply.view('org/billing', {
-      human_name: request.query.human_name,
+      humanName: request.query["human-name"],
       orgScope: orgScope,
       stripePublicKey: process.env.STRIPE_PUBLIC_KEY
     });
@@ -491,7 +491,7 @@ exports.getTransferPage = function(request, reply) {
     });
   }
   return reply.view('org/transfer', {
-    human_name: request.query.human_name,
+    humanName: request.query["human-name"],
     orgScope: request.query.orgScope
   });
 };

--- a/routes/authenticated.js
+++ b/routes/authenticated.js
@@ -119,7 +119,7 @@ module.exports = [
         inUseError: query.inUseError,
         inUseByMe: query.inUseByMe,
         orgScope: query.orgScope,
-        fullname: query.fullname
+        human_name: query.human_name
       });
     }
   }, {

--- a/routes/authenticated.js
+++ b/routes/authenticated.js
@@ -119,7 +119,7 @@ module.exports = [
         inUseError: query.inUseError,
         inUseByMe: query.inUseByMe,
         orgScope: query.orgScope,
-        human_name: query.human_name
+        humanName: query['human-name']
       });
     }
   }, {

--- a/templates/org/billing.hbs
+++ b/templates/org/billing.hbs
@@ -13,7 +13,7 @@
         <span class="included">$14/month for 2 included users</span>
         <span class="additional">$7/month for additional users</span>
       </p>
-      <input type="hidden" name="fullname" value="{{fullname}}"/>
+      <input type="hidden" name="human_name" value="{{human_name}}"/>
       <input type="hidden" name="orgScope" value="{{orgScope}}"/>
       {{#if newUser}}
       <input type="hidden" name="new-user" value="{{newUser}}"/>

--- a/templates/org/billing.hbs
+++ b/templates/org/billing.hbs
@@ -13,7 +13,7 @@
         <span class="included">$14/month for 2 included users</span>
         <span class="additional">$7/month for additional users</span>
       </p>
-      <input type="hidden" name="human_name" value="{{human_name}}"/>
+      <input type="hidden" name="human-name" value="{{humanName}}"/>
       <input type="hidden" name="orgScope" value="{{orgScope}}"/>
       {{#if newUser}}
       <input type="hidden" name="new-user" value="{{newUser}}"/>

--- a/templates/org/create.hbs
+++ b/templates/org/create.hbs
@@ -11,8 +11,8 @@
   <div class="content-column">
       <form{{#if inUseError}} class="error-state"{{/if}} method="GET" id="create-org-form" action="/org/create-validation">
         <section>
-          <label for="human_name">Org name</label>
-          <input required="required" type="text" id="human_name" name="human_name" placeholder="My Org" {{#if human_name}} value="{{human_name}}"{{/if}}/>
+          <label for="human-name">Org name</label>
+          <input required="required" type="text" id="human-name" name="human-name" placeholder="My Org" {{#if humanName}} value="{{humanName}}"{{/if}}/>
           <p class="description">A human-readable name for your org, can include spaces &amp; punctuation.</p>
 
           <label for="orgScope">Org <a href="https://docs.npmjs.com/misc/scope" target="_blank">@scope</a></label>
@@ -21,7 +21,7 @@
 
           {{#if inUseByMe}}
           <div class="hint-block">
-            <a href="/org/transfer-user-name?orgScope={{orgScope}}&human_name={{human_name}}">transfer @{{orgScope}} to become your organization's scope?</a>
+            <a href="/org/transfer-user-name?orgScope={{orgScope}}&human-name={{humanName}}">transfer @{{orgScope}} to become your organization's scope?</a>
           </div>
           {{/if}}
 

--- a/templates/org/create.hbs
+++ b/templates/org/create.hbs
@@ -11,8 +11,8 @@
   <div class="content-column">
       <form{{#if inUseError}} class="error-state"{{/if}} method="GET" id="create-org-form" action="/org/create-validation">
         <section>
-          <label for="fullname">Org name</label>
-          <input required="required" type="text" id="fullname" name="fullname" placeholder="My Org" {{#if fullname}} value="{{fullname}}"{{/if}}/>
+          <label for="human_name">Org name</label>
+          <input required="required" type="text" id="human_name" name="human_name" placeholder="My Org" {{#if human_name}} value="{{human_name}}"{{/if}}/>
           <p class="description">A human-readable name for your org, can include spaces &amp; punctuation.</p>
 
           <label for="orgScope">Org <a href="https://docs.npmjs.com/misc/scope" target="_blank">@scope</a></label>
@@ -21,7 +21,7 @@
 
           {{#if inUseByMe}}
           <div class="hint-block">
-            <a href="/org/transfer-user-name?orgScope={{orgScope}}&fullname={{fullname}}">transfer @{{orgScope}} to become your organization's scope?</a>
+            <a href="/org/transfer-user-name?orgScope={{orgScope}}&human_name={{human_name}}">transfer @{{orgScope}} to become your organization's scope?</a>
           </div>
           {{/if}}
 

--- a/test/agents/org.js
+++ b/test/agents/org.js
@@ -33,7 +33,7 @@ describe('Org', function() {
 
       Org('bob').create({
         scope: 'bigco',
-        fullname: "Bob's Big Co"
+        human_name: "Bob's Big Co"
       }, function(err, org) {
         orgMock.done();
         expect(err).to.exist();
@@ -69,7 +69,7 @@ describe('Org', function() {
 
       Org('bob').create({
         scope: "bigco",
-        fullname: "Bob's Big Co"
+        human_name: "Bob's Big Co"
       }, function(err, org) {
         orgMock.done();
         expect(err).to.not.exist();

--- a/test/agents/org.js
+++ b/test/agents/org.js
@@ -31,7 +31,10 @@ describe('Org', function() {
         })
         .reply(401);
 
-      Org('bob').create('bigco', "Bob's Big Co", function(err, org) {
+      Org('bob').create({
+        scope: 'bigco',
+        fullname: "Bob's Big Co"
+      }, function(err, org) {
         orgMock.done();
         expect(err).to.exist();
         expect(err.message).to.equal('no bearer token included in creation of bigco');
@@ -64,7 +67,10 @@ describe('Org', function() {
           "deleted": null
         });
 
-      Org('bob').create("bigco", "Bob's Big Co", function(err, org) {
+      Org('bob').create({
+        scope: "bigco",
+        fullname: "Bob's Big Co"
+      }, function(err, org) {
         orgMock.done();
         expect(err).to.not.exist();
         expect(org.name).to.equal("bigco");

--- a/test/agents/org.js
+++ b/test/agents/org.js
@@ -33,7 +33,7 @@ describe('Org', function() {
 
       Org('bob').create({
         scope: 'bigco',
-        human_name: "Bob's Big Co"
+        humanName: "Bob's Big Co"
       }, function(err, org) {
         orgMock.done();
         expect(err).to.exist();
@@ -69,7 +69,7 @@ describe('Org', function() {
 
       Org('bob').create({
         scope: "bigco",
-        human_name: "Bob's Big Co"
+        humanName: "Bob's Big Co"
       }, function(err, org) {
         orgMock.done();
         expect(err).to.not.exist();

--- a/test/agents/org.js
+++ b/test/agents/org.js
@@ -24,11 +24,14 @@ describe('Org', function() {
     it("errors out if bearer token is not included", function(done) {
       var orgMock = nock('https://user-api-example.com')
         .put('/org', {
-          name: 'bigco'
+          name: 'bigco',
+          resource: {
+            "human_name": "Bob's Big Co"
+          }
         })
         .reply(401);
 
-      Org('bob').create('bigco', function(err, org) {
+      Org('bob').create('bigco', "Bob's Big Co", function(err, org) {
         orgMock.done();
         expect(err).to.exist();
         expect(err.message).to.equal('no bearer token included in creation of bigco');
@@ -45,18 +48,23 @@ describe('Org', function() {
         }
       })
         .put('/org', {
-          name: "bigco"
+          name: "bigco",
+          resource: {
+            "human_name": "Bob's Big Co"
+          }
         })
         .reply(200, {
           "name": "bigco",
           "description": "",
-          "resource": {},
+          "resource": {
+            "human_name": "Bob's Big Co"
+          },
           "created": "2015-06-19T23:35:42.659Z",
           "updated": "2015-06-19T23:35:42.659Z",
           "deleted": null
         });
 
-      Org('bob').create("bigco", function(err, org) {
+      Org('bob').create("bigco", "Bob's Big Co", function(err, org) {
         orgMock.done();
         expect(err).to.not.exist();
         expect(org.name).to.equal("bigco");
@@ -83,7 +91,9 @@ describe('Org', function() {
         .reply(200, {
           'name': 'bigco',
           'description': '',
-          'resource': {},
+          'resource': {
+            "human_name": "Bob's Big Co"
+          },
           'created': '2015-06-19T23:35:42.659Z',
           'updated': '2015-06-19T23:35:42.659Z',
           'deleted': null
@@ -104,6 +114,7 @@ describe('Org', function() {
         expect(err).to.be.null();
         expect(org.users.items[0].name).to.equal('bob');
         expect(org.info.name).to.equal('bigco');
+        expect(org.info.resource.human_name).to.equal("Bob's Big Co");
         expect(org.packages.items[0].name).to.equal('fake');
         expect(org.deleted).to.be.undefined();
         done();
@@ -139,7 +150,7 @@ describe('Org', function() {
         name: 'bigco',
         description: 'bigco organization',
         resource: {
-          fullname: 'BigCo Enterprises'
+          human_name: 'BigCo Enterprises'
         }
       };
 
@@ -168,7 +179,7 @@ describe('Org', function() {
         name: 'bigco',
         description: 'bigco organization',
         resource: {
-          fullname: 'BigCo Enterprises'
+          human_name: 'BigCo Enterprises'
         }
       };
 
@@ -197,7 +208,7 @@ describe('Org', function() {
         name: 'bigco',
         description: 'bigco organization',
         resource: {
-          fullname: 'BigCo Enterprises'
+          human_name: 'BigCo Enterprises'
         }
       };
 
@@ -226,7 +237,7 @@ describe('Org', function() {
         name: 'bigco',
         description: 'bigco organization',
         resource: {
-          fullname: 'BigCo Enterprises'
+          human_name: 'BigCo Enterprises'
         }
       };
 
@@ -240,7 +251,7 @@ describe('Org', function() {
           name: "bigco",
           description: "bigco organization",
           resource: {
-            fullname: "BigCo Enterprises"
+            human_name: "BigCo Enterprises"
           },
           created: "2015-06-19T23:35:42.659Z",
           updated: "2015-07-10T19:59:08.395Z",
@@ -250,8 +261,9 @@ describe('Org', function() {
       Org('bob').update(data, function(err, org) {
         orgMocks.done();
         expect(err).to.be.null();
+        expect(org.name).to.equal("bigco");
         expect(org.description).to.equal("bigco organization");
-        expect(org.resource.fullname).to.equal("BigCo Enterprises");
+        expect(org.resource.human_name).to.equal("BigCo Enterprises");
         done();
       });
     });

--- a/test/fixtures/orgs.js
+++ b/test/fixtures/orgs.js
@@ -2,7 +2,7 @@ exports.bigco = {
   "name": "bigco",
   "description": "bigco organization",
   "resource": {
-    "fullname": "BigCo Enterprises"
+    "human_name": "BigCo Enterprises"
   },
   "created": "2015-07-10T20:29:37.816Z",
   "updated": "2015-07-10T21:07:16.799Z",
@@ -13,7 +13,7 @@ exports.bigcoDeleted = {
   "name": "bigco",
   "description": "bigco organization",
   "resource": {
-    "fullname": "BigCo Enterprises"
+    "human_name": "BigCo Enterprises"
   },
   "created": "2015-07-10T20:29:37.816Z",
   "updated": "2015-07-10T21:07:16.799Z",
@@ -170,7 +170,7 @@ exports.notBobsOrg = {
   "name": "bligco",
   "description": "bligco organization",
   "resource": {
-    "fullname": "BligCo Enterprises"
+    "human_name": "BligCo Enterprises"
   },
   "created": "2015-07-10T20:29:37.816Z",
   "updated": "2015-07-10T21:07:16.799Z",

--- a/test/handlers/customer.js
+++ b/test/handlers/customer.js
@@ -915,13 +915,15 @@ describe("subscribing to an org", function() {
         .get("/org/boomer/package")
         .reply(404, "not found")
         .put("/org", {
-          name: "boomer"
+          name: "boomer",
+          resource: {}
         })
         .reply(200, {
           "name": "boomer",
           "created": "2015-08-05T20:55:54.759Z",
           "updated": "2015-08-05T20:55:54.759Z",
           "deleted": null,
+          "resource": {}
         });
 
       var customerMock = nock("https://license-api-example.com")
@@ -1173,7 +1175,8 @@ describe("subscribing to an org", function() {
         .get("/org/bob/package")
         .reply(404, "not found")
         .put("/org", {
-          name: "bob"
+          name: "bob",
+          resource: {}
         })
         .reply(409, "that scope name is already in use");
 

--- a/test/handlers/org.js
+++ b/test/handlers/org.js
@@ -400,7 +400,7 @@ describe('creating an org', function() {
         .reply(200, fixtures.packages.fake);
 
       var options = {
-        url: "/org/create-validation?orgScope=bigco&human_name=Bob's big co",
+        url: "/org/create-validation?orgScope=bigco&human-name=Bob's big co",
         method: "GET",
         credentials: fixtures.users.bob
       };
@@ -433,7 +433,7 @@ describe('creating an org', function() {
         .reply(404, fixtures.packages.fake);
 
       var options = {
-        url: "/org/create-validation?orgScope=bigco&human_name=Bob's big co",
+        url: "/org/create-validation?orgScope=bigco&human-name=Bob's big co",
         method: "GET",
         credentials: fixtures.users.bob
       };
@@ -455,7 +455,7 @@ describe('creating an org', function() {
         .reply(200, fixtures.users.bob);
 
       var options = {
-        url: "/org/create-validation?orgScope=bob&human_name=Bob's big co",
+        url: "/org/create-validation?orgScope=bob&human-name=Bob's big co",
         method: "GET",
         credentials: fixtures.users.bob
       };
@@ -476,7 +476,7 @@ describe('creating an org', function() {
         .reply(200, fixtures.users.bob);
 
       var options = {
-        url: "/org/create-validation?orgScope=afdo@;;;383&human_name=Bob's big co",
+        url: "/org/create-validation?orgScope=afdo@;;;383&human-name=Bob's big co",
         method: "GET",
         credentials: fixtures.users.bob
       };
@@ -507,7 +507,7 @@ describe('creating an org', function() {
         .reply(404, fixtures.packages.fake);
 
       var options = {
-        url: "/org/create-validation?orgScope=bigco&human_name=Bob's big co",
+        url: "/org/create-validation?orgScope=bigco&human-name=Bob's big co",
         method: "GET",
         credentials: fixtures.users.bob
       };
@@ -531,7 +531,7 @@ describe('transferring username to org', function() {
         .reply(200, fixtures.users.bob);
 
       var options = {
-        url: "/org/transfer-user-name?human_name=Bob's big co&orgScope=adsjo@ffoo;;",
+        url: "/org/transfer-user-name?human-name=Bob's big co&orgScope=adsjo@ffoo;;",
         method: "GET",
         credentials: fixtures.users.bob
       };
@@ -552,7 +552,7 @@ describe('transferring username to org', function() {
         .reply(200, fixtures.users.bob);
 
       var options = {
-        url: "/org/transfer-user-name?human_name=Bob's big co&orgScope=bob",
+        url: "/org/transfer-user-name?human-name=Bob's big co&orgScope=bob",
         method: "GET",
         credentials: fixtures.users.bob
       };
@@ -572,7 +572,7 @@ describe('transferring username to org', function() {
         .reply(200, fixtures.users.bob);
 
       var options = {
-        url: "/org/create/billing?orgScope=org-915001&human_name=Bob%27s%20Org%20Is%20Cool",
+        url: "/org/create/billing?orgScope=org-915001&human-name=Bob%27s%20Org%20Is%20Cool",
         method: "GET",
         credentials: fixtures.users.bob
       };
@@ -592,7 +592,7 @@ describe('transferring username to org', function() {
         .reply(200, fixtures.users.bob);
 
       var options = {
-        url: "/org/create/billing?orgScope=org-915001&human_name=Bob%27s%20Org%20Is%20Cool&new-user=bigco",
+        url: "/org/create/billing?orgScope=org-915001&human-name=Bob%27s%20Org%20Is%20Cool&new-user=bigco",
         method: "GET",
         credentials: fixtures.users.bob
       };
@@ -612,7 +612,7 @@ describe('transferring username to org', function() {
         .reply(200, fixtures.users.bob);
 
       var options = {
-        url: "/org/create/billing?orgScope=org-915001&human_name=Bob%27s%20Org%20Is%20Cool&new-user=bigco",
+        url: "/org/create/billing?orgScope=org-915001&human-name=Bob%27s%20Org%20Is%20Cool&new-user=bigco",
         method: "GET",
         credentials: fixtures.users.bob
       };

--- a/test/handlers/org.js
+++ b/test/handlers/org.js
@@ -305,7 +305,7 @@ describe('getting an org', function() {
     });
   });
 
-  it('passes fullname attribute if human_name is set', function(done) {
+  it('passes human_name attribute if human_name is set', function(done) {
     var userMock = nock("https://user-api-example.com")
       .get("/user/bob")
       .reply(200, fixtures.users.bob);
@@ -335,12 +335,12 @@ describe('getting an org', function() {
       licenseMock.done();
       orgMock.done();
       expect(resp.request.response.source.context.org.info.name).to.equal("bigco");
-      expect(resp.request.response.source.context.org.info.fullname).to.equal("BigCo Enterprises");
+      expect(resp.request.response.source.context.org.info.human_name).to.equal("BigCo Enterprises");
       done();
     });
   });
 
-  it('passes fullname attribute as scope name if human_name is not set', function(done) {
+  it('passes human_name attribute as scope name if human_name is not set', function(done) {
     var userMock = nock("https://user-api-example.com")
       .get("/user/bob")
       .reply(200, fixtures.users.bob);
@@ -377,7 +377,7 @@ describe('getting an org', function() {
       licenseMock.done();
       orgMock.done();
       expect(resp.request.response.source.context.org.info.name).to.equal("bigco");
-      expect(resp.request.response.source.context.org.info.fullname).to.equal("bigco");
+      expect(resp.request.response.source.context.org.info.human_name).to.equal("bigco");
       done();
     });
   });
@@ -400,7 +400,7 @@ describe('creating an org', function() {
         .reply(200, fixtures.packages.fake);
 
       var options = {
-        url: "/org/create-validation?orgScope=bigco&fullname=Bob's big co",
+        url: "/org/create-validation?orgScope=bigco&human_name=Bob's big co",
         method: "GET",
         credentials: fixtures.users.bob
       };
@@ -433,7 +433,7 @@ describe('creating an org', function() {
         .reply(404, fixtures.packages.fake);
 
       var options = {
-        url: "/org/create-validation?orgScope=bigco&fullname=Bob's big co",
+        url: "/org/create-validation?orgScope=bigco&human_name=Bob's big co",
         method: "GET",
         credentials: fixtures.users.bob
       };
@@ -455,7 +455,7 @@ describe('creating an org', function() {
         .reply(200, fixtures.users.bob);
 
       var options = {
-        url: "/org/create-validation?orgScope=bob&fullname=Bob's big co",
+        url: "/org/create-validation?orgScope=bob&human_name=Bob's big co",
         method: "GET",
         credentials: fixtures.users.bob
       };
@@ -476,7 +476,7 @@ describe('creating an org', function() {
         .reply(200, fixtures.users.bob);
 
       var options = {
-        url: "/org/create-validation?orgScope=afdo@;;;383&fullname=Bob's big co",
+        url: "/org/create-validation?orgScope=afdo@;;;383&human_name=Bob's big co",
         method: "GET",
         credentials: fixtures.users.bob
       };
@@ -507,7 +507,7 @@ describe('creating an org', function() {
         .reply(404, fixtures.packages.fake);
 
       var options = {
-        url: "/org/create-validation?orgScope=bigco&fullname=Bob's big co",
+        url: "/org/create-validation?orgScope=bigco&human_name=Bob's big co",
         method: "GET",
         credentials: fixtures.users.bob
       };
@@ -531,7 +531,7 @@ describe('transferring username to org', function() {
         .reply(200, fixtures.users.bob);
 
       var options = {
-        url: "/org/transfer-user-name?fullname=Bob's big co&orgScope=adsjo@ffoo;;",
+        url: "/org/transfer-user-name?human_name=Bob's big co&orgScope=adsjo@ffoo;;",
         method: "GET",
         credentials: fixtures.users.bob
       };
@@ -552,7 +552,7 @@ describe('transferring username to org', function() {
         .reply(200, fixtures.users.bob);
 
       var options = {
-        url: "/org/transfer-user-name?fullname=Bob's big co&orgScope=bob",
+        url: "/org/transfer-user-name?human_name=Bob's big co&orgScope=bob",
         method: "GET",
         credentials: fixtures.users.bob
       };
@@ -572,7 +572,7 @@ describe('transferring username to org', function() {
         .reply(200, fixtures.users.bob);
 
       var options = {
-        url: "/org/create/billing?orgScope=org-915001&fullname=Bob%27s%20Org%20Is%20Cool",
+        url: "/org/create/billing?orgScope=org-915001&human_name=Bob%27s%20Org%20Is%20Cool",
         method: "GET",
         credentials: fixtures.users.bob
       };
@@ -592,7 +592,7 @@ describe('transferring username to org', function() {
         .reply(200, fixtures.users.bob);
 
       var options = {
-        url: "/org/create/billing?orgScope=org-915001&fullname=Bob%27s%20Org%20Is%20Cool&new-user=bigco",
+        url: "/org/create/billing?orgScope=org-915001&human_name=Bob%27s%20Org%20Is%20Cool&new-user=bigco",
         method: "GET",
         credentials: fixtures.users.bob
       };
@@ -612,7 +612,7 @@ describe('transferring username to org', function() {
         .reply(200, fixtures.users.bob);
 
       var options = {
-        url: "/org/create/billing?orgScope=org-915001&fullname=Bob%27s%20Org%20Is%20Cool&new-user=bigco",
+        url: "/org/create/billing?orgScope=org-915001&human_name=Bob%27s%20Org%20Is%20Cool&new-user=bigco",
         method: "GET",
         credentials: fixtures.users.bob
       };


### PR DESCRIPTION
fullname is an optional attribute for an organization that is currently
stored in the user-acl `resource` hstore (as `human_name`) but will eventually become a
column on that model.

Since it is stored as `human_name` on the user-acl, we finesse it a
little along the way.

This updates tests, fixtures, handlers, and the agent