### PR TITLE
added missed background color for form inputs

### DIFF
--- a/assets/styles/forms.styl
+++ b/assets/styles/forms.styl
@@ -38,6 +38,7 @@ textarea
   width 100%
   min-height 300px
   border-radius 4px
+  background-color background-color
   color text-color
   outline 0
   resize none
@@ -57,6 +58,7 @@ input[type=password]
   border 1px solid greigh5
   margin 0 0 20px
   border-radius 4px
+  background-color background-color
   color text-color
   outline 0
 


### PR DESCRIPTION
You can see how it is with dark system theme without background color:
![selection_001](https://cloud.githubusercontent.com/assets/799353/12375036/7615456a-bcc1-11e5-9e4c-1f94d5341f98.png)
![selection_002](https://cloud.githubusercontent.com/assets/799353/12375035/761437a6-bcc1-11e5-8096-8438f6d4fbd1.png)
