### PR TITLE
Support for npmo-specific error page

### DIFF
--- a/facets/enterprise/show-verification.js
+++ b/facets/enterprise/show-verification.js
@@ -16,9 +16,9 @@ module.exports = function verifyEnterpriseTrial(request, reply) {
   verifyTrial(request.query.v, function(err, trial) {
 
     if (err) {
-      err.internalStatusCode = 500;
       request.logger.error('Unable to verify the trial', request.query.v);
       request.logger.error(err);
+      err.statusCode = 500;
       reply(err);
       return;
     }
@@ -26,9 +26,9 @@ module.exports = function verifyEnterpriseTrial(request, reply) {
     getCustomer(trial.customer_id, function(err, customer) {
 
       if (err) {
-        err.internalStatusCode = 500;
         request.logger.error('Unable to get customer from hubspot', trial.customer_id);
         request.logger.error(err);
+        err.statusCode = 500;
         reply(err);
         return;
       }
@@ -36,9 +36,9 @@ module.exports = function verifyEnterpriseTrial(request, reply) {
       getLicenses(process.env.NPME_PRODUCT_ID, trial.customer_id, function(err, licenses) {
 
         if (err) {
-          err.internalStatusCode = 500;
           request.logger.error('Unable to get licenses from hubspot for customer ' + trial.customer_id);
           request.logger.error(err);
+          err.statusCode = 500;
           reply(err);
           return;
         }
@@ -47,7 +47,7 @@ module.exports = function verifyEnterpriseTrial(request, reply) {
         if (licenses.length !== 1) {
           var msg = 'zero or more than one license for ' + trial.customer_id;
           var error = new Error(msg);
-          error.internalStatusCode = 400;
+          error.statusCode = 400;
           request.logger.error(msg, 'licenses: ', licenses);
           reply(error);
           return;
@@ -75,9 +75,9 @@ module.exports = function verifyEnterpriseTrial(request, reply) {
 
         sendEmail('enterprise-verification', mail, request.redis)
           .catch(function(er) {
-            er.internalStatusCode = 500;
             request.logger.error('Unable to send license to email', opts.email);
             request.logger.error(er);
+            er.statusCode = 500;
             reply(er);
             return;
           })

--- a/facets/enterprise/show-verification.js
+++ b/facets/enterprise/show-verification.js
@@ -16,34 +16,40 @@ module.exports = function verifyEnterpriseTrial(request, reply) {
   verifyTrial(request.query.v, function(err, trial) {
 
     if (err) {
+      err.internalStatusCode = 500;
       request.logger.error('Unable to verify the trial', request.query.v);
       request.logger.error(err);
-      reply.view('errors/internal', opts).code(500);
+      reply(err);
       return;
     }
 
     getCustomer(trial.customer_id, function(err, customer) {
 
       if (err) {
+        err.internalStatusCode = 500;
         request.logger.error('Unable to get customer from hubspot', trial.customer_id);
         request.logger.error(err);
-        reply.view('errors/internal', opts).code(500);
+        reply(err);
         return;
       }
 
       getLicenses(process.env.NPME_PRODUCT_ID, trial.customer_id, function(err, licenses) {
 
         if (err) {
+          err.internalStatusCode = 500;
           request.logger.error('Unable to get licenses from hubspot for customer ' + trial.customer_id);
           request.logger.error(err);
-          reply.view('errors/internal', opts).code(500);
+          reply(err);
           return;
         }
 
         // zero licenses bad, more than one license confusing
         if (licenses.length !== 1) {
-          request.logger.error('zero or more than one license for ' + trial.customer_id, 'licenses: ', licenses);
-          reply.view('errors/internal', opts).code(400);
+          var msg = 'zero or more than one license for ' + trial.customer_id;
+          var error = new Error(msg);
+          error.internalStatusCode = 400;
+          request.logger.error(msg, 'licenses: ', licenses);
+          reply(error);
           return;
         }
 
@@ -69,9 +75,10 @@ module.exports = function verifyEnterpriseTrial(request, reply) {
 
         sendEmail('enterprise-verification', mail, request.redis)
           .catch(function(er) {
+            er.internalStatusCode = 500;
             request.logger.error('Unable to send license to email', opts.email);
             request.logger.error(er);
-            reply.view('errors/internal', opts).code(500);
+            reply(er);
             return;
           })
           .then(function() {

--- a/facets/registry/show-search.js
+++ b/facets/registry/show-search.js
@@ -87,9 +87,9 @@ module.exports = function(request, reply) {
     var opts = { };
 
     if (error) {
-      error.internalStatusCode = 500;
       request.logger.warn('elasticsearch failed searching ' + request.query.q);
       request.logger.error(error);
+      error.statusCode = 500;
       return reply(error);
     }
 

--- a/facets/registry/show-search.js
+++ b/facets/registry/show-search.js
@@ -87,9 +87,10 @@ module.exports = function(request, reply) {
     var opts = { };
 
     if (error) {
+      error.internalStatusCode = 500;
       request.logger.warn('elasticsearch failed searching ' + request.query.q);
       request.logger.error(error);
-      return reply.view('errors/internal', opts).code(500);
+      return reply(error);
     }
 
     request.timing.page = 'search';

--- a/handlers/access.js
+++ b/handlers/access.js
@@ -27,7 +27,7 @@ module.exports = function(request, reply) {
           reply.view('errors/not-found').code(404);
           break;
         default:
-          err.internalStatusCode = 500;
+          err.statusCode = 500;
           reply(err);
       }
       return promise.cancel();

--- a/handlers/homepage.js
+++ b/handlers/homepage.js
@@ -45,6 +45,6 @@ module.exports = function(request, reply) {
     reply.view('homepage', context);
   }).catch(function(err) {
     request.logger.error(err);
-    reply.view('errors/internal', err);
+    return reply(err);
   });
 };

--- a/handlers/package.js
+++ b/handlers/package.js
@@ -101,7 +101,8 @@ exports.show = function(request, reply) {
       }
 
       request.logger.error(err);
-      reply.view('errors/internal', context).code(500);
+      err.internalStatusCode = 500;
+      reply(err);
       return;
     });
 };

--- a/handlers/package.js
+++ b/handlers/package.js
@@ -101,7 +101,7 @@ exports.show = function(request, reply) {
       }
 
       request.logger.error(err);
-      err.internalStatusCode = 500;
+      err.statusCode = 500;
       reply(err);
       return;
     });

--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -13,10 +13,11 @@ exports.register = function(server, options, next) {
     }
 
     var logger = bole(request.id);
+    var statusCode = response.internalStatusCode || response.statusCode || response.output.statusCode || 500;
     response.correlationID = request.id;
     response.features = request.features;
 
-    if (response.statusCode === 404 || response.output.statusCode == 404) {
+    if (statusCode === 404) {
       return reply.view('errors/not-found', response).code(404);
     } else {
       logger.warn(response);
@@ -24,7 +25,7 @@ exports.register = function(server, options, next) {
       // is a Boom-wrapped Error object - build the "full" stack (with cause)
       // for npmo display (see templates/errors/internal.hbs)
       if (feature('npmo')) response.npmoFullStack = utils.stackToString(response);
-      return reply.view('errors/internal', response).code(500);
+      return reply.view('errors/internal', response).code(statusCode);
     }
   });
 

--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -13,12 +13,12 @@ exports.register = function(server, options, next) {
     }
 
     var logger = bole(request.id);
-    var statusCode = response.internalStatusCode || response.statusCode || response.output.statusCode || 500;
+    var statusCode = response.statusCode || response.output.statusCode || 500;
     response.correlationID = request.id;
     response.features = request.features;
 
     if (statusCode === 404) {
-      return reply.view('errors/not-found', response).code(404);
+      return reply.view('errors/not-found', response).code(statusCode);
     } else {
       logger.warn(response);
       // if reply(err) was used in handler (which is preferred) then response

--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var bole = require('bole');
 var feature = require('./feature-flags.js');
 var utils = require('./utils.js');
@@ -17,16 +19,18 @@ exports.register = function(server, options, next) {
     response.correlationID = request.id;
     response.features = request.features;
 
+    let view;
     if (statusCode === 404) {
-      return reply.view('errors/not-found', response).code(statusCode);
+      view = reply.view('errors/not-found', response);
     } else {
       logger.warn(response);
       // if reply(err) was used in handler (which is preferred) then response
       // is a Boom-wrapped Error object - build the "full" stack (with cause)
       // for npmo display (see templates/errors/internal.hbs)
       if (feature('npmo')) response.npmoFullStack = utils.stackToString(response);
-      return reply.view('errors/internal', response).code(statusCode);
+      view = reply.view('errors/internal', response);
     }
+    return view.code(statusCode).type('text/html').charset('utf-8');
   });
 
   next();

--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -1,4 +1,6 @@
 var bole = require('bole');
+var feature = require('./feature-flags.js');
+var utils = require('./utils.js');
 
 exports.register = function(server, options, next) {
 
@@ -11,12 +13,17 @@ exports.register = function(server, options, next) {
     }
 
     var logger = bole(request.id);
-    response.correlationID = request.id
+    response.correlationID = request.id;
+    response.features = request.features;
 
     if (response.statusCode === 404 || response.output.statusCode == 404) {
-      return reply.view('errors/not-found', response).code(404)
+      return reply.view('errors/not-found', response).code(404);
     } else {
       logger.warn(response);
+      // if reply(err) was used in handler (which is preferred) then response
+      // is a Boom-wrapped Error object - build the "full" stack (with cause)
+      // for npmo display (see templates/errors/internal.hbs)
+      if (feature('npmo')) response.npmoFullStack = utils.stackToString(response);
       return reply.view('errors/internal', response).code(500);
     }
   });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -37,4 +37,16 @@ utils.getUserIP = function(request) {
   return request.headers['fastly-client-ip'] || request.headers['x-forwarded-for'] || "unknown";
 };
 
+// stolen from bole private method of same name
+utils.stackToString = function stackToString (err) {
+  var stack = err.stack;
+  var cause;
+
+  if (typeof err.cause === 'function' && (cause = err.cause())) {
+    stack += '\nCaused by: ' + stackToString(cause);
+  }
+
+  return stack;
+};
+
 module.exports = utils;

--- a/services/npme/methods/verifyTrial.js
+++ b/services/npme/methods/verifyTrial.js
@@ -11,6 +11,11 @@ module.exports = function(verificationKey, callback) {
     json: true
   }, function(er, resp, trial) {
 
+    if (er) {
+      log.error('error finding verification key ' + verificationKey, er);
+      return callback(er);
+    }
+
     if (resp.statusCode === 404) {
       log.error('unable to find verification key ' + verificationKey);
 
@@ -31,7 +36,12 @@ module.exports = function(verificationKey, callback) {
     request.put({
       url: trialEndpoint + '/' + trial.id + '/verification',
       json: true
-    }, function(er, resp, verifiedTrial) {
+    }, function(err, resp, verifiedTrial) {
+
+      if (err) {
+        log.error('error starting trial, from hubspot', err);
+        return callback(err);
+      }
 
       if (resp.statusCode === 200) {
         return callback(null, verifiedTrial);

--- a/templates/errors/internal.hbs
+++ b/templates/errors/internal.hbs
@@ -8,7 +8,7 @@
   {{#if npmoFullStack}}
   <p>
     If you feel this error is the result of a bug, please email
-    <a href="mailto:support@npmjs.com">support@npmjs.com</a>
+    <a href="mailto:support@npmjs.com?subject=npm%20On-Site%20Error&body={{encode npmoFullStack}}">support@npmjs.com</a>
     and reference the following error:
   </p>
 

--- a/templates/errors/internal.hbs
+++ b/templates/errors/internal.hbs
@@ -1,10 +1,19 @@
-<div class="container narrow">
+<div class="container{{#unless npmoFullStack}} narrow{{/unless}}">
 
   <hgroup>
     <h1>{{t "errors.generic.title"}}</h1>
     <h2>{{t "errors.generic.subtitle"}}</h2>
   </hgroup>
 
+  {{#if npmoFullStack}}
+  <p>
+    If you feel this error is the result of a bug, please email
+    <a href="mailto:support@npmjs.com">support@npmjs.com</a>
+    and reference the following error:
+  </p>
+
+  <pre><code>{{npmoFullStack}}</code></pre>
+  {{else}}
   <p>
     If you feel this error is the result of a bug, please
     <a href="mailto:support@npmjs.com">email us</a>,
@@ -14,6 +23,7 @@
   </p>
 
   <pre><code>{{correlationID}}</code></pre>
+  {{/if}}
 
   <p>Be sure to let us know what you were doing and how you got here so we can help you as quickly as possible!</p>
 

--- a/templates/helpers/encode.js
+++ b/templates/helpers/encode.js
@@ -1,0 +1,3 @@
+module.exports = function (value) {
+  return encodeURIComponent(value);
+};

--- a/test/adapters/bonbon.js
+++ b/test/adapters/bonbon.js
@@ -40,7 +40,11 @@ before(function(done) {
     .get('/user/mikeal')
     .reply(404)
     .get('/user/bob/org').times(2)
-    .reply(401);
+    .reply(401)
+    .get('/package?sort=modified&count=12')
+    .reply(200, fixtures.aggregates.recently_updated_packages)
+    .get('/package?sort=dependents&count=12')
+    .reply(200, fixtures.aggregates.most_depended_upon_packages);
 
   licenseMock = nock('https://license-api-example.com')
     .get('/customer/bob/stripe').times(13)

--- a/test/enterprise/verification.js
+++ b/test/enterprise/verification.js
@@ -15,7 +15,7 @@ before(function(done) {
     server = obj;
     server.app.cache._cache.connection.client = {};
     done();
-  });
+  }, require('../../lib/error-handler'));
 });
 
 after(function(done) {

--- a/test/mocks/server.js
+++ b/test/mocks/server.js
@@ -1,7 +1,7 @@
 var path = require('path');
 var Hapi = require('hapi');
 
-module.exports = function(done) {
+module.exports = function(done, additionalPlugins) {
 
   var metrics = require('../../adapters/metrics')();
   var server = new Hapi.Server();
@@ -40,7 +40,7 @@ module.exports = function(done) {
       require('../../adapters/bonbon'),
       hackishMockRedis,
       require('hapi-stateless-notifications')
-    ], function(err) {
+    ].concat(additionalPlugins || []), function(err) {
       if (err) {
         throw err;
       }


### PR DESCRIPTION
Meant to address #1501.

Things changed:

- Error handling in `handlers/homepage.js` adds a `npmoFullStack` property to the view context
- The `templates/errors/internal.hbs` view renders slightly differently when the `npmoFullStack` context property is defined:
    - Uses `container` instead of `container narrow` class on outer div
    - Displays a slightly different message that displays the support@npmjs.com email and no longer mentions twitter or IRC
    - Displays full stack trace of error instead of just a correlation ID

Things still missing:

- [x] Apply `npmoFullStack` to view context for all npmo-relevant handlers that forward to the `errors/internal` view
- [x] Unit tests for view changes
- [x] Unit tests for handler changes
- [x] ~~Display license info (email address/billing id and license key) - _this data is currently not available in newww_~~ Out of scope
- [x] ~~Potentially provide a link/button to download the newww log file (not a requirement of #1501)~~ Out of scope

Things I don't like about the current implementation (and would like feedback on):

1. In order to provide a "full" stack trace to the user, I copied the private `stackToString` method from `bole` and stuck it in `lib/utils.js`. I figured it was either this or pull in another dependency.
2. Manually checking the `npmo` feature and applying the `npmoFullStack` to the view context in every handler seems clumsy/cumbersome. Is there a way to do this in a central place that automatically gets applied to a rendering of a specific view? I tried `adapters/bonbon.js` and `lib/error-handler.js` but the `stack` from the error seems to be lost by that point (inaccessible from `response.source.context`).

EDIT: I found a way to fix (2) above and centralize the logic in `lib/error-handler.js`, but it means changing handlers and facets to do `reply(err)` instead of `reply.view('errors/internal', err)`. That will be addressed by the first item in the todo list above.