### PR TITLE
Link to terms of use first in "Legal Stuff" footer

### DIFF
--- a/templates/layouts/default.hbs
+++ b/templates/layouts/default.hbs
@@ -178,9 +178,9 @@
           <li>
             <h3>Legal Stuff</h3>
             <ul class="links">
+              <li><a href="/policies/terms">Terms of Use</a></li>
               <li><a href="/policies/conduct">Code of Conduct</a></li>
               <li><a href="/policies/disputes">Package Name Disputes</a></li>
-              <li><a href="/policies/npm-license">npm License</a></li>
               <li><a href="/policies/privacy">Privacy Policy</a></li>
               <li><a href="/policies/receiving-reports">Reporting Abuse</a></li>
               <li><a href="/policies/">Other policies</a></li>


### PR DESCRIPTION
This PR follows on from npm/policies#16 and npm/npm#10326 with a small
change to the "Legal Stuff" footer. Long story short, it makes the top
link to "Terms of Use" and <https://wwww.npmjs.com/policies/terms>,
which corresponds to a new `terms.md` file in npm/policies. That file in
turn links to terms of use for npm Open Source, npm Personal, and the
CLI LICENSE.

Longer term, npm can add terms for specific products to npm/policies and
link to them from /terms without creating a massive list of terms at the
bottom of each page on newww.