### PR TITLE
allows unpaid super-admin to still access org

### DIFF
--- a/handlers/org.js
+++ b/handlers/org.js
@@ -81,7 +81,7 @@ exports.getOrg = function(request, reply) {
     .then(function(opts) {
 
       if (!opts.perms.isSuperAdmin) {
-        return P.resolve(null);
+        return null;
       }
 
       return request.customer.getById(request.loggedInUser.email)

--- a/handlers/org.js
+++ b/handlers/org.js
@@ -84,16 +84,11 @@ exports.getOrg = function(request, reply) {
         return P.resolve(null);
       }
 
-      request.customer.getById(request.loggedInUser.email)
-        .then(function(cust) {
-          return P.resolve(cust);
-        })
+      return request.customer.getById(request.loggedInUser.email)
         .catch(function(err) {
-          if (err.statusCode === '404') {
-            return P.resolve(null);
-          } else {
-            return P.reject(err);
-          }
+          return Number(err.statusCode) === 404;
+        }, function(err) {
+          return null;
         });
     })
     .then(function(cust) {

--- a/handlers/org.js
+++ b/handlers/org.js
@@ -70,7 +70,6 @@ exports.getOrg = function(request, reply) {
         return member.name === loggedInUser;
       });
 
-
       opts.perms = {
         isSuperAdmin: isSuperAdmin,
         isAtLeastTeamAdmin: isAtLeastTeamAdmin,
@@ -80,9 +79,22 @@ exports.getOrg = function(request, reply) {
       return opts;
     })
     .then(function(opts) {
-      return opts.perms.isSuperAdmin ?
-        request.customer.getById(request.loggedInUser.email)
-        : P.resolve(null);
+
+      if (!opts.perms.isSuperAdmin) {
+        return P.resolve(null);
+      }
+
+      request.customer.getById(request.loggedInUser.email)
+        .then(function(cust) {
+          return P.resolve(cust);
+        })
+        .catch(function(err) {
+          if (err.statusCode === '404') {
+            return P.resolve(null);
+          } else {
+            return P.reject(err);
+          }
+        });
     })
     .then(function(cust) {
       cust = cust || {};


### PR DESCRIPTION
users who are unpaid super-admins (for whatever reason) are unable to access the org page. this PR fixes that.

That said, we've got the following issues:
1) this PR doesn't necessarily prevent unpaid super-admins from at least attempting to add/remove users. What do we do about that?

2) I'm not sure that this is the best way to use promises for what we want to achieve. In particular, the tests will pass, but the following will pop up as well: 
```shell
Unhandled rejection Error: Customer not found
  at Error (<anonymous>:null:null)
  at /Users/rockbot/npm-inc/newww/agents/customer.js:38:15
  at Request._callback (/Users/rockbot/npm-inc/newww/lib/external-request.js:38:12)
  at Request.self.callback (/Users/rockbot/npm-inc/newww/node_modules/request/request.js:198:22)
  at Request.emit (events.js:98:17)
  at Request.<anonymous> (/Users/rockbot/npm-inc/newww/node_modules/request/request.js:1082:10)
  at Request.emit (events.js:117:20)
  at OutgoingMessage.<anonymous> (/Users/rockbot/npm-inc/newww/node_modules/request/request.js:1009:12)
  at OutgoingMessage.emit (events.js:117:20)
  at /Users/rockbot/npm-inc/newww/node_modules/nock/lib/request_overrider.js:483:20
  at Object._onImmediate (/Users/rockbot/npm-inc/newww/node_modules/nock/lib/request_overrider.js:502:11)
  at processImmediate [as _immediateCallback] (timers.js:363:15)
```

Thoughts?