### PR TITLE
adds missing detail to team package page (fixes #1520)

### DIFF
--- a/handlers/team.js
+++ b/handlers/team.js
@@ -180,7 +180,8 @@ exports.showTeam = function(request, reply) {
       return Team(loggedInUser)
         .get({
           orgScope: orgName,
-          teamName: teamName
+          teamName: teamName,
+          detailed: true
         });
 
     })
@@ -188,6 +189,10 @@ exports.showTeam = function(request, reply) {
       team.packages.items.forEach(function(pkg) {
         if (pkg.permissions === 'write') {
           pkg.canWrite = true;
+        }
+
+        if(pkg.access === 'restricted') {
+          pkg.private = true;
         }
       });
 

--- a/templates/team/show.hbs
+++ b/templates/team/show.hbs
@@ -35,7 +35,7 @@
               package name
             </th>
             <th>author</th>
-            <th>date added</th>
+            <th>last published</th>
             {{#if perms.isAtLeastTeamAdmin }}
             <th>access</th>
             <th>action</th>
@@ -52,11 +52,16 @@
                 {{/if}}
                 <span class="name">
                   <a class="packagename" href="/package/{{name}}">{{name}}</a>
+                  {{#if version}}<strong>&nbsp;(v{{version}})</strong>{{/if}}
                 </span><!--/.name-->
               </div>
             </td>
-            <td>author</td>
-            <td>date</td>
+            <td><a href="/~{{publisher.name}}">{{publisher.name}}</a></td>
+            <td>
+              <span data-date="{{lastPublishedAt}}" data-date-format="relative">
+                {{lastPublishedAt}}
+              </span>
+            </td>
             {{#if ../../perms.isAtLeastTeamAdmin }}
             <td>
               <div class="collapsible-wrapper">

--- a/test/handlers/team.js
+++ b/test/handlers/team.js
@@ -646,7 +646,7 @@ describe('team', function() {
         .reply(404)
         .get('/team/bigco/bigcoteam/user')
         .reply(404)
-        .get('/team/bigco/bigcoteam/package?format=mini')
+        .get('/team/bigco/bigcoteam/package?format=detailed')
         .reply(404);
 
       var options = {
@@ -690,7 +690,7 @@ describe('team', function() {
         .reply(200, fixtures.teams.bigcoteam)
         .get('/team/bigco/bigcoteam/user')
         .reply(200, fixtures.teams.bigcoteamUsers)
-        .get('/team/bigco/bigcoteam/package?format=mini')
+        .get('/team/bigco/bigcoteam/package?format=detailed')
         .reply(200, fixtures.teams.bigcoteamPackages);
 
       var options = {
@@ -1513,7 +1513,7 @@ describe('team', function() {
         .reply(200, fixtures.teams.bigcoteam)
         .get('/team/bigco/bigcoteam/user')
         .reply(200, fixtures.teams.bigcoteamUsers)
-        .get('/team/bigco/bigcoteam/package?format=mini')
+        .get('/team/bigco/bigcoteam/package?format=detailed')
         .reply(200, fixtures.teams.bigcoteamPackages);
 
       var options = {


### PR DESCRIPTION
Now it looks like this: <img width="1133" alt="screen shot 2015-11-19 at 11 11 34 am" src="https://cloud.githubusercontent.com/assets/954269/11281195/5db6b1a2-8eae-11e5-8f5c-59d60fda32c8.png">

(Note if we're missing data, we're just showing a blank entry.. that may very well be that my one package is broken though - everything else seems to be just fine.)