### PR TITLE
Move to getLicenseForOrg from getLicenseIdForOrg

### DIFF
--- a/test/agents/customer.js
+++ b/test/agents/customer.js
@@ -395,60 +395,62 @@ describe("Customer", function() {
 
   });
 
-  describe("getLicenseIdForOrg", function() {
-    it('returns an error if there is no org with that name', function(done) {
+  describe("getLicenseForOrg", function() {
+    it('returns an error if customer does not exist', function(done) {
       var Customer = new CustomerAgent('bob');
       var customerMock = nock(Customer.host)
-        .get('/customer/bob/stripe/subscription')
+        .get('/customer/bob/stripe/subscription?org=bigco')
         .reply(404);
 
-      Customer.getLicenseIdForOrg('bigco', function(err, licenseId) {
+      Customer.getLicenseForOrg('bigco', function(err, license) {
         customerMock.done();
         expect(err).to.exist();
-        expect(err.message).to.equal('No org with that name exists');
-        expect(licenseId).not.exist();
+        expect(err.message).to.equal('Customer not found');
+        expect(license).to.not.exist();
         done();
       });
     });
 
-    it('returns an error if the org does not have a license id', function(done) {
+    it('returns an error if org does not exist', function(done) {
       var Customer = new CustomerAgent('bob');
       var customerMock = nock(Customer.host)
-        .get('/customer/bob/stripe/subscription')
-        .reply(200, [
-          {
-            "id": "sub_abcd",
-            "current_period_end": 1439766874,
-            "current_period_start": 1437088474,
-            "quantity": 2,
-            "status": "active",
-            "interval": "month",
-            "amount": 600,
-            "npm_org": "bigco",
-            "npm_user": "rockbot",
-            "product_id": "1031405a-70b7-4a3f-b557-8609d9e1428a"
-          }
-        ]);
+        .get('/customer/bob/stripe/subscription?org=bigco')
+        .reply(200, []);
 
-      Customer.getLicenseIdForOrg('bigco', function(err, licenseId) {
+      Customer.getLicenseForOrg('bigco', function(err, license) {
         customerMock.done();
         expect(err).to.exist();
-        expect(err.message).to.equal('That org does not have a license_id');
-        expect(licenseId).to.not.exist();
+        expect(err.statusCode).to.equal(404);
+        expect(err.message).to.equal('No license for org bigco found');
+        expect(license).to.not.exist();
         done();
       });
-    });
+    }) ;
 
-    it('gets the license id for an org', function(done) {
+
+    it('gets the license for an org', function(done) {
       var Customer = new CustomerAgent('bob');
       var customerMock = nock(Customer.host)
-        .get('/customer/bob/stripe/subscription')
-        .reply(200, fixtures.users.bobsubscriptions);
+        .get('/customer/bob/stripe/subscription?org=bigco')
+        .reply(200, [{
+          "amount": 700,
+          "cancel_at_period_end": false,
+          "current_period_end": 1451324640,
+          "current_period_start": 1448732640,
+          "id": "sub_6sc",
+          "interval": "month",
+          "license_id": 1,
+          "npm_org": "bigco",
+          "npm_user": "bob",
+          "product_id": "b5822d32",
+          "quantity": 8,
+          "status": "active"
+        }]);
 
-      Customer.getLicenseIdForOrg('bigco', function(err, licenseId) {
+      Customer.getLicenseForOrg('bigco', function(err, license) {
         customerMock.done();
         expect(err).to.be.null();
-        expect(licenseId).to.equal(1);
+        expect(license.license_id).to.equal(1);
         done();
       });
     });

--- a/test/fixtures/orgs.js
+++ b/test/fixtures/orgs.js
@@ -135,6 +135,21 @@ exports.bigcoSponsorships = [
   }
 ];
 
+exports.bobsBigcoSubscription = [{
+  "id": "sub_abcd",
+  "current_period_end": 1439766874,
+  "current_period_start": 1437088474,
+  "quantity": 2,
+  "status": "active",
+  "interval": "month",
+  "amount": 700,
+  "license_id": 1,
+  "npm_org": "bigco",
+  "npm_user": "bob",
+  "product_id": "1031405a-70b7-4a3f-b557-8609d9e1428a",
+  "cancel_at_period_end": false
+}];
+
 exports.bobsOrgSubscriptions = [
   {
     "amount": 700,

--- a/test/handlers/org.js
+++ b/test/handlers/org.js
@@ -947,7 +947,7 @@ describe('updating an org', function() {
         var licenseMock = nock("https://license-api-example.com")
           .get("/customer/bob/stripe")
           .reply(200, fixtures.customers.happy)
-          .get("/customer/bob/stripe/subscription")
+          .get("/customer/bob/stripe/subscription?org=bigco")
           .reply(200, []);
 
         var orgMock = nock("https://user-api-example.com")
@@ -998,7 +998,7 @@ describe('updating an org', function() {
           }, function(err, notice) {
             expect(err).to.not.exist();
             expect(notice.notices).to.be.array();
-            expect(notice.notices[0]).to.equal('No org with that name exists');
+            expect(notice.notices[0]).to.equal('No license for org bigco found');
             done();
           });
         });
@@ -1014,8 +1014,8 @@ describe('updating an org', function() {
         var licenseMock = nock("https://license-api-example.com")
           .get("/customer/bob/stripe")
           .reply(200, fixtures.customers.happy)
-          .get("/customer/bob/stripe/subscription")
-          .reply(200, fixtures.users.bobsubscriptions)
+          .get("/customer/bob/stripe/subscription?org=bigco")
+          .reply(200, fixtures.orgs.bobsBigcoSubscription)
           .put("/sponsorship/1", {
             "npm_user": "betty"
           })
@@ -1085,8 +1085,8 @@ describe('updating an org', function() {
         var licenseMock = nock("https://license-api-example.com")
           .get("/customer/bob/stripe")
           .reply(200, fixtures.customers.happy)
-          .get("/customer/bob/stripe/subscription")
-          .reply(200, fixtures.users.bobsubscriptions)
+          .get("/customer/bob/stripe/subscription?org=bigco")
+          .reply(200, fixtures.orgs.bobsBigcoSubscription)
           .put("/sponsorship/1", {
             "npm_user": "betty"
           })
@@ -1167,8 +1167,8 @@ describe('updating an org', function() {
         var licenseMock = nock("https://license-api-example.com")
           .get("/customer/bob/stripe")
           .reply(404)
-          .get("/customer/bob/stripe/subscription")
-          .reply(200, fixtures.users.bobsubscriptions)
+          .get("/customer/bob/stripe/subscription?org=bigco")
+          .reply(200, fixtures.orgs.bobsBigcoSubscription)
           .put("/sponsorship/1", {
             "npm_user": "betty"
           })
@@ -1234,8 +1234,8 @@ describe('updating an org', function() {
         var licenseMock = nock("https://license-api-example.com")
           .get("/customer/bob/stripe")
           .reply(404)
-          .get("/customer/bob/stripe/subscription")
-          .reply(200, fixtures.users.bobsubscriptions)
+          .get("/customer/bob/stripe/subscription?org=bigco")
+          .reply(200, fixtures.orgs.bobsBigcoSubscription)
           .put("/sponsorship/1", {
             "npm_user": "betty"
           })
@@ -1312,8 +1312,8 @@ describe('updating an org', function() {
         var licenseMock = nock("https://license-api-example.com")
           .get("/customer/bob/stripe")
           .reply(200, fixtures.customers.happy)
-          .get("/customer/bob/stripe/subscription")
-          .reply(404);
+          .get("/customer/bob/stripe/subscription?org=bigco")
+          .reply(200, []);
 
         var options = {
           url: "/org/bigco",
@@ -1348,7 +1348,7 @@ describe('updating an org', function() {
           }, function(err, notice) {
             expect(err).to.not.exist();
             expect(notice.notices).to.be.array();
-            expect(notice.notices[0]).to.equal('No org with that name exists');
+            expect(notice.notices[0]).to.equal("No license for org bigco found");
             done();
           });
         });
@@ -1364,8 +1364,8 @@ describe('updating an org', function() {
         var licenseMock = nock("https://license-api-example.com")
           .get("/customer/bob/stripe")
           .reply(200, fixtures.customers.happy)
-          .get("/customer/bob/stripe/subscription")
-          .reply(200, fixtures.users.bobsubscriptions)
+          .get("/customer/bob/stripe/subscription?org=bigco")
+          .reply(200, fixtures.orgs.bobsBigcoSubscription)
           .delete("/sponsorship/1/betty")
           .reply(404);
 
@@ -1418,8 +1418,8 @@ describe('updating an org', function() {
         var licenseMock = nock("https://license-api-example.com")
           .get("/customer/bob/stripe")
           .reply(200, fixtures.customers.happy)
-          .get("/customer/bob/stripe/subscription")
-          .reply(200, fixtures.users.bobsubscriptions)
+          .get("/customer/bob/stripe/subscription?org=bigco")
+          .reply(200, fixtures.orgs.bobsBigcoSubscription)
           .delete("/sponsorship/1/betty")
           .reply(200, {
             "created": "2015-08-05T20:55:54.759Z",
@@ -1487,8 +1487,8 @@ describe('updating an org', function() {
         var licenseMock = nock("https://license-api-example.com")
           .get("/customer/bob/stripe")
           .reply(200, fixtures.customers.happy)
-          .get("/customer/bob/stripe/subscription")
-          .reply(200, fixtures.users.bobsubscriptions)
+          .get("/customer/bob/stripe/subscription?org=bigco")
+          .reply(200, fixtures.orgs.bobsBigcoSubscription)
           .delete("/sponsorship/1/betty")
           .reply(200, {
             "created": "2015-08-05T20:55:54.759Z",
@@ -1539,8 +1539,8 @@ describe('updating an org', function() {
           .reply(200, fixtures.users.bob);
 
         var licenseMock = nock("https://license-api-example.com")
-          .get("/customer/bob/stripe/subscription")
-          .reply(200, fixtures.users.bobsubscriptions)
+          .get("/customer/bob/stripe/subscription?org=bigco")
+          .reply(200, fixtures.orgs.bobsBigcoSubscription)
           .get("/customer/bob/stripe")
           .reply(200)
           .delete("/sponsorship/1/betty")
@@ -1604,8 +1604,8 @@ describe('updating an org', function() {
         var licenseMock = nock("https://license-api-example.com:443")
           .get("/customer/bob/stripe")
           .reply(200)
-          .get("/customer/bob/stripe/subscription")
-          .reply(200, fixtures.users.bobsubscriptions)
+          .get("/customer/bob/stripe/subscription?org=bigco")
+          .reply(200, fixtures.orgs.bobsBigcoSubscription)
           .put("/sponsorship/1", {
             "npm_user": "betty"
           })
@@ -1664,8 +1664,8 @@ describe('updating an org', function() {
         var licenseMock = nock("https://license-api-example.com")
           .get("/customer/bob/stripe")
           .reply(404)
-          .get("/customer/bob/stripe/subscription")
-          .reply(200, fixtures.users.bobsubscriptions)
+          .get("/customer/bob/stripe/subscription?org=bigco")
+          .reply(200, fixtures.orgs.bobsBigcoSubscription)
           .delete("/sponsorship/1/betty")
           .reply(200, {
             "created": "2015-08-05T20:55:54.759Z",
@@ -1713,12 +1713,12 @@ describe('deleting an org', function() {
 
       var licenseMock = nock("https://license-api-example.com")
         .get("/customer/bob/stripe/subscription")
-        .reply(200, fixtures.users.bobsubscriptions)
+        .reply(200, fixtures.orgs.bobsOrgSubscriptions)
         .get("/customer/bob/stripe")
         .reply(404)
-        .delete("/customer/bob/stripe/subscription/sub_abcd")
+        .delete("/customer/bob/stripe/subscription/sub_12346")
         .reply(200, {
-          "id": "sub_abcd",
+          "id": "sub_12346",
           "current_period_end": 1439766874,
           "current_period_start": 1437088474,
           "quantity": 2,


### PR DESCRIPTION
We will frequently be needing to reference parts of the license instead of just the `license_id`. A highlight to this is that we can do this all in one call now, instead of having to make the call and then loop through.

Also:
Cleanup some linting errors on org handler
Update tests