### PR TITLE
Pagination for Org packages

### DIFF
--- a/test/agents/org.js
+++ b/test/agents/org.js
@@ -689,11 +689,13 @@ describe('Org', function() {
 
       Org('bob').getPackages('bigco')
         .catch(function(err) {
-          orgMock.done();
           expect(err).to.exist();
         })
         .then(function(packages) {
           expect(packages).to.not.exist();
+        })
+        .finally(function() {
+          orgMock.done();
           done();
         });
 
@@ -714,15 +716,17 @@ describe('Org', function() {
         });
 
       Org('bob').getPackages('bigco')
-        .catch(function(err) {
-          orgMock.done();
-          expect(err).to.not.exist();
-        })
         .then(function(packages) {
           expect(packages).to.exist();
           expect(packages.count).to.equal(1);
           expect(packages.items.length).to.equal(1);
           expect(packages.items[0].name).to.equal("super-package");
+        })
+        .catch(function(err) {
+          expect(err).to.not.exist();
+        })
+        .finally(function() {
+          orgMock.done();
           done();
         });
 

--- a/test/agents/org.js
+++ b/test/agents/org.js
@@ -680,4 +680,52 @@ describe('Org', function() {
       });
     });
   });
+
+  describe('getPackages', function() {
+    it('returns an error when one happens', function(done) {
+      var orgMock = nock('https://user-api-example.com')
+        .get('/org/bigco/package?per_page=100&page=0')
+        .reply(404);
+
+      Org('bob').getPackages('bigco')
+        .catch(function(err) {
+          orgMock.done();
+          expect(err).to.exist();
+        })
+        .then(function(packages) {
+          expect(packages).to.not.exist();
+          done();
+        });
+
+    });
+
+    it('returns packages when response is good', function(done) {
+      var orgMock = nock('https://user-api-example.com')
+        .get('/org/bigco/package?per_page=100&page=0')
+        .reply(200, {
+          count: 1,
+          items: [{
+            "name": "super-package",
+            "private": "false",
+            "created": "2015-06-19T23:35:42.659Z",
+            "updated": "2015-06-19T23:35:42.659Z",
+            "deleted": null
+          }]
+        });
+
+      Org('bob').getPackages('bigco')
+        .catch(function(err) {
+          orgMock.done();
+          expect(err).to.not.exist();
+        })
+        .then(function(packages) {
+          expect(packages).to.exist();
+          expect(packages.count).to.equal(1);
+          expect(packages.items.length).to.equal(1);
+          expect(packages.items[0].name).to.equal("super-package");
+          done();
+        });
+
+    });
+  });
 });

--- a/test/agents/org.js
+++ b/test/agents/org.js
@@ -109,7 +109,7 @@ describe('Org', function() {
           'count': 1,
           'items': [fixtures.users.bigcoadmin]
         })
