### PR TITLE
Add view team members

### DIFF
--- a/agents/org.js
+++ b/agents/org.js
@@ -71,7 +71,6 @@ Org.prototype.get = function(name, callback) {
 
   var self = this;
   var orgUrl = USER_HOST + '/org/' + name;
-  var userUrl = USER_HOST + '/org/' + name + '/user';
   var packageUrl = USER_HOST + '/org/' + name + '/package';
 
   var makeRequest = function(url) {
@@ -107,7 +106,7 @@ Org.prototype.get = function(name, callback) {
 
   var requests = [
     makeRequest(orgUrl),
-    makeRequest(userUrl),
+    this.getUsers(name),
     makeRequest(packageUrl),
     this.getTeams(name)
   ];
@@ -251,10 +250,15 @@ Org.prototype.addUser = function(name, user, callback) {
   }).nodeify(callback);
 };
 
-Org.prototype.getUsers = function(name, callback) {
+Org.prototype.getUsers = function(name, page) {
   assert(_.isString(name), "name must be a string");
 
+  if (typeof page === 'undefined') {
+    page = 0;
+  }
+
   var url = USER_HOST + '/org/' + name + '/user';
+  var PER_PAGE = 100;
 
   return new P(function(accept, reject) {
     return Request.get({
@@ -263,6 +267,10 @@ Org.prototype.getUsers = function(name, callback) {
       headers: {
         bearer: this.bearer
       },
+      qs: {
+        per_page: PER_PAGE,
+        page: page
+      }
     }, function(err, resp, users) {
       if (err) {
         reject(err);
@@ -282,7 +290,7 @@ Org.prototype.getUsers = function(name, callback) {
 
       return accept(users);
     });
-  }).nodeify(callback);
+  });
 
 };
 

--- a/test/agents/org.js
+++ b/test/agents/org.js
@@ -104,7 +104,7 @@ describe('Org', function() {
           'updated': '2015-06-19T23:35:42.659Z',
           'deleted': null
         })
-        .get('/org/' + name + '/user')
+        .get('/org/' + name + '/user?per_page=100&page=0')
         .reply(200, {
           'count': 1,
           'items': [fixtures.users.bigcoadmin]
@@ -140,7 +140,7 @@ describe('Org', function() {
           'updated': '2015-06-19T23:35:42.659Z',
           'deleted': null
         })
-        .get('/org/' + name + '/user')
+        .get('/org/' + name + '/user?per_page=100&page=0')
         .reply(200, {
           'count': 1,
           'items': [fixtures.users.bigcoadmin]
@@ -183,7 +183,7 @@ describe('Org', function() {
       var orgMocks = nock('https://user-api-example.com')
         .get('/org/' + name)
         .reply(404, 'not found')
-        .get('/org/' + name + '/user')
+        .get('/org/' + name + '/user?per_page=100&page=0')
         .reply(404, 'not found')
         .get('/org/' + name + '/package')
         .reply(404, 'not found')
@@ -427,37 +427,43 @@ describe('Org', function() {
       var name = 'bigco';
 
       var orgMocks = nock('https://user-api-example.com')
-        .get('/org/' + name + '/user')
+        .get('/org/' + name + '/user?per_page=100&page=0')
         .reply(200, {
           "count": 1,
           "items": [fixtures.users.bigcoadmin]
         });
 
-      Org('bob').getUsers(name, function(err, users) {
-        orgMocks.done();
-        expect(err).to.be.null();
-        expect(users.items).to.be.an.array();
-        expect(users.count).to.equal(1);
-        expect(users.items[0].name).to.equal('bob');
-        done();
-      });
+      Org('bob').getUsers(name)
+        .catch(function(err) {
+          orgMocks.done();
+          expect(err).to.be.null();
+        })
+        .then(function(users) {
+          expect(users.items).to.be.an.array();
+          expect(users.count).to.equal(1);
+          expect(users.items[0].name).to.equal('bob');
+          done();
+        });
     });
 
     it('returns no users if the org does not exist', function(done) {
       var name = 'bigco';
 
       var orgMocks = nock('https://user-api-example.com')
-        .get('/org/' + name + '/user')
+        .get('/org/' + name + '/user?per_page=100&page=0')
         .reply(404, 'Org not found');
 
-      Org('bob').getUsers(name, function(err, users) {
-        orgMocks.done();
-        expect(err).to.exist();
-        expect(err.message).to.equal('org not found');
-        expect(err.statusCode).to.equal(404);
-        expect(users).to.not.exist();
-        done();
-      });
+      Org('bob').getUsers(name)
+        .catch(function(err) {
+          orgMocks.done();
+          expect(err).to.exist();
+          expect(err.message).to.equal('org not found');
+          expect(err.statusCode).to.equal(404);
+        })
+        .then(function(users) {
+          expect(users).to.not.exist();
+          done();
+        });
     });
   });
 

--- a/test/handlers/customer.js
+++ b/test/handlers/customer.js
@@ -930,7 +930,7 @@ describe("subscribing to an org", function() {
       var orgMock = nock("https://user-api-example.com")
         .get("/org/boomer")
         .reply(404, "not found")
-        .get("/org/boomer/user")
+        .get("/org/boomer/user?per_page=100&page=0")
         .reply(404, "not found")
         .get("/org/boomer/package")
         .reply(404, "not found")
@@ -1032,7 +1032,7 @@ describe("subscribing to an org", function() {
           "updated": "2015-07-10T21:07:16.799Z",
           "deleted": null
         })
-        .get("/org/boomer/user")
+        .get("/org/boomer/user?per_page=100&page=0")
         .reply(200, {
           "count": 1,
           "items": [fixtures.users.bob]
@@ -1204,7 +1204,7 @@ describe("subscribing to an org", function() {
       var orgMock = nock("https://user-api-example.com")
         .get("/org/bob")
         .reply(404, "not found")
-        .get("/org/bob/user")
+        .get("/org/bob/user?per_page=100&page=0")
         .reply(404, "not found")
         .get("/org/bob/package")
         .reply(404, "not found")

--- a/test/handlers/org.js
+++ b/test/handlers/org.js
@@ -172,7 +172,7 @@ describe('getting an org', function() {
     var orgMock = nock("https://user-api-example.com")
       .get('/org/bigco')
       .reply(200, fixtures.orgs.bigco)
-      .get('/org/bigco/user')
+      .get('/org/bigco/user?per_page=100&page=0')
       .reply(200, fixtures.orgs.bigcoUsers)
       .get('/org/bigco/package')
       .reply(200, {
@@ -215,7 +215,7 @@ describe('getting an org', function() {
     var orgMock = nock("https://user-api-example.com")
       .get('/org/bigco')
       .reply(200, fixtures.orgs.bigco)
-      .get('/org/bigco/user')
+      .get('/org/bigco/user?per_page=100&page=0')
       .reply(200, fixtures.orgs.bigcoAddedUsers)
       .get('/org/bigco/package')
       .reply(200, {
@@ -258,7 +258,7 @@ describe('getting an org', function() {
     var orgMock = nock("https://user-api-example.com")
       .get("/org/bigconotthere")
       .reply(404)
-      .get("/org/bigconotthere/user")
+      .get("/org/bigconotthere/user?per_page=100&page=0")
       .reply(404)
       .get("/org/bigconotthere/package")
       .reply(404)
@@ -310,7 +310,7 @@ describe('getting an org', function() {
     var orgMock = nock("https://user-api-example.com")
       .get('/org/bigco')
       .reply(200, fixtures.orgs.bigco)
-      .get('/org/bigco/user')
+      .get('/org/bigco/user?per_page=100&page=0')
       .reply(200, fixtures.orgs.bigcoUsers)
       .get('/org/bigco/package')
       .reply(200, {
@@ -350,7 +350,7 @@ describe('getting an org', function() {
       var orgMock = nock("https://user-api-example.com")
         .get('/org/notbobsorg')
         .reply(200, fixtures.orgs.notBobsOrg)
-        .get('/org/notbobsorg/user')
+        .get('/org/notbobsorg/user?per_page=100&page=0')
         .reply(200, fixtures.orgs.notBobsOrgUsers)
         .get('/org/notbobsorg/package')
         .reply(200, {
@@ -390,7 +390,7 @@ describe('getting an org', function() {
       var orgMock = nock("https://user-api-example.com")
         .get('/org/bigco')
         .reply(200, fixtures.orgs.bigco)
-        .get('/org/bigco/user')
+        .get('/org/bigco/user?per_page=100&page=0')
         .reply(200, fixtures.orgs.bigcoUsers)
         .get('/org/bigco/package')
         .reply(200, {
@@ -429,7 +429,7 @@ describe('getting an org', function() {
       var orgMock = nock("https://user-api-example.com")
         .get('/org/bigco')
         .reply(200, fixtures.orgs.bigco)
-        .get('/org/bigco/user')
+        .get('/org/bigco/user?per_page=100&page=0')
         .reply(200, fixtures.orgs.bigcoAddedUsers)
         .get('/org/bigco/package')
         .reply(200, {
@@ -467,7 +467,7 @@ describe('getting an org', function() {
       var orgMock = nock("https://user-api-example.com")
         .get('/org/bigco')
         .reply(200, fixtures.orgs.bigco)
-        .get('/org/bigco/user')
+        .get('/org/bigco/user?per_page=100&page=0')
         .reply(200, fixtures.orgs.bigcoAddedUsers)
         .get('/org/bigco/package')
         .reply(200, {
@@ -506,7 +506,7 @@ describe('getting an org', function() {
     var orgMock = nock("https://user-api-example.com")
       .get('/org/bigco')
       .reply(200, fixtures.orgs.bigco)
-      .get('/org/bigco/user')
+      .get('/org/bigco/user?per_page=100&page=0')
       .reply(200, fixtures.orgs.bigcoAddedUsers)
       .get('/org/bigco/package')
       .reply(200, {
@@ -550,7 +550,7 @@ describe('getting an org', function() {
         "updated": "2015-07-10T21:07:16.799Z",
         "deleted": null
       })
-      .get('/org/bigco/user')
+      .get('/org/bigco/user?per_page=100&page=0')
       .reply(200, fixtures.orgs.bigcoAddedUsers)
       .get('/org/bigco/package')
       .reply(200, {
@@ -590,7 +590,7 @@ describe('creating an org', function() {
     var orgMock = nock("https://user-api-example.com")
       .get("/org/bigco")
       .reply(200, fixtures.orgs.bigco)
-      .get("/org/bigco/user")
+      .get("/org/bigco/user?per_page=100&page=0")
       .reply(200, fixtures.orgs.bigcoAddedUsers)
       .get("/org/bigco/package")
       .reply(200, fixtures.packages.fake)
@@ -629,7 +629,7 @@ describe('creating an org', function() {
       var orgMock = nock("https://user-api-example.com")
         .get("/org/bigco")
         .reply(404, fixtures.orgs.bigco)
-        .get("/org/bigco/user")
+        .get("/org/bigco/user?per_page=100&page=0")
         .reply(404, fixtures.orgs.bigcoAddedUsers)
         .get("/org/bigco/package")
         .reply(404, fixtures.packages.fake)
@@ -720,7 +720,7 @@ describe('creating an org', function() {
       var orgMock = nock("https://user-api-example.com")
         .get("/org/bigco")
         .reply(404, fixtures.orgs.bigco)
-        .get("/org/bigco/user")
+        .get("/org/bigco/user?per_page=100&page=0")
         .reply(404, fixtures.orgs.bigcoAddedUsers)
         .get("/org/bigco/package")
         .reply(404, fixtures.packages.fake)
@@ -831,7 +831,7 @@ describe('transferring username to org', function() {
         .reply(404)
         .get("/org/bigco")
         .reply(404)
-        .get("/org/bigco/user")
+        .get("/org/bigco/user?per_page=100&page=0")
         .reply(404)
         .get("/org/bigco/package")
         .reply(404);
@@ -864,7 +864,7 @@ describe('transferring username to org', function() {
         // .reply(404)
         .get("/org/bigco")
         .reply(200, fixtures.orgs.bigco)
-        .get("/org/bigco/user")
+        .get("/org/bigco/user?per_page=100&page=0")
         .reply(200, fixtures.orgs.bigcoUsers)
         .get("/org/bigco/package")
         .reply(200, [])
@@ -1776,7 +1776,7 @@ describe('deleting an org', function() {
         .reply(200, fixtures.users.bob);
 
       var orgMock = nock("https://user-api-example.com")
-        .get('/org/bigco/user')
+        .get('/org/bigco/user?per_page=100&page=0')
         .reply(200, fixtures.orgs.bigcoUsers);
 
       var options = {
@@ -1799,7 +1799,7 @@ describe('deleting an org', function() {
         .reply(200, fixtures.users.bob);
 
       var orgMock = nock("https://user-api-example.com")
-        .get('/org/bigco/user')
+        .get('/org/bigco/user?per_page=100&page=0')
         .reply(404);
 
       var options = {
@@ -1822,7 +1822,7 @@ describe('deleting an org', function() {
         .reply(200, fixtures.users.bob);
 
       var orgMock = nock("https://user-api-example.com")
-        .get('/org/bigco/user')
+        .get('/org/bigco/user?per_page=100&page=0')
         .reply(200, fixtures.orgs.bigcoUsers);
 
       var options = {

--- a/test/handlers/team.js
+++ b/test/handlers/team.js
@@ -72,7 +72,7 @@ describe('team', function() {
       var orgMock = nock("https://user-api-example.com")
         .get('/org/bigco')
         .reply(404)
-        .get('/org/bigco/user')
+        .get('/org/bigco/user?per_page=100&page=0')
         .reply(404)
         .get('/org/bigco/package')
         .reply(404)
@@ -106,7 +106,7 @@ describe('team', function() {
       var orgMock = nock("https://user-api-example.com")
         .get('/org/bigco')
         .reply(200, fixtures.orgs.bigco)
-        .get('/org/bigco/user')
+        .get('/org/bigco/user?per_page=100&page=0')
         .reply(200, fixtures.orgs.bigcoUsers)
         .get('/org/bigco/package')
         .reply(200, {
@@ -144,7 +144,7 @@ describe('team', function() {
       var orgMock = nock("https://user-api-example.com")
         .get('/org/bigco')
         .reply(200, fixtures.orgs.bigco)
-        .get('/org/bigco/user')
+        .get('/org/bigco/user?per_page=100&page=0')
         .reply(200, fixtures.orgs.bigcoUsers)
         .get('/org/bigco/package')
         .reply(200, {
@@ -278,7 +278,7 @@ describe('team', function() {
         var orgMock = nock("https://user-api-example.com")
           .get('/org/bigco')
           .reply(404)
-          .get('/org/bigco/user')
+          .get('/org/bigco/user?per_page=100&page=0')
           .reply(404)
           .get('/org/bigco/package')
           .reply(404)
@@ -321,7 +321,7 @@ describe('team', function() {
         var orgMock = nock("https://user-api-example.com")
           .get('/org/bigco')
           .reply(500)
-          .get('/org/bigco/user')
+          .get('/org/bigco/user?per_page=100&page=0')
           .reply(500)
           .get('/org/bigco/package')
           .reply(500)
@@ -364,7 +364,7 @@ describe('team', function() {
       var orgMock = nock("https://user-api-example.com")
         .get('/org/bigco')
         .reply(200, fixtures.orgs.bigco)
-        .get('/org/bigco/user')
+        .get('/org/bigco/user?per_page=100&page=0')
         .reply(200, fixtures.orgs.bigcoUsers)
         .get('/org/bigco/package')
         .reply(200, {
@@ -419,7 +419,7 @@ describe('team', function() {
       var orgMock = nock("https://user-api-example.com")
         .get('/org/bigco')
         .reply(200, fixtures.orgs.bigco)
-        .get('/org/bigco/user')
+        .get('/org/bigco/user?per_page=100&page=0')
         .reply(200, fixtures.orgs.bigcoUsers)
         .get('/org/bigco/package')
         .reply(200, {
@@ -479,7 +479,7 @@ describe('team', function() {
       var orgMock = nock("https://user-api-example.com")
         .get('/org/bigco')
         .reply(200, fixtures.orgs.bigco)
-        .get('/org/bigco/user')
+        .get('/org/bigco/user?per_page=100&page=0')
         .reply(200, fixtures.orgs.bigcoUsers)
         .get('/org/bigco/package')
         .reply(200, {
@@ -598,7 +598,7 @@ describe('team', function() {
       var orgMock = nock("https://user-api-example.com")
         .get('/org/bigco')
         .reply(404)
-        .get('/org/bigco/user')
+        .get('/org/bigco/user?per_page=100&page=0')
         .reply(404)
         .get('/org/bigco/package')
         .reply(404)
@@ -633,7 +633,7 @@ describe('team', function() {
       var orgMock = nock("https://user-api-example.com")
         .get('/org/bigco')
         .reply(200, fixtures.orgs.bigco)
-        .get('/org/bigco/user')
+        .get('/org/bigco/user?per_page=100&page=0')
         .reply(200, fixtures.orgs.bigcoAddedUsers)
         .get('/org/bigco/package')
         .reply(200, {
@@ -677,7 +677,7 @@ describe('team', function() {
       var orgMock = nock("https://user-api-example.com")
         .get('/org/bigco')
         .reply(200, fixtures.orgs.bigco)
-        .get('/org/bigco/user')
+        .get('/org/bigco/user?per_page=100&page=0')
         .reply(200, fixtures.orgs.bigcoAddedUsers)
         .get('/org/bigco/package')
         .reply(200, {
@@ -770,7 +770,7 @@ describe('team', function() {
         var orgMock = nock("https://user-api-example.com")
           .get('/org/bigco')
           .reply(200, fixtures.orgs.bigco)
-          .get('/org/bigco/user')
+          .get('/org/bigco/user?per_page=100&page=0')
           .reply(200, fixtures.orgs.bigcoAddedUsers)
           .get('/org/bigco/package')
           .reply(200, {
@@ -810,7 +810,7 @@ describe('team', function() {
         var orgMock = nock("https://user-api-example.com")
           .get('/org/bigco')
           .reply(200, fixtures.orgs.bigco)
-          .get('/org/bigco/user')
+          .get('/org/bigco/user?per_page=100&page=0')
           .reply(200, fixtures.orgs.bigcoAddedUsers)
           .get('/org/bigco/package')
           .reply(200, {
@@ -1403,7 +1403,7 @@ describe('team', function() {
       var orgMock = nock("https://user-api-example.com")
         .get('/org/bigco')
         .reply(200, fixtures.orgs.bigco)
-        .get('/org/bigco/user')
+        .get('/org/bigco/user?per_page=100&page=0')
         .reply(200, fixtures.orgs.bigcoAddedUsers)
         .get('/org/bigco/package')
         .reply(200, {
@@ -1452,7 +1452,7 @@ describe('team', function() {
       var orgMock = nock("https://user-api-example.com")
         .get('/org/bigco')
         .reply(200, fixtures.orgs.bigco)
-        .get('/org/bigco/user')
+        .get('/org/bigco/user?per_page=100&page=0')
         .reply(200, fixtures.orgs.bigcoAddedUsers)
         .get('/org/bigco/package')
         .reply(200, {
@@ -1500,7 +1500,7 @@ describe('team', function() {
       var orgMock = nock("https://user-api-example.com")
         .get('/org/bigco')
         .reply(200, fixtures.orgs.bigco)
-        .get('/org/bigco/user')
+        .get('/org/bigco/user?per_page=100&page=0')
         .reply(200, fixtures.orgs.bigcoAddedUsers)
         .get('/org/bigco/package')
         .reply(200, {


### PR DESCRIPTION
This fix is not comprehensive, as we'll hit it again when an org has more than 100 users, but that requires a bit of refactoring.

This fix fixes the issue where if there are more than 25 members to an org, we don't recognize that.