### PR TITLE
Fix expected error message in addPackages() test

### DIFF
--- a/test/agents/team.js
+++ b/test/agents/team.js
@@ -427,7 +427,7 @@ describe('Team', function() {
         }).catch(function(err) {
           expect(err).to.exist();
           // i'd like this to show _all_ of the errors, not just the first one.
-          expect(err.message).to.equal('Team or Org or not found');
+          expect(err.message).to.equal('Team or Org not found');
           expect(err.statusCode).to.equal(404);
         }).then(function(packages) {
           expect(packages).to.not.exist();


### PR DESCRIPTION
Change expected error message from `Team or Org or not found` to `Team or Org not found` (one too many `or`s in the first one).

Fixes the `addPackages() returns an error if something goes wrong` test.