### PR TITLE
Remove newrelic module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ node_modules/
 .idea
 dump.rdb
 erl_crash.dump
-newrelic_agent.log
 npm-debug.log
 numbat.log
 numbat-config.js
@@ -13,4 +12,3 @@ config.admin.js
 static
 test/coverage.html
 *.swp
-newrelic.js

--- a/README.md
+++ b/README.md
@@ -158,13 +158,6 @@ If you have any trouble getting the site running locally, please [open an issue]
 * `HUBSPOT_PORTAL_ID`, the hubspot portal ID
 * `MAILCHIMP_KEY`, the mailchimp key
 
-## New Relic integration
-
-* `NEW_RELIC_LICENSE_KEY`, the license key
-* `NEW_RELIC_APP_NAME`, the app name
-* `NEW_RELIC_NO_CONFIG_FILE`, must be set to true because we provide config in the environment
-* `NEW_RELIC_ENABLED`, boolean
-
 ## Feature Flags
 
 * `FEATURE_ORG_BILLING`, users who are allowed to use Teams and Orgs

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "mousetrap": "0.0.1",
     "murmurhash": "0.0.2",
     "mustache-mailer": "^2.1.2",
-    "newrelic": "^1.22.2",
     "nib": "^1.1.0",
     "node-fetch": "^1.3.3",
     "node-uuid": "^1.4.3",

--- a/server.js
+++ b/server.js
@@ -1,5 +1,4 @@
 require("./lib/environment")();
-require("newrelic");
 
 var replify = require('replify');
 var bole = require('bole');


### PR DESCRIPTION
Undo #1417 and fix #1649. Removes the `newrelic` module and any mention of its requirements/resources.