### PR TITLE
ensures charset=utf-8 on response headers (fixes #1301)

### DIFF
--- a/adapters/bonbon.js
+++ b/adapters/bonbon.js
@@ -104,6 +104,10 @@ exports.register = function(server, options, next) {
       case "view":
         request.response.source.context = Hoek.applyToDefaults(options, request.response.source.context);
         request.response.source.context.user = request.loggedInUser;
+
+        // appends charset to content-type header, for security reasons
+        request.response.type('text/html').charset('utf-8');
+
         break;
       case "plain":
         if (typeof (request.response.source) === "object") {
@@ -126,9 +130,6 @@ exports.register = function(server, options, next) {
         return reply(request.response.source.context);
       }
     }
-
-    // appends charset to content-type header, for security reasons
-    request.response.type('text/html').charset('utf-8');
 
     return reply.continue();
   });

--- a/test/adapters/bonbon.js
+++ b/test/adapters/bonbon.js
@@ -290,4 +290,13 @@ describe("bonbon", function() {
     });
   });
 
+  describe('headers', function() {
+    it('includes the charset=utf-8 header', function(done) {
+      server.inject('/', function(resp) {
+        expect(resp.headers['content-type']).to.equal('text/html; charset=utf-8');
+        done();
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
also reordered the lifecycle extensions to be [in order](http://hapijs.com/api#request-lifecycle).