### PR TITLE
Update npm-expansions to 2.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "normalize-license-data": "^1.0.1",
     "normalize-package-data": "^2.3.4",
     "npm-email-templates": "^1.9.2",
-    "npm-expansions": "^2.2.1",
+    "npm-expansions": "^2.2.3",
     "npm-explicit-installs": "^2.0.0",
     "npm-humans": "^2.13.1",
     "npm-package-arg": "^3.1.1",


### PR DESCRIPTION
We are deeply concerned that we are already in 2016, but **npm expansions** in the live website seem to be as old as from **August 14, 2015** ([version 2.2.1](https://github.com/npm/npm-expansions/tree/v2.2.1))!!!

This is absurdly unnaceptable. This utmost treasure of highest wisdom cannot be ignored and just wasted like this. We need urgent action!

The community is worried about current state of affairs: https://github.com/npm/npm-expansions/issues/881

**N**ow **P**lease **M**erge this Pull Request immediately so we can finally share these highly valuable contributions with the world.

In my humble opinion, not even an update to 2.2.3 is enough... this version is already 18 days old and we already have [26 new brilliant contributions](https://github.com/npm/npm-expansions/pulls) since then. @seldo could absorb these in a new 2.2.4 version so we may begin 2016 with the bleeding edge New Phantastic Meanings for npm.

Thank you.