### PR TITLE
Make sure up to 100 teams can show on an org page

### DIFF
--- a/agents/org.js
+++ b/agents/org.js
@@ -338,9 +338,13 @@ Org.prototype.getUsers = function(name, page) {
 
 };
 
-Org.prototype.getTeams = function(name) {
+Org.prototype.getTeams = function(name, page) {
   var url = USER_HOST + '/org/' + name + '/team';
   var bearer = this.bearer;
+  var PER_PAGE = 100;
+
+  page = page || 0;
+
 
   return new P(function(accept, reject) {
 
@@ -349,6 +353,10 @@ Org.prototype.getTeams = function(name) {
       json: true,
       headers: {
         bearer: bearer
+      },
+      qs: {
+        per_page: PER_PAGE,
+        page: page
       }
     }, function(err, resp, body) {
       if (err) {

--- a/test/agents/org.js
+++ b/test/agents/org.js
@@ -114,7 +114,7 @@ describe('Org', function() {
           'count': 1,
           'items': [fixtures.packages.fake]
         })
-        .get('/org/bigco/team')
+        .get('/org/bigco/team?per_page=100&page=0')
         .reply(401);
 
       Org('betty').get(name, function(err, org) {
@@ -150,7 +150,7 @@ describe('Org', function() {
           'count': 1,
           'items': [fixtures.packages.fake]
         })
-        .get('/org/bigco/team')
+        .get('/org/bigco/team?per_page=100&page=0')
         .reply(200, {
           count: 1,
           items: [
@@ -187,7 +187,7 @@ describe('Org', function() {
         .reply(404, 'not found')
         .get('/org/' + name + '/package?per_page=100&page=0')
         .reply(404, 'not found')
-        .get('/org/' + name + '/team')
+        .get('/org/' + name + '/team?per_page=100&page=0')
         .reply(404, 'not found');
 
       Org('betty').get(name, function(err, org) {
@@ -580,7 +580,7 @@ describe('Org', function() {
       var name = 'bigcoOrg';
 
       var orgMocks = nock('https://user-api-example.com')
-        .get('/org/' + name + '/team')
+        .get('/org/' + name + '/team?per_page=100&page=0')
         .reply(200, fixtures.teams.bigcoOrg);
 
       Org('bob').getTeams(name)
@@ -602,7 +602,7 @@ describe('Org', function() {
       var name = 'bigcoOrg';
 
       var orgMocks = nock('https://user-api-example.com')
-        .get('/org/' + name + '/team')
+        .get('/org/' + name + '/team?per_page=100&page=0')
         .reply(404, 'Org not found');
 
       Org('bob').getTeams(name)

--- a/test/handlers/customer.js
+++ b/test/handlers/customer.js
@@ -1042,7 +1042,7 @@ describe("subscribing to an org", function() {
           "count": 1,
           "items": [fixtures.packages.fake]
         })
-        .get("/org/boomer/team")
+        .get("/org/boomer/team?per_page=100&page=0")
         .reply(200, {
           count: 1,
           items: [

--- a/test/handlers/org.js
+++ b/test/handlers/org.js
@@ -179,7 +179,7 @@ describe('getting an org', function() {
         count: 1,
         items: [fixtures.packages.fake]
       })
-      .get('/org/bigco/team')
+      .get('/org/bigco/team?per_page=100&page=0')
       .reply(200, fixtures.teams.bigcoOrg);
 
 
@@ -222,7 +222,7 @@ describe('getting an org', function() {
         count: 1,
         items: [fixtures.packages.fake]
       })
-      .get('/org/bigco/team')
+      .get('/org/bigco/team?per_page=100&page=0')
       .reply(200, fixtures.teams.bigcoOrg);
 
 
@@ -262,7 +262,7 @@ describe('getting an org', function() {
       .reply(404)
       .get("/org/bigconotthere/package?per_page=100&page=0")
       .reply(404)
-      .get("/org/bigconotthere/team")
+      .get("/org/bigconotthere/team?per_page=100&page=0")
       .reply(404);
 
 
@@ -301,7 +301,7 @@ describe('getting an org', function() {
         count: 1,
         items: [fixtures.packages.fake]
       })
-      .get('/org/bigco/team')
+      .get('/org/bigco/team?per_page=100&page=0')
       .reply(200, fixtures.teams.bigcoOrg);
 
     var options = {
@@ -341,7 +341,7 @@ describe('getting an org', function() {
           count: 1,
           items: [fixtures.packages.fake]
         })
-        .get('/org/notbobsorg/team')
+        .get('/org/notbobsorg/team?per_page=100&page=0')
         .reply(401);
 
       var options = {
@@ -381,7 +381,7 @@ describe('getting an org', function() {
           count: 1,
           items: [fixtures.packages.fake]
         })
-        .get('/org/bigco/team')
+        .get('/org/bigco/team?per_page=100&page=0')
         .reply(200, fixtures.teams.bigcoOrg);
 
       var options = {
@@ -420,7 +420,7 @@ describe('getting an org', function() {
           count: 1,
           items: [fixtures.packages.fake]
         })
-        .get('/org/bigco/team')
+        .get('/org/bigco/team?per_page=100&page=0')
         .reply(200, fixtures.teams.bigcoOrg);
 
       var options = {
@@ -458,7 +458,7 @@ describe('getting an org', function() {
           count: 1,
           items: [fixtures.packages.fake]
         })
-        .get('/org/bigco/team')
+        .get('/org/bigco/team?per_page=100&page=0')
         .reply(200, fixtures.teams.bigcoOrg);
 
       var options = {
@@ -497,7 +497,7 @@ describe('getting an org', function() {
         count: 1,
         items: [fixtures.packages.fake]
       })
-      .get('/org/bigco/team')
+      .get('/org/bigco/team?per_page=100&page=0')
       .reply(200, fixtures.teams.bigcoOrg);
 
     var options = {
@@ -541,7 +541,7 @@ describe('getting an org', function() {
         count: 1,
         items: [fixtures.packages.fake]
       })
-      .get('/org/bigco/team')
+      .get('/org/bigco/team?per_page=100&page=0')
       .reply(200, fixtures.teams.bigcoOrg);
 
     var options = {
@@ -578,7 +578,7 @@ describe('creating an org', function() {
       .reply(200, fixtures.orgs.bigcoAddedUsers)
       .get("/org/bigco/package?per_page=100&page=0")
       .reply(200, fixtures.packages.fake)
-      .get('/org/bigco/team')
+      .get('/org/bigco/team?per_page=100&page=0')
       .reply(200, fixtures.teams.bigcoOrg);
 
     var options = {
@@ -617,7 +617,7 @@ describe('creating an org', function() {
         .reply(404, fixtures.orgs.bigcoAddedUsers)
         .get("/org/bigco/package?per_page=100&page=0")
         .reply(404, fixtures.packages.fake)
-        .get("/org/bigco/team")
+        .get("/org/bigco/team?per_page=100&page=0")
         .reply(404);
 
       var options = {
@@ -708,7 +708,7 @@ describe('creating an org', function() {
         .reply(404, fixtures.orgs.bigcoAddedUsers)
         .get("/org/bigco/package?per_page=100&page=0")
         .reply(404, fixtures.packages.fake)
-        .get("/org/bigco/team")
+        .get("/org/bigco/team?per_page=100&page=0")
         .reply(404);
 
       var options = {
@@ -852,7 +852,7 @@ describe('transferring username to org', function() {
         .reply(200, fixtures.orgs.bigcoUsers)
         .get("/org/bigco/package?per_page=100&page=0")
         .reply(200, [])
-        .get('/org/bigco/team')
+        .get('/org/bigco/team?per_page=100&page=0')
         .reply(200, fixtures.teams.bigcoOrg);
 
       var licenseMock = nock("https://license-api-example.com")

--- a/test/handlers/team.js
+++ b/test/handlers/team.js
@@ -76,7 +76,7 @@ describe('team', function() {
         .reply(404)
         .get('/org/bigco/package?per_page=100&page=0')
         .reply(404)
-        .get('/org/bigco/team')
+        .get('/org/bigco/team?per_page=100&page=0')
         .reply(404);
 
       var options = {
@@ -113,7 +113,7 @@ describe('team', function() {
           count: 1,
           items: [fixtures.packages.fake]
         })
-        .get('/org/bigco/team')
+        .get('/org/bigco/team?per_page=100&page=0')
         .reply(200, fixtures.teams.bigcoOrg);
 
       var options = {
@@ -151,7 +151,7 @@ describe('team', function() {
           count: 1,
           items: [fixtures.packages.fake]
         })
-        .get('/org/bigco/team')
+        .get('/org/bigco/team?per_page=100&page=0')
         .reply(200, fixtures.teams.bigcoOrg);
 
       var options = {
@@ -282,7 +282,7 @@ describe('team', function() {
           .reply(404)
           .get('/org/bigco/package?per_page=100&page=0')
           .reply(404)
-          .get('/org/bigco/team')
+          .get('/org/bigco/team?per_page=100&page=0')
           .reply(404);
 
         var options = {
@@ -325,7 +325,7 @@ describe('team', function() {
           .reply(500)
           .get('/org/bigco/package?per_page=100&page=0')
           .reply(500)
-          .get('/org/bigco/team')
+          .get('/org/bigco/team?per_page=100&page=0')
           .reply(500);
 
         var options = {
@@ -371,7 +371,7 @@ describe('team', function() {
           count: 1,
           items: [fixtures.packages.fake]
         })
-        .get('/org/bigco/team')
+        .get('/org/bigco/team?per_page=100&page=0')
         .reply(200, fixtures.teams.bigcoOrg)
         .put('/org/bigco/team', {
           scope: 'bigco',
@@ -426,7 +426,7 @@ describe('team', function() {
           count: 1,
           items: [fixtures.packages.fake]
         })
-        .get('/org/bigco/team')
+        .get('/org/bigco/team?per_page=100&page=0')
         .reply(200, fixtures.teams.bigcoOrg)
         .put('/org/bigco/team', {
           scope: 'bigco',
@@ -486,7 +486,7 @@ describe('team', function() {
           count: 1,
           items: [fixtures.packages.fake]
         })
-        .get('/org/bigco/team')
+        .get('/org/bigco/team?per_page=100&page=0')
         .reply(200, fixtures.teams.bigcoOrg)
         .put('/org/bigco/team', {
           scope: 'bigco',
@@ -552,7 +552,9 @@ describe('team', function() {
       generateCrumb(server, function(crumb) {
         var options = {
           credentials: fixtures.users.bob,
-          headers: {cookie: 'crumb=' + crumb},
+          headers: {
+            cookie: 'crumb=' + crumb
+          },
           method: 'POST',
           payload: {
             crumb: crumb,
@@ -592,7 +594,9 @@ describe('team', function() {
       generateCrumb(server, function(crumb) {
         var options = {
           credentials: fixtures.users.betty,
-          headers: {cookie: 'crumb=' + crumb},
+          headers: {
+            cookie: 'crumb=' + crumb
+          },
           method: 'POST',
           payload: {
             crumb: crumb,
@@ -606,13 +610,17 @@ describe('team', function() {
             var parsedRedirectUrl = URL.parse(response.headers.location);
             var redirectPath = parsedRedirectUrl.pathname
             var noticeToken = qs.parse(parsedRedirectUrl.query).notice;
-            var tokenFacilitator = new TokenFacilitator({redis: redisClient});
+            var tokenFacilitator = new TokenFacilitator({
+              redis: redisClient
+            });
 
             expect(noticeToken).to.be.string();
             expect(noticeToken).to.not.be.empty();
             expect(response.statusCode).to.equal(302);
             expect(redirectPath).to.equal('/org/bigco/team/bigcoteam');
-            tokenFacilitator.read(noticeToken, {prefix: 'notice:'}, function(error, noticeContainer) {
+            tokenFacilitator.read(noticeToken, {
+              prefix: 'notice:'
+            }, function(error, noticeContainer) {
               expect(error).to.not.exist();
               expect(noticeContainer.notices).to.be.array();
               expect(noticeContainer.notices[0]).to.equal('You do not have permission to perform this operation.');
@@ -696,7 +704,7 @@ describe('team', function() {
         .reply(404)
         .get('/org/bigco/package?per_page=100&page=0')
         .reply(404)
-        .get('/org/bigco/team')
+        .get('/org/bigco/team?per_page=100&page=0')
         .reply(404);
 
       var options = {
@@ -734,7 +742,7 @@ describe('team', function() {
           count: 1,
           items: [fixtures.packages.fake]
         })
-        .get('/org/bigco/team')
+        .get('/org/bigco/team?per_page=100&page=0')
         .reply(200, fixtures.teams.bigcoOrg)
         .get('/team/bigco/bigcoteam')
         .reply(404)
@@ -778,7 +786,7 @@ describe('team', function() {
           count: 1,
           items: [fixtures.packages.fake]
         })
-        .get('/org/bigco/team')
+        .get('/org/bigco/team?per_page=100&page=0')
         .reply(200, fixtures.teams.bigcoOrg)
         .get('/team/bigco/bigcoteam')
         .reply(200, fixtures.teams.bigcoteam)
@@ -871,7 +879,7 @@ describe('team', function() {
             count: 1,
             items: [fixtures.packages.fake]
           })
-          .get('/org/bigco/team')
+          .get('/org/bigco/team?per_page=100&page=0')
           .reply(200, fixtures.teams.bigcoOrg);
 
         var options = {
@@ -911,7 +919,7 @@ describe('team', function() {
             count: 1,
             items: [fixtures.packages.fake]
           })
-          .get('/org/bigco/team')
+          .get('/org/bigco/team?per_page=100&page=0')
           .reply(200, fixtures.teams.bigcoOrg)
           .get('/team/bigco/bigcoteam')
           .reply(200, fixtures.teams.bigcoteam)
@@ -1504,7 +1512,7 @@ describe('team', function() {
           count: 1,
           items: [fixtures.packages.fake]
         })
-        .get('/org/bigco/team')
+        .get('/org/bigco/team?per_page=100&page=0')
         .reply(200, fixtures.teams.bigcoOrg);
 
       var options = {
@@ -1553,7 +1561,7 @@ describe('team', function() {
           count: 1,
           items: [fixtures.packages.fake]
         })
-        .get('/org/bigco/team')
+        .get('/org/bigco/team?per_page=100&page=0')
         .reply(200, fixtures.teams.bigcoOrg);
 
       var teamMock = nock("https://user-api-example.com")
@@ -1601,7 +1609,7 @@ describe('team', function() {
           count: 1,
           items: [fixtures.packages.fake]
         })
-        .get('/org/bigco/team')
+        .get('/org/bigco/team?per_page=100&page=0')
         .reply(200, fixtures.teams.bigcoOrg)
         .get('/team/bigco/bigcoteam')
         .reply(200, fixtures.teams.bigcoteam)


### PR DESCRIPTION
This is a temporary fix, similar to how we handle users and packages.
It includes expanding the amount of teams that come back from the user-acl
It also updates handler tests to reflect query strings.