### PR TITLE
adds roles of users to org member page (fixes #1556)

### DIFF
--- a/templates/org/members.hbs
+++ b/templates/org/members.hbs
@@ -25,10 +25,11 @@
       <table class="org-table org-users org-edit-user-table">
         <thead>
           <tr>
-            <th>Collaborators</th>
+            <th>collaborators</th>
+            <th>role</th>
             {{#if perms.isSuperAdmin}}
-            <th>Status</th>
-            <th>Action</th>
+            <th>status</th>
+            <th>action</th>
             {{/if}}
           </tr>
         </thead>
@@ -48,6 +49,7 @@
                   </span><!--/.name-->
                 </div>
               </td>
+              <td>{{role}}</td>
             {{#if ../perms.isSuperAdmin}}
               <td>
                 <div class="collapsible-wrapper">

--- a/templates/team/show.hbs
+++ b/templates/team/show.hbs
@@ -115,10 +115,9 @@
       <table class="org-table org-users">
         <thead>
           <tr>
-            <th>avatar</th>
+            <th></th>
             <th>member name</th>
             <th>role</th>
-            <th>date added</th>
             {{#if perms.isAtLeastTeamAdmin }}
             <th>status</th>
             <th>action</th>
@@ -141,7 +140,6 @@
               </div>
             </td>
             <td>{{role}}</td>
-            <td>date added</td>
             {{#if ../perms.isAtLeastTeamAdmin }}
             <td>{{#if ../sponsored}}active{{else}}inactive{{/if}}</td>
             <td>


### PR DESCRIPTION
also removes the `date added` column (which was filled with just "date" because we don't actually have that data).