-        .get('/org/' + name + '/package')
+        .get('/org/' + name + '/package?per_page=100&page=0')
         .reply(200, {
           'count': 1,
           'items': [fixtures.packages.fake]
@@ -145,7 +145,7 @@ describe('Org', function() {
           'count': 1,
           'items': [fixtures.users.bigcoadmin]
         })
-        .get('/org/' + name + '/package')
+        .get('/org/' + name + '/package?per_page=100&page=0')
         .reply(200, {
           'count': 1,
           'items': [fixtures.packages.fake]
@@ -185,7 +185,7 @@ describe('Org', function() {
         .reply(404, 'not found')
         .get('/org/' + name + '/user?per_page=100&page=0')
         .reply(404, 'not found')
-        .get('/org/' + name + '/package')
+        .get('/org/' + name + '/package?per_page=100&page=0')
         .reply(404, 'not found')
         .get('/org/' + name + '/team')
         .reply(404, 'not found');

--- a/test/handlers/customer.js
+++ b/test/handlers/customer.js
@@ -932,7 +932,7 @@ describe("subscribing to an org", function() {
         .reply(404, "not found")
         .get("/org/boomer/user?per_page=100&page=0")
         .reply(404, "not found")
-        .get("/org/boomer/package")
+        .get("/org/boomer/package?per_page=100&page=0")
         .reply(404, "not found")
         .put("/org", {
           name: "boomer",
@@ -1037,7 +1037,7 @@ describe("subscribing to an org", function() {
           "count": 1,
           "items": [fixtures.users.bob]
         })
-        .get("/org/boomer/package")
+        .get("/org/boomer/package?per_page=100&page=0")
         .reply(200, {
           "count": 1,
           "items": [fixtures.packages.fake]
@@ -1206,7 +1206,7 @@ describe("subscribing to an org", function() {
         .reply(404, "not found")
         .get("/org/bob/user?per_page=100&page=0")
         .reply(404, "not found")
-        .get("/org/bob/package")
+        .get("/org/bob/package?per_page=100&page=0")
         .reply(404, "not found")
         .put("/org", {
           name: "bob",

--- a/test/handlers/org.js
+++ b/test/handlers/org.js
@@ -174,7 +174,7 @@ describe('getting an org', function() {
       .reply(200, fixtures.orgs.bigco)
       .get('/org/bigco/user?per_page=100&page=0')
       .reply(200, fixtures.orgs.bigcoUsers)
-      .get('/org/bigco/package')
+      .get('/org/bigco/package?per_page=100&page=0')
       .reply(200, {
         count: 1,
         items: [fixtures.packages.fake]
@@ -217,7 +217,7 @@ describe('getting an org', function() {
       .reply(200, fixtures.orgs.bigco)
       .get('/org/bigco/user?per_page=100&page=0')
       .reply(200, fixtures.orgs.bigcoAddedUsers)
-      .get('/org/bigco/package')
+      .get('/org/bigco/package?per_page=100&page=0')
       .reply(200, {
         count: 1,
         items: [fixtures.packages.fake]
@@ -260,7 +260,7 @@ describe('getting an org', function() {
       .reply(404)
       .get("/org/bigconotthere/user?per_page=100&page=0")
       .reply(404)
-      .get("/org/bigconotthere/package")
+      .get("/org/bigconotthere/package?per_page=100&page=0")
       .reply(404)
       .get("/org/bigconotthere/team")
       .reply(404);
@@ -312,7 +312,7 @@ describe('getting an org', function() {
       .reply(200, fixtures.orgs.bigco)
       .get('/org/bigco/user?per_page=100&page=0')
       .reply(200, fixtures.orgs.bigcoUsers)
-      .get('/org/bigco/package')
+      .get('/org/bigco/package?per_page=100&page=0')
       .reply(200, {
         count: 1,
         items: [fixtures.packages.fake]
@@ -352,7 +352,7 @@ describe('getting an org', function() {
         .reply(200, fixtures.orgs.notBobsOrg)
         .get('/org/notbobsorg/user?per_page=100&page=0')
         .reply(200, fixtures.orgs.notBobsOrgUsers)
-        .get('/org/notbobsorg/package')
+        .get('/org/notbobsorg/package?per_page=100&page=0')
         .reply(200, {
           count: 1,
           items: [fixtures.packages.fake]
@@ -392,7 +392,7 @@ describe('getting an org', function() {
         .reply(200, fixtures.orgs.bigco)
         .get('/org/bigco/user?per_page=100&page=0')
         .reply(200, fixtures.orgs.bigcoUsers)
-        .get('/org/bigco/package')
+        .get('/org/bigco/package?per_page=100&page=0')
         .reply(200, {
           count: 1,
           items: [fixtures.packages.fake]
@@ -431,7 +431,7 @@ describe('getting an org', function() {
         .reply(200, fixtures.orgs.bigco)
         .get('/org/bigco/user?per_page=100&page=0')
         .reply(200, fixtures.orgs.bigcoAddedUsers)
-        .get('/org/bigco/package')
+        .get('/org/bigco/package?per_page=100&page=0')
         .reply(200, {
           count: 1,
           items: [fixtures.packages.fake]
@@ -469,7 +469,7 @@ describe('getting an org', function() {
         .reply(200, fixtures.orgs.bigco)
         .get('/org/bigco/user?per_page=100&page=0')
         .reply(200, fixtures.orgs.bigcoAddedUsers)
-        .get('/org/bigco/package')
+        .get('/org/bigco/package?per_page=100&page=0')
         .reply(200, {
           count: 1,
           items: [fixtures.packages.fake]
@@ -508,7 +508,7 @@ describe('getting an org', function() {
       .reply(200, fixtures.orgs.bigco)
       .get('/org/bigco/user?per_page=100&page=0')
       .reply(200, fixtures.orgs.bigcoAddedUsers)
-      .get('/org/bigco/package')
+      .get('/org/bigco/package?per_page=100&page=0')
       .reply(200, {
         count: 1,
         items: [fixtures.packages.fake]
@@ -552,7 +552,7 @@ describe('getting an org', function() {
       })
       .get('/org/bigco/user?per_page=100&page=0')
       .reply(200, fixtures.orgs.bigcoAddedUsers)
-      .get('/org/bigco/package')
+      .get('/org/bigco/package?per_page=100&page=0')
       .reply(200, {
         count: 1,
         items: [fixtures.packages.fake]
@@ -592,7 +592,7 @@ describe('creating an org', function() {
       .reply(200, fixtures.orgs.bigco)
       .get("/org/bigco/user?per_page=100&page=0")
       .reply(200, fixtures.orgs.bigcoAddedUsers)
-      .get("/org/bigco/package")
+      .get("/org/bigco/package?per_page=100&page=0")
       .reply(200, fixtures.packages.fake)
       .get('/org/bigco/team')
       .reply(200, fixtures.teams.bigcoOrg);
@@ -631,7 +631,7 @@ describe('creating an org', function() {
         .reply(404, fixtures.orgs.bigco)
         .get("/org/bigco/user?per_page=100&page=0")
         .reply(404, fixtures.orgs.bigcoAddedUsers)
-        .get("/org/bigco/package")
+        .get("/org/bigco/package?per_page=100&page=0")
         .reply(404, fixtures.packages.fake)
         .get("/org/bigco/team")
         .reply(404);
@@ -722,7 +722,7 @@ describe('creating an org', function() {
         .reply(404, fixtures.orgs.bigco)
         .get("/org/bigco/user?per_page=100&page=0")
         .reply(404, fixtures.orgs.bigcoAddedUsers)
-        .get("/org/bigco/package")
+        .get("/org/bigco/package?per_page=100&page=0")
         .reply(404, fixtures.packages.fake)
         .get("/org/bigco/team")
         .reply(404);
@@ -833,7 +833,7 @@ describe('transferring username to org', function() {
         .reply(404)
         .get("/org/bigco/user?per_page=100&page=0")
         .reply(404)
-        .get("/org/bigco/package")
+        .get("/org/bigco/package?per_page=100&page=0")
         .reply(404);
 
       var licenseMock = nock("https://license-api-example.com")
@@ -866,7 +866,7 @@ describe('transferring username to org', function() {
         .reply(200, fixtures.orgs.bigco)
         .get("/org/bigco/user?per_page=100&page=0")
         .reply(200, fixtures.orgs.bigcoUsers)
-        .get("/org/bigco/package")
+        .get("/org/bigco/package?per_page=100&page=0")
         .reply(200, [])
         .get('/org/bigco/team')
         .reply(200, fixtures.teams.bigcoOrg);

--- a/test/handlers/team.js
+++ b/test/handlers/team.js
@@ -74,7 +74,7 @@ describe('team', function() {
         .reply(404)
         .get('/org/bigco/user?per_page=100&page=0')
         .reply(404)
-        .get('/org/bigco/package')
+        .get('/org/bigco/package?per_page=100&page=0')
         .reply(404)
         .get('/org/bigco/team')
         .reply(404);
@@ -108,7 +108,7 @@ describe('team', function() {
         .reply(200, fixtures.orgs.bigco)
         .get('/org/bigco/user?per_page=100&page=0')
         .reply(200, fixtures.orgs.bigcoUsers)
-        .get('/org/bigco/package')
+        .get('/org/bigco/package?per_page=100&page=0')
         .reply(200, {
           count: 1,
           items: [fixtures.packages.fake]
@@ -146,7 +146,7 @@ describe('team', function() {
         .reply(200, fixtures.orgs.bigco)
         .get('/org/bigco/user?per_page=100&page=0')
         .reply(200, fixtures.orgs.bigcoUsers)
-        .get('/org/bigco/package')
+        .get('/org/bigco/package?per_page=100&page=0')
         .reply(200, {
           count: 1,
           items: [fixtures.packages.fake]
@@ -280,7 +280,7 @@ describe('team', function() {
           .reply(404)
           .get('/org/bigco/user?per_page=100&page=0')
           .reply(404)
-          .get('/org/bigco/package')
+          .get('/org/bigco/package?per_page=100&page=0')
           .reply(404)
           .get('/org/bigco/team')
           .reply(404);
@@ -323,7 +323,7 @@ describe('team', function() {
           .reply(500)
           .get('/org/bigco/user?per_page=100&page=0')
           .reply(500)
-          .get('/org/bigco/package')
+          .get('/org/bigco/package?per_page=100&page=0')
           .reply(500)
           .get('/org/bigco/team')
           .reply(500);
@@ -366,7 +366,7 @@ describe('team', function() {
         .reply(200, fixtures.orgs.bigco)
         .get('/org/bigco/user?per_page=100&page=0')
         .reply(200, fixtures.orgs.bigcoUsers)
-        .get('/org/bigco/package')
+        .get('/org/bigco/package?per_page=100&page=0')
         .reply(200, {
           count: 1,
           items: [fixtures.packages.fake]
@@ -421,7 +421,7 @@ describe('team', function() {
         .reply(200, fixtures.orgs.bigco)
         .get('/org/bigco/user?per_page=100&page=0')
         .reply(200, fixtures.orgs.bigcoUsers)
-        .get('/org/bigco/package')
+        .get('/org/bigco/package?per_page=100&page=0')
         .reply(200, {
           count: 1,
           items: [fixtures.packages.fake]
@@ -481,7 +481,7 @@ describe('team', function() {
         .reply(200, fixtures.orgs.bigco)
         .get('/org/bigco/user?per_page=100&page=0')
         .reply(200, fixtures.orgs.bigcoUsers)
-        .get('/org/bigco/package')
+        .get('/org/bigco/package?per_page=100&page=0')
         .reply(200, {
           count: 1,
           items: [fixtures.packages.fake]
@@ -600,7 +600,7 @@ describe('team', function() {
         .reply(404)
         .get('/org/bigco/user?per_page=100&page=0')
         .reply(404)
-        .get('/org/bigco/package')
+        .get('/org/bigco/package?per_page=100&page=0')
         .reply(404)
         .get('/org/bigco/team')
         .reply(404);
@@ -635,7 +635,7 @@ describe('team', function() {
         .reply(200, fixtures.orgs.bigco)
         .get('/org/bigco/user?per_page=100&page=0')
         .reply(200, fixtures.orgs.bigcoAddedUsers)
-        .get('/org/bigco/package')
+        .get('/org/bigco/package?per_page=100&page=0')
         .reply(200, {
           count: 1,
           items: [fixtures.packages.fake]
@@ -679,7 +679,7 @@ describe('team', function() {
         .reply(200, fixtures.orgs.bigco)
         .get('/org/bigco/user?per_page=100&page=0')
         .reply(200, fixtures.orgs.bigcoAddedUsers)
-        .get('/org/bigco/package')
+        .get('/org/bigco/package?per_page=100&page=0')
         .reply(200, {
           count: 1,
           items: [fixtures.packages.fake]
@@ -772,7 +772,7 @@ describe('team', function() {
           .reply(200, fixtures.orgs.bigco)
           .get('/org/bigco/user?per_page=100&page=0')
           .reply(200, fixtures.orgs.bigcoAddedUsers)
-          .get('/org/bigco/package')
+          .get('/org/bigco/package?per_page=100&page=0')
           .reply(200, {
             count: 1,
             items: [fixtures.packages.fake]
@@ -812,7 +812,7 @@ describe('team', function() {
           .reply(200, fixtures.orgs.bigco)
           .get('/org/bigco/user?per_page=100&page=0')
           .reply(200, fixtures.orgs.bigcoAddedUsers)
-          .get('/org/bigco/package')
+          .get('/org/bigco/package?per_page=100&page=0')
           .reply(200, {
             count: 1,
             items: [fixtures.packages.fake]
@@ -1405,7 +1405,7 @@ describe('team', function() {
         .reply(200, fixtures.orgs.bigco)
         .get('/org/bigco/user?per_page=100&page=0')
         .reply(200, fixtures.orgs.bigcoAddedUsers)
-        .get('/org/bigco/package')
+        .get('/org/bigco/package?per_page=100&page=0')
         .reply(200, {
           count: 1,
           items: [fixtures.packages.fake]
@@ -1454,7 +1454,7 @@ describe('team', function() {
         .reply(200, fixtures.orgs.bigco)
         .get('/org/bigco/user?per_page=100&page=0')
         .reply(200, fixtures.orgs.bigcoAddedUsers)
-        .get('/org/bigco/package')
+        .get('/org/bigco/package?per_page=100&page=0')
         .reply(200, {
           count: 1,
           items: [fixtures.packages.fake]
@@ -1502,7 +1502,7 @@ describe('team', function() {
         .reply(200, fixtures.orgs.bigco)
         .get('/org/bigco/user?per_page=100&page=0')
         .reply(200, fixtures.orgs.bigcoAddedUsers)
-        .get('/org/bigco/package')
+        .get('/org/bigco/package?per_page=100&page=0')
         .reply(200, {
           count: 1,
           items: [fixtures.packages.fake]


### PR DESCRIPTION
Much like the fix for #1596, this is temporary.

The method for grabbing packages is now grabbing the first 100, instead of the first 25 packages. This will hold us off until we refactor to better cover this.