### PR TITLE
Use handlebars {{ instead of {{{ to escape html on package description

### DIFF
--- a/templates/package/access.hbs
+++ b/templates/package/access.hbs
@@ -2,7 +2,7 @@
   <h1 class="package-name centered">
     <a href="/package/{{name}}">{{name}}</a>
   </h1>
-  <p class="package-description centered">{{{description}}}</p>
+  <p class="package-description centered">{{description}}</p>
 {{/with}}
 
 {{> package-header package}}

--- a/templates/package/show.hbs
+++ b/templates/package/show.hbs
@@ -10,7 +10,7 @@
       <i class="icon-public"></i>
     {{/if}}
   </h1>
-  <p class="package-description">{{{description}}}</p>
+  <p class="package-description">{{description}}</p>
 
   <form class="star">
     <input type="hidden" name="name" value="{{name}}">


### PR DESCRIPTION
@aredridel I believe that this should fix https://github.com/npm/newww/issues/1730

I couldn't figure out how to run the site locally (I think it's still not possible) so I wasn't able to check for any unintended side effects. I don't think there would be as the only relevant difference between `{{{` and `{{` is that the latter escapes html and the former doesn't.