### PR TITLE
Add restart button to payment info page

### DIFF
--- a/templates/org/payment-info.hbs
+++ b/templates/org/payment-info.hbs
@@ -30,6 +30,13 @@
       {{#if org.canceled}}
         <li>Next billing date: <strong>n/a</strong></li>
         <li>No payment on file</li>
+        <li>
+          <form action="/org/{{org.info.name}}" method="POST">
+            <input type="hidden" name="updateType" value="restartOrg">
+            {{> form_security}}
+            <button type="submit" class="btn-secondary link-btn">restart payment</button>
+          </form>
+        </li>
       {{else}}
       <li>Next billing date: <strong data-date="{{org.next_billing_date}}" data-date-format="%B %e, %Y">{{org.next_billing_date}}</strong></li>
         <li>Valid payment method ending in <a href="#">{{customer.card.last4}}</a></li>


### PR DESCRIPTION
This restarts payment on an organization for a customer that has not
deleted their account or the license for this (deleted by stopping
payment entirely)

Addresses #1708 