### PR TITLE
Do not include hiring-container in search view for npmo mode

### DIFF
--- a/templates/registry/search.hbs
+++ b/templates/registry/search.hbs
@@ -51,7 +51,8 @@
   {{> pagination}}
 </div>
 
-<div class="sidebar">
-  <div class="hiring-container" data-template="vanilla"></div>
-</div>
-
+{{#unless features.npmo}}
+  <div class="sidebar">
+    <div class="hiring-container" data-template="vanilla"></div>
+  </div>
+{{/unless}}


### PR DESCRIPTION
Of the four templates that include a `.hiring-container` (for displaying a who's hiring list), only the package search result view (`templates/registry/search.hbs`) neglects the check for `features.npmo`.

This fixes that.