### PR TITLE
fix(CSS): change imports order since colors are needed by variables

### DIFF
--- a/assets/styles/index.styl
+++ b/assets/styles/index.styl
@@ -1,6 +1,8 @@
+// variables and reset depend on colors, so it should be imported first
+
+@import "colors"
 @import "variables"
 @import "reset"
-@import "colors"
 @import "typography"
 @import "icons"
 @import "iconic"


### PR DESCRIPTION
Hi

variables.styl needs the color `npmred`
https://github.com/npm/newww/blob/master/assets/styles/variables.styl#L54

reset.styl also need colors to define the `hr` element 
https://github.com/npm/newww/blob/master/assets/styles/reset.styl#L27

and the `body` element
https://github.com/npm/newww/blob/master/assets/styles/reset.styl#L74-L75

Therefore, colors.styl should be imported first.
