### PR TITLE
disables ability to remove super admin from an org (fixes #1564)

### DIFF
--- a/handlers/org.js
+++ b/handlers/org.js
@@ -50,11 +50,12 @@ exports.getOrg = function(request, reply) {
         return user;
       });
 
-
       var isSuperAdmin = org.users.items.filter(function(user) {
         return user.role && user.role.match(/super-admin/);
       }).some(function(admin) {
-        return admin.name === loggedInUser;
+        var isSA = admin.name === loggedInUser;
+        admin.isTheSuperAdmin = isSA;
+        return isSA;
       });
 
       var isAtLeastTeamAdmin = org.users.items.filter(function(user) {

--- a/templates/org/members.hbs
+++ b/templates/org/members.hbs
@@ -69,6 +69,7 @@
                 </form>
               </td>
               <td>
+                {{#unless isTheSuperAdmin}}
                   <form method="POST" id="org-user-delete-overview-{{@index}}" action="/org/{{../../org.info.name}}">
                     {{#with ../../this}}
                     {{> form_security }}
@@ -76,7 +77,8 @@
                     <input type="hidden" name="username" value="{{name}}" />
                     <input type="hidden" name="updateType" value="deleteUser" />
                     <button type="submit" class="delete-user icon-x"><span class="a11y-only">Delete User {{name}}</span></button>
-                </form>
+                  </form>
+                {{/unless}}
               </td>
               {{/if}}
             </tr>


### PR DESCRIPTION
basically makes this happen: 

![screen shot 2015-11-24 at 4 19 04 pm](https://cloud.githubusercontent.com/assets/954269/11384724/1d0290b4-92c7-11e5-930e-570cf47318b9.png)

it's not much, and until a fix is made in the user-acl, a super admin can still delete themselves via the cli.

thoughts? cc @seldo, @chrisdickinson, @ncawthon 