### PR TITLE
Make sure 404 turns out a not found page

### DIFF
--- a/handlers/org.js
+++ b/handlers/org.js
@@ -121,7 +121,9 @@ exports.getOrg = function(request, reply) {
     .catch(function(err) {
       request.logger.error(err);
 
-      if (err.statusCode < 500) {
+      if (err.statusCode === 404) {
+        return reply.view('errors/not-found', err).code(404);
+      } else if (err.statusCode < 500) {
         return request.saveNotifications([
           P.reject(err.message)
         ]).then(function(token) {
@@ -133,7 +135,7 @@ exports.getOrg = function(request, reply) {
           request.logger.log(err);
         });
       } else {
-        return reply.view('errors/internal', err);
+        return reply(err);
       }
     });
 

--- a/test/handlers/org.js
+++ b/test/handlers/org.js
@@ -275,24 +275,8 @@ describe('getting an org', function() {
       userMock.done();
       orgMock.done();
       licenseMock.done();
-      var redirectPath = resp.headers.location;
-      var url = URL.parse(redirectPath);
-      var query = url.query;
-      var token = qs.parse(query).notice;
-      var tokenFacilitator = new TokenFacilitator({
-        redis: client
-      });
-      expect(token).to.be.string();
-      expect(token).to.not.be.empty();
-      expect(resp.statusCode).to.equal(302);
-      tokenFacilitator.read(token, {
-        prefix: "notice:"
-      }, function(err, notice) {
-        expect(err).to.not.exist();
-        expect(notice.notices).to.be.array();
-        expect(notice.notices[0]).to.equal('Org not found');
-        done();
-      });
+      expect(resp.statusCode).to.equal(404);
+      done();
     });
   });
 


### PR DESCRIPTION
A 404 on an org is currently causing a redirect loop.

This fixes that.

Fixes #1611 