### PR TITLE
A 409 is returned from the server in production

### DIFF
--- a/agents/customer.js
+++ b/agents/customer.js
@@ -326,9 +326,9 @@ Customer.prototype.acceptSponsorship = function(verificationKey, callback) {
         return reject(err);
       }
 
-      if (resp.statusCode === 409 || resp.statusCode === 500) {
+      if (resp.statusCode === 409) {
         err = Error('user is already sponsored');
-        err.statusCode = 403;
+        err.statusCode = resp.statusCode;
         return accept(err);
       }
 

--- a/handlers/org.js
+++ b/handlers/org.js
@@ -164,7 +164,7 @@ exports.addUserToOrg = function(request, reply) {
     .then(function(extendedSponsorship) {
       return request.customer.acceptSponsorship(extendedSponsorship.verification_key)
         .catch(function(err) {
-          if (err.statusCode !== 403) {
+          if (err.statusCode !== 409) {
             throw err;
           }
         });
@@ -251,7 +251,7 @@ exports.updateUserPayStatus = function(request, reply) {
       .then(function(extendedSponsorship) {
         return request.customer.acceptSponsorship(extendedSponsorship.verification_key)
           .catch(function(err) {
-            if (err.statusCode !== 403) {
+            if (err.statusCode !== 409) {
               throw err;
             }
           });


### PR DESCRIPTION
We no longer need this safeguard, and the 403 isn't the right error to
send back