### PR TITLE
Fix broken package test

### DIFF
--- a/adapters/metrics.js
+++ b/adapters/metrics.js
@@ -8,8 +8,7 @@ module.exports = function constructEmitter() {
 
   if (!process.env.METRICS_URL) {
     emitter = new StubMetricsEmitter();
-  }
-  else {
+  } else {
     emitter = new Emitter({
       uri: process.env.METRICS_URL,
       app: 'newww',
@@ -20,5 +19,6 @@ module.exports = function constructEmitter() {
   return emitter;
 };
 
-function StubMetricsEmitter() {}
+function StubMetricsEmitter() {
+}
 StubMetricsEmitter.prototype.metric = function() {};

--- a/agents/team.js
+++ b/agents/team.js
@@ -199,7 +199,7 @@ Team.prototype.addPackage = function(opts) {
 
 Team.prototype.addPackages = function(opts) {
   opts = opts || {};
-  var packages = (opts.packages || []).map(function (xs) {
+  var packages = (opts.packages || []).map(function(xs) {
     return {
       name: xs.name,
       permissions: xs.permissions
@@ -215,14 +215,16 @@ Team.prototype.addPackages = function(opts) {
     headers: {
       bearer: this.bearer
     }
-  }).spread(function (resp, body) {
+  }).spread(function(resp, body) {
     if (resp.statusCode >= 400) {
       throw _.extend(new Error(
         resp.statusCode === 400 ? body.error :
-        resp.statusCode === 401 ? 'user is unauthorized to perform this action' :
-        resp.statusCode === 404 ? 'Team or Org not found' :
-        body.error
-      ), {statusCode: resp.statusCode});
+          resp.statusCode === 401 ? 'user is unauthorized to perform this action' :
+            resp.statusCode === 404 ? 'Team or Org not found' :
+              body.error
+      ), {
+        statusCode: resp.statusCode
+      });
     }
     return body;
   })

--- a/assets/scripts/add-packages-to-teams.js
+++ b/assets/scripts/add-packages-to-teams.js
@@ -105,8 +105,8 @@ AddPackageForm.prototype.addPackages = function(packages) {
   this.updatePackageCount();
 };
 
-AddPackageForm.prototype.addPackage = function (package) {
-  var pkg = template(package);
+AddPackageForm.prototype.addPackage = function(pack) {
+  var pkg = template(pack);
   this.pkgsList.append(pkg);
   this.packageCount += 1;
   this.updatePackageCount();
@@ -171,7 +171,7 @@ module.exports = function() {
           });
       });
 
-      auf.personalSelect.on("change", function () {
+      auf.personalSelect.on("change", function() {
         var packageName = this.options[this.selectedIndex].value;
         if (packageName === "_none_") {
           return;

--- a/handlers/team.js
+++ b/handlers/team.js
@@ -191,7 +191,7 @@ exports.showTeam = function(request, reply) {
           pkg.canWrite = true;
         }
 
-        if(pkg.access === 'restricted') {
+        if (pkg.access === 'restricted') {
           pkg.private = true;
         }
       });

--- a/test/agents/team.js
+++ b/test/agents/team.js
@@ -3,13 +3,36 @@ var Code = require('code'),
   lab = exports.lab = Lab.script(),
   describe = lab.experiment,
   it = lab.test,
+  afterEach = lab.afterEach,
   expect = Code.expect,
   nock = require('nock'),
   fixtures = require('../fixtures');
 
 var Team = require('../../agents/team');
 
+var rejectionMap = {};
+
+process.on('unhandledRejection', function(reason, promise) {
+  rejectionMap[promise] = reason;
+});
+
+process.on('rejectionHandled', function(promise) {
+  delete rejectionMap[promise]
+  ;
+});
+
 describe('Team', function() {
+  afterEach(function(done) {
+    while (process.domain) {
+      process.domain.exit();
+    }
+    for (var xs in rejectionMap) {
+      if (rejectionMap.hasOwnProperty(xs)) {
+        throw rejectionMap[xs];
+      }
+    }
+    done();
+  });
   it('throws if no bearer is passed', function(done) {
     expect(function() {
       return Team();

--- a/test/agents/team.js
+++ b/test/agents/team.js
@@ -388,7 +388,7 @@ describe('Team', function() {
         }).catch(function(err) {
           expect(err).to.exist();
           // i'd like this to show _all_ of the errors, not just the first one.
-          expect(err.message).to.equal('Team or Org or not found');
+          expect(err.message).to.equal('Team or Org not found');
           expect(err.statusCode).to.equal(404);
         }).then(function(packages) {
           expect(packages).to.not.exist();

--- a/test/feature-flags.js
+++ b/test/feature-flags.js
@@ -72,7 +72,8 @@ describe('feature flags', function() {
   afterEach(function(done) {
     Object.keys(process.env).forEach(function(key) {
       if (key.match(/^FEATURE_/i)) {
-        delete process.env[key];
+        delete process.env[key]
+        ;
       }
     });
     done();


### PR DESCRIPTION
These changes came about because there was a failing test, but it wasn't failing when we ran the tests, despite a "failing" print out.

This happens when a test fails inside of a `catch` block.

[One](https://github.com/npm/newww/commit/796890374350a3ff5c6e4ddfdd77949c71962ad8): the formatter had a thing or two to say about our code at the time, so I made sure to run it before making other changes.

[Two](https://github.com/npm/newww/commit/1303e2e8ae432734e22179457dfeb9a42a6c72f8): Fixed the failing test

[Three](https://github.com/npm/newww/commit/2466fe307a2a9148844c9677ebff503f41e0cf87): Make sure this doesn't happen again. Now tests that fail in the `catch` blocks will stop the test runner

The problem with change three is that it's a global change. We should talk about where that goes.