### PR TITLE
Set up mechanism to prevent page indexing.

### DIFF
--- a/handlers/access.js
+++ b/handlers/access.js
@@ -10,6 +10,7 @@ module.exports = function(request, reply) {
     title: request.packageName + ": access",
     userHasReadAccessToPackage: false,
     userHasWriteAccessToPackage: false,
+    norobots: true,
   };
 
   var promise = Package(request.loggedInUser)

--- a/templates/layouts/default.hbs
+++ b/templates/layouts/default.hbs
@@ -12,6 +12,10 @@
     <meta name="twitter:description" content="{{package.description}}">
   {{/if}}
 
+  {{#if norobots}}
+    <meta name="robots" content="noindex">
+  {{/if}}
+
   <meta http-equiv="cleartype" content="on" />
 
   <meta name="apple-mobile-web-app-capable" content="no">


### PR DESCRIPTION
Also block the access pages from search engine indexing

If you Google "parse messy schedule" the first result is the Github repo and the second is the "access" page. The package page itself doesn't show up.

Since `access` is an administrative page without a lot of useful information for non-maintainers it shouldn't be indexed.