### PR TITLE
Don't call auth tokens one-time tokens

### DIFF
--- a/templates/user/tokens.hbs
+++ b/templates/user/tokens.hbs
@@ -7,7 +7,7 @@
   </hgroup>
 
   <p class="notice">
-    When you log into npm via the Command Line Interface (CLI), we create a unique, one-time identifier that we give to your computer, which is stored in your <a href="https://docs.npmjs.com/files/npmrc">.npmrc</a> file. The token gives your CLI the ability to do things like publish and unpublish packages, and manage owners and teams. You can share tokens with, for example, CI systems to allow them to download and publish your packages.</p>
+    When you log into npm via the Command Line Interface (CLI), we create a unique identifier that we give to your computer, which is stored in your <a href="https://docs.npmjs.com/files/npmrc">.npmrc</a> file. The token gives your CLI the ability to do things like publish and unpublish packages, and manage owners and teams. You can share tokens with, for example, CI systems to allow them to download and publish your packages.</p>
 
   <p class="notice">
     If you're not using a token any more, or the token got posted somewhere publicly where somebody unauthorized can use it, you should revoke that token. You can do that below. Once you've done so, anywhere that was using the token will need to get a new one, for instance by running `npm login` again.


### PR DESCRIPTION
Auth tokens generated via a cli log-in are not technically one-time
tokens.  They are multi-use tokens.

Very minor copy edit.  Not urgent.