### PR TITLE
Give npmo its own default page title based on customer name

### DIFF
--- a/templates/layouts/default.hbs
+++ b/templates/layouts/default.hbs
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>{{#if title}}{{title}}{{#if q}}{{q}}{{/if}}{{else}}npm{{/if}}</title>
+  <title>{{#if title}}{{title}}{{#if q}}{{q}}{{/if}}{{else}}npm{{#if env.NPMO_COBRAND}} ♡ {{env.NPMO_COBRAND}}{{/if}}{{/if}}</title>
 
   {{#if package}}
     <meta name="description" content="{{package.description}}">


### PR DESCRIPTION
Makes it easier to distinguish between npm On-Site and the public registry site in browser tabs.

Plus it makes npmo that much more customized for our awesome customers!

Public registry tab:

<img width="272" alt="screen shot 2015-12-14 at 11 22 04 pm" src="https://cloud.githubusercontent.com/assets/1929625/11802013/ab7a88c2-a2b9-11e5-9b0d-58e1177bae37.png">

New and improved On-Site tab:

<img width="272" alt="screen shot 2015-12-14 at 11 21 27 pm" src="https://cloud.githubusercontent.com/assets/1929625/11802020/ba6b571c-a2b9-11e5-9692-8df3e148800e.png">
