### PR TITLE
adds classes to org nav to appease the newww-tests deity

### DIFF
--- a/templates/partials/org-nav.hbs
+++ b/templates/partials/org-nav.hbs
@@ -3,8 +3,8 @@
     <ul class="nav nav-4 clear" role="navigation">
       <li class="packages{{#if packages}} current{{/if}}"><a href="/org/{{org.info.name}}">{{pluralize org.packages.count "package" true}}</a></li>
       {{#if perms.isAtLeastMember}}
-        <li class="teams{{#if teams}}current{{/if}}"><a href="/org/{{org.info.name}}/teams">{{pluralize org.teams.count "team" true}}</a></li>
-        <li class="members{{#if members}}current{{/if}}"><a href="/org/{{org.info.name}}/members">{{pluralize org.users.count "member" true}}</a></li>
+        <li class="teams{{#if teams}} current{{/if}}"><a href="/org/{{org.info.name}}/teams">{{pluralize org.teams.count "team" true}}</a></li>
+        <li class="members{{#if members}} current{{/if}}"><a href="/org/{{org.info.name}}/members">{{pluralize org.users.count "member" true}}</a></li>
       {{/if}}
       {{#if perms.isSuperAdmin}}
         <li><a href="/settings/billing" class="payment-info">payment info</a></li>

--- a/templates/partials/org-nav.hbs
+++ b/templates/partials/org-nav.hbs
@@ -1,13 +1,13 @@
 <div class="tab-nav-container">
   <div class="nav-container nav-4-container">
     <ul class="nav nav-4 clear" role="navigation">
-      <li {{#if packages}}class="current"{{/if}}><a href="/org/{{org.info.name}}">{{pluralize org.packages.count "package" true}}</a></li>
+      <li class="packages{{#if packages}} current{{/if}}"><a href="/org/{{org.info.name}}">{{pluralize org.packages.count "package" true}}</a></li>
       {{#if perms.isAtLeastMember}}
-        <li {{#if teams}}class="current"{{/if}}><a href="/org/{{org.info.name}}/teams">{{pluralize org.teams.count "team" true}}</a></li>
-        <li {{#if members}}class="current"{{/if}}><a href="/org/{{org.info.name}}/members">{{pluralize org.users.count "member" true}}</a></li>
+        <li class="teams{{#if teams}}current{{/if}}"><a href="/org/{{org.info.name}}/teams">{{pluralize org.teams.count "team" true}}</a></li>
+        <li class="members{{#if members}}current{{/if}}"><a href="/org/{{org.info.name}}/members">{{pluralize org.users.count "member" true}}</a></li>
       {{/if}}
       {{#if perms.isSuperAdmin}}
-        <li><a href="/settings/billing">payment info</a></li>
+        <li><a href="/settings/billing" class="payment-info">payment info</a></li>
       {{/if}}
     </ul>
   </div>


### PR DESCRIPTION
there's a bug in the u2o newww-tests test, in which we need to click on the `members` tab to see the members in the org... but in order to click on the tab, we need some sort of defining characteristic; a class will do just the trick.