### PR TITLE
Change "node" to "Node.js" ...

### DIFF
--- a/assets/misc/install.sh
+++ b/assets/misc/install.sh
@@ -50,16 +50,16 @@ else
 fi
 export npm_config_loglevel
 
-# make sure that node exists
+# make sure that Node.js exists
 node=`which node 2>&1`
 ret=$?
 if [ $ret -eq 0 ] && [ -x "$node" ]; then
   (exit 0)
 else
-  echo "npm cannot be installed without node.js." >&2
-  echo "Install node first, and then try again." >&2
+  echo "npm cannot be installed without Node.js." >&2
+  echo "Install Node.js first, and then try again." >&2
   echo "" >&2
-  echo "Maybe node is installed, but not in the PATH?" >&2
+  echo "Maybe Node.js is installed, but not in the PATH?" >&2
   echo "Note that running as sudo can change envs." >&2
   echo ""
   echo "PATH=$PATH" >&2
@@ -149,21 +149,21 @@ fi
 node_version=`"$node" --version 2>&1`
 ret=$?
 if [ $ret -ne 0 ]; then
-  echo "You need node to run this program." >&2
+  echo "You need Node.js to run this program." >&2
   echo "node --version reports: $node_version" >&2
   echo "with exit code = $ret" >&2
-  echo "Please install node before continuing." >&2
+  echo "Please install Node.js before continuing." >&2
   exit $ret
 fi
 
 t="${npm_install}"
 if [ -z "$t" ]; then
-  # switch based on node version.
+  # switch based on Node.js version.
   # note that we can only use strict sh-compatible patterns here.
   case $node_version in
     0.[01234567].* | v0.[01234567].*)
       echo "You are using an outdated and unsupported version of" >&2
-      echo "node ($node_version).  Please update node and try again." >&2
+      echo "Node.js ($node_version).  Please update Node.js and try again." >&2
       exit 99
       ;;
     *)

--- a/templates/enterprise/index.hbs
+++ b/templates/enterprise/index.hbs
@@ -42,13 +42,13 @@
 
   <p>npm On-Site is an npm registry that works with the same standard npm client you
   already use, but provides the features needed by larger organizations who
-  are now enthusiastically adopting node. It's built by npm, Inc., the sponsor
+  are now enthusiastically adopting Node.js. It's built by npm, Inc., the sponsor
   of the npm open source project and the host of the public npm registry.</p>
 
   <h3><a name="scoped">Private, scoped modules</a></h3>
 
   <p>Lots of companies using Node.js love the "many small modules" pattern that is
-  part of the Node culture. However, splitting internal applications and private
+  part of the Node.js culture. However, splitting internal applications and private
   code up into small modules has been inconvenient, requiring git dependencies or
   other workarounds to avoid publishing sensitive code to the public registry. npm
   On-Site makes private modules a first-class citizen. Just log in to your

--- a/templates/homepage.hbs
+++ b/templates/homepage.hbs
@@ -1,7 +1,7 @@
 <div class="container">
 
   <div class="centered">
-    <h1>npm is the package manager for <span id="what-npm-is-for">node</span></h1>
+    <h1>npm is the package manager for <span id="what-npm-is-for">node.js</span></h1>
   </div>
 
   <div id="home-stats">
@@ -54,9 +54,9 @@
   <li>
     <h3><a href="https://nodejs.org/en/download/">installing npm</a></h3>
     <p>
-      The npm command-line tool is bundled with <a href="https://nodejs.org/">node</a>. If you have
+      The npm command-line tool is bundled with <a href="https://nodejs.org/">Node.js</a>. If you have
       it installed, then you already have npm too. If not, go download
-      <a href="https://nodejs.org/en/download/">node</a>.
+      <a href="https://nodejs.org/en/download/">Node.js</a>.
     </p>
   </li>
 


### PR DESCRIPTION
We mention __Node.js__ as "__node__" many times in the codebase and we're a bit inconsistent with it, so I chased the instances down. Obviously not a super important PR, but I just thought, "Why not?"

CC: @aredridel, @rockbot, @jefflembeck.