### PR TITLE
Only make a metrics emitter if there is config asking for one.

### DIFF
--- a/adapters/metrics.js
+++ b/adapters/metrics.js
@@ -1,19 +1,27 @@
-var assert = require('assert'),
-  Emitter = require('numbat-emitter'),
+var Emitter = require('numbat-emitter'),
   os = require('os'),
   emitter;
 
-var metrics = module.exports = function constructEmitter(app) {
-  if (emitter) return emitter;
+module.exports = function constructEmitter(app) {
+  if (emitter) {
+    return emitter;
+  }
 
-  emitter = new Emitter({
-    uri: process.env.METRICS_URL || 'udp://localhost:3333',
-    node: os.hostname(),
-    app:app, // optional.
-  });
-
-  // add port field to defaults to distinguish between multiple workers
-  emitter.defaults.port = (process.env.PORT||'0')
+  if (!process.env.METRICS_URL) {
+    emitter = new StubMetricsEmitter();
+  }
+  else {
+    emitter = new Emitter({
+      uri: process.env.METRICS_URL,
+      node: os.hostname(),
+      app:app, // optional.
+    });
+    // add port field to defaults to distinguish between multiple workers
+    emitter.defaults.port = (process.env.PORT||'0');
+  }
 
   return emitter;
 };
+
+function StubMetricsEmitter() {}
+StubMetricsEmitter.prototype.metric = function() {};


### PR DESCRIPTION
If process.env.METRICS_URL is set, we make a real emitter. Otherwise, we make a stub that does nothing when called. This allows us to change the configuration in production by changing settings in etcd, without having to change code. It also allows us to not try to connect to a non-existent metrics collector in dev or test.

To get metrics flowing in production again, we'll need to accompany this change with

`renv config set -e production -a newww service.env.METRICS_URL=whatever`