### PR TITLE
Updated the "boom" dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "blankie": "^1.1.0",
     "bluebird": "^2.10.2",
     "bole": "~1.0.0",
-    "boom": "^2.9.0",
+    "boom": "^3.0.0",
     "catbox-redis": "^1.0.6",
     "cheerio": "^0.17.0",
     "chunk": "0.0.2",


### PR DESCRIPTION
__Note:__ We can't merge this to master until #1465 is merged. (`boom` requires __Node.js v4.0+__.)

Edit: I should probably rebase to the Node.js 4 update branch.