### PR TITLE
Handle 500 delete

### DIFF
--- a/agents/customer.js
+++ b/agents/customer.js
@@ -346,28 +346,30 @@ Customer.prototype.acceptSponsorship = function(verificationKey, callback) {
 Customer.prototype.removeSponsorship = function(npmUser, licenseId, callback) {
   var url = this.host + '/sponsorship/' + licenseId + '/' + npmUser;
 
-  Request.del({
-    url: url,
-    json: true
-  }, function(err, resp, body) {
-    if (err) {
-      callback(err);
-    }
+  return new P(function(accept, reject) {
+    Request.del({
+      url: url,
+      json: true
+    }, function(err, resp, body) {
+      if (err) {
+        return reject(err);
+      }
 
-    if (resp.statusCode === 404) {
-      err = Error('user or licenseId not found');
-      err.statusCode = resp.statusCode;
-      return callback(err);
-    }
+      if (resp.statusCode === 404) {
+        err = Error('user or licenseId not found');
+        err.statusCode = resp.statusCode;
+        return reject(err);
+      }
 
-    if (resp.statusCode >= 400) {
-      err = new Error(body);
-      err.statusCode = resp.statusCode;
-      return callback(err);
-    }
+      if (resp.statusCode >= 400) {
+        err = new Error(body);
+        err.statusCode = resp.statusCode;
+        return reject(err);
+      }
 
-    return callback(null, body);
-  });
+      return accept(body);
+    });
+  }).nodeify(callback);
 };
 
 Customer.prototype.declineSponsorship = Customer.prototype.revokeSponsorship = Customer.prototype.removeSponsorship;

--- a/agents/org.js
+++ b/agents/org.js
@@ -327,11 +327,10 @@ Org.prototype.removeUser = function(name, userId, callback) {
       }
 
       if (resp.statusCode >= 400) {
-        err = new Error(body);
+        err = new Error(removedUser);
         err.statusCode = resp.statusCode;
         return reject(err);
       }
-
 
       return accept(removedUser);
 

--- a/agents/org.js
+++ b/agents/org.js
@@ -306,32 +306,36 @@ Org.prototype.getTeams = function(name, callback) {
 Org.prototype.removeUser = function(name, userId, callback) {
   var url = USER_HOST + '/org/' + name + '/user/' + userId;
 
-  Request.del({
-    url: url,
-    json: true,
-    id: name,
-    userId: userId,
-    headers: {
-      bearer: this.bearer
-    }
-  }, function(err, resp, removedUser) {
-    if (err) {
-      callback(err);
-    }
+  return new P(function(accept, reject) {
+    Request.del({
+      url: url,
+      json: true,
+      id: name,
+      userId: userId,
+      headers: {
+        bearer: this.bearer
+      }
+    }, function(err, resp, removedUser) {
+      if (err) {
+        return reject(err);
+      }
 
-    if (resp.statusCode === 404) {
-      err = Error('org or user not found');
-      err.statusCode = resp.statusCode;
-      return callback(err);
-    }
+      if (resp.statusCode === 404) {
+        err = Error('org or user not found');
+        err.statusCode = resp.statusCode;
+        return reject(err);
+      }
 
-    if (resp.statusCode >= 400) {
-      err = new Error(body);
-      err.statusCode = resp.statusCode;
-      return callback(err);
-    }
+      if (resp.statusCode >= 400) {
+        err = new Error(body);
+        err.statusCode = resp.statusCode;
+        return reject(err);
+      }
 
 
-    return callback(null, removedUser);
-  });
+      return accept(removedUser);
+
+    });
+  }.bind(this)).nodeify(callback);
+
 };

--- a/agents/org.js
+++ b/agents/org.js
@@ -305,6 +305,7 @@ Org.prototype.getTeams = function(name, callback) {
 
 Org.prototype.removeUser = function(name, userId, callback) {
   var url = USER_HOST + '/org/' + name + '/user/' + userId;
+  var self = this;
 
   return new P(function(accept, reject) {
     Request.del({
@@ -313,7 +314,7 @@ Org.prototype.removeUser = function(name, userId, callback) {
       id: name,
       userId: userId,
       headers: {
-        bearer: this.bearer
+        bearer: self.bearer
       }
     }, function(err, resp, removedUser) {
       if (err) {
@@ -335,6 +336,6 @@ Org.prototype.removeUser = function(name, userId, callback) {
       return accept(removedUser);
 
     });
-  }.bind(this)).nodeify(callback);
+  }).nodeify(callback);
 
 };

--- a/handlers/org.js
+++ b/handlers/org.js
@@ -139,6 +139,7 @@ exports.removeUserFromOrg = function(request, reply) {
     })
     .catch(function(err) {
       if (err.statusCode >= 500) {
+        request.logger.error(err);
         return reply.view('errors/internal', err);
       } else {
         return request.saveNotifications([

--- a/handlers/org.js
+++ b/handlers/org.js
@@ -138,8 +138,8 @@ exports.removeUserFromOrg = function(request, reply) {
       return reply.redirect('/org/' + orgName);
     })
     .catch(function(err) {
-      if (err.statusCode === 500) {
-        return reply.view('errors/internal', err).statusCode(500);
+      if (err.statusCode >= 500) {
+        return reply.view('errors/internal', err);
       } else {
         return request.saveNotifications([
           P.reject(err.message)

--- a/test/handlers/org.js
+++ b/test/handlers/org.js
@@ -1043,9 +1043,24 @@ describe('updating an org', function() {
         server.inject(options, function(resp) {
           userMock.done();
           licenseMock.done();
-          expect(resp.statusCode).to.equal(404);
-          expect(resp.request.response.source.template).to.equal('errors/internal');
-          done();
+          var redirectPath = resp.headers.location;
+          var url = URL.parse(redirectPath);
+          var query = url.query;
+          var token = qs.parse(query).notice;
+          var tokenFacilitator = new TokenFacilitator({
+            redis: client
+          });
+          expect(token).to.be.string();
+          expect(token).to.not.be.empty();
+          expect(resp.statusCode).to.equal(302);
+          tokenFacilitator.read(token, {
+            prefix: "notice:"
+          }, function(err, notice) {
+            expect(err).to.not.exist();
+            expect(notice.notices).to.be.array();
+            expect(notice.notices[0]).to.equal('No org with that name exists');
+            done();
+          });
         });
       });
     });
@@ -1082,9 +1097,24 @@ describe('updating an org', function() {
         server.inject(options, function(resp) {
           userMock.done();
           licenseMock.done();
-          expect(resp.statusCode).to.equal(404);
-          expect(resp.request.response.source.template).to.equal('errors/internal');
-          done();
+          var redirectPath = resp.headers.location;
+          var url = URL.parse(redirectPath);
+          var query = url.query;
+          var token = qs.parse(query).notice;
+          var tokenFacilitator = new TokenFacilitator({
+            redis: client
+          });
+          expect(token).to.be.string();
+          expect(token).to.not.be.empty();
+          expect(resp.statusCode).to.equal(302);
+          tokenFacilitator.read(token, {
+            prefix: "notice:"
+          }, function(err, notice) {
+            expect(err).to.not.exist();
+            expect(notice.notices).to.be.array();
+            expect(notice.notices[0]).to.equal('user or licenseId not found');
+            done();
+          });
         });
       });
     });
@@ -1135,9 +1165,24 @@ describe('updating an org', function() {
           userMock.done();
           licenseMock.done();
           orgMock.done();
-          expect(resp.statusCode).to.equal(404);
-          expect(resp.request.response.source.template).to.equal('errors/internal');
-          done();
+          var redirectPath = resp.headers.location;
+          var url = URL.parse(redirectPath);
+          var query = url.query;
+          var token = qs.parse(query).notice;
+          var tokenFacilitator = new TokenFacilitator({
+            redis: client
+          });
+          expect(token).to.be.string();
+          expect(token).to.not.be.empty();
+          expect(resp.statusCode).to.equal(302);
+          tokenFacilitator.read(token, {
+            prefix: "notice:"
+          }, function(err, notice) {
+            expect(err).to.not.exist();
+            expect(notice.notices).to.be.array();
+            expect(notice.notices[0]).to.equal('org or user not found');
+            done();
+          });
         });
       });
     });
@@ -1149,8 +1194,6 @@ describe('updating an org', function() {
           .reply(200, fixtures.users.bob);
 
         var licenseMock = nock("https://license-api-example.com")
-          .get("/customer/bob@boom.me")
-          .reply(200, fixtures.customers.fetched_happy)
           .get("/customer/bob/stripe/subscription")
           .reply(200, fixtures.users.bobsubscriptions)
           .delete("/sponsorship/1/betty")
@@ -1174,15 +1217,6 @@ describe('updating an org', function() {
             "role": "developer",
             "updated": "2015-08-05T15:26:46.970Z",
             "user_id": 15
-          })
-          .get("/org/bigco")
-          .reply(200, fixtures.orgs.bigco)
-          .get("/org/bigco/user")
-          .reply(200, fixtures.orgs.bigcoAddedUsers)
-          .get('/org/bigco/package')
-          .reply(200, {
-            count: 1,
-            items: [fixtures.packages.fake]
           });
 
         var options = {
@@ -1204,8 +1238,8 @@ describe('updating an org', function() {
           userMock.done();
           licenseMock.done();
           orgMock.done();
-          expect(resp.statusCode).to.equal(200);
-          expect(resp.request.response.source.template).to.equal('org/info');
+          expect(resp.statusCode).to.equal(302);
+          expect(resp.headers.location).to.equal('/org/bigco');
           done();
         });
       });


### PR DESCRIPTION
We've got a 500 on production and it needs handling.

This change involved some serious promisifying of our handler, so I could better track the errors - 4xx errors are now displayed as notices while 5xx errors are sent to an internal page.

Test added for 500.