### PR TITLE
bump marky-markdown dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "lodash": "^3.8.0",
     "mailchimp-api": "^2.0.7",
     "malarkey": "^1.3.2",
-    "marky-markdown": "~5.4.0",
+    "marky-markdown": "~5.5.1",
     "moment": "^2.10.2",
     "moment-tokens": "^1.0.0",
     "month": "^1.0.0",


### PR DESCRIPTION
By bumping marky-markdown, we fix a 500 error that was being caused by image urls in this format:

`![Methods](#methods)`

I think what the user actually intended was `[Methods](#methods)`, but better that we handle this edge-case without exploding.

## Note

we should test thoroughly because `marky-markdown` `5.4.0` -> `5.5.1` updates quite a few dependencies:

CC: @ceejbot @ashleygwilliams 