### PR TITLE
Add assertions for expanded email data to facet or handler tests that send email

### DIFF
--- a/test/company/contact-support.js
+++ b/test/company/contact-support.js
@@ -3,24 +3,55 @@ var Code = require('code'),
   lab = exports.lab = Lab.script(),
   describe = lab.experiment,
   before = lab.before,
+  afterEach = lab.afterEach,
   after = lab.after,
   it = lab.test,
   expect = Code.expect,
   generateCrumb = require("../handlers/crumb.js"),
+  emailMock,
   server;
 
 before(function(done) {
   require('../mocks/server')(function(obj) {
     server = obj;
+    emailMock = server.methods.email.send.mailConfig.mailTransportModule;
     server.app.cache._cache.connection.client = {};
     done();
   });
+});
+
+afterEach(function(done) {
+  emailMock.sentMail = [];
+  done();
 });
 
 after(function(done) {
   delete server.app.cache._cache.connection.client;
   server.stop(done);
 });
+
+function assertEmail (opts, expectedTo) {
+  var expectedFrom = 'website@npmjs.com';
+  var expectedText = opts.payload.message;
+  var expectedSubject = opts.payload.subject + ' - FROM: "' +
+    opts.payload.name + '" <' + opts.payload.email + '>';
+
+  var msg = emailMock.sentMail[0];
+  expect(msg.data.to).to.equal(expectedTo);
+  expect(msg.message._headers.find(function (header) {
+    return header.key === 'To';
+  }).value).to.equal(expectedTo);
+  expect(msg.data.from).to.equal(expectedFrom);
+  expect(msg.message._headers.find(function (header) {
+    return header.key === 'From';
+  }).value).to.equal(expectedFrom);
+  expect(msg.data.text).to.equal(expectedText);
+  expect(msg.message.content).to.equal(expectedText);
+  expect(msg.data.subject).to.equal(expectedSubject);
+  expect(msg.message._headers.find(function (header) {
+    return header.key === 'Subject';
+  }).value).to.equal(expectedSubject);
+}
 
 describe('getting contact info', function() {
   it('can be reached via the /contact route', function(done) {
@@ -152,19 +183,21 @@ describe('sending a contact email', function() {
         });
       });
     });
+  });
 
-    it("sends an email to security if it's a security inquiry", function(done) {
+  it("sends an email to security if it's a security inquiry", function(done) {
 
-      server.inject({
-        url: '/contact'
-      }, function(resp) {
-        var header = resp.headers['set-cookie'];
-        expect(header.length).to.equal(1);
+    server.inject({
+      url: '/contact'
+    }, function(resp) {
+      var header = resp.headers['set-cookie'];
+      expect(header.length).to.equal(1);
 
-        var cookieCrumb = header[0].match(/crumb=([^\x00-\x20\"\,\;\\\x7F]*)/)[1];
+      var cookieCrumb = header[0].match(/crumb=([^\x00-\x20\"\,\;\\\x7F]*)/)[1];
 
-        expect(resp.result).to.include('<input type="hidden" name="crumb" value="' + cookieCrumb + '"/>');
+      expect(resp.result).to.include('<input type="hidden" name="crumb" value="' + cookieCrumb + '"/>');
 
+      generateCrumb(server, function(crumb) {
         var opts = {
           url: '/send-contact',
           method: 'POST',
@@ -174,24 +207,35 @@ describe('sending a contact email', function() {
             subject: 'Hi!',
             inquire: 'security',
             message: 'This is a message.',
-            crumb: cookieCrumb
+            crumb: crumb
           },
           headers: {
-            cookie: 'crumb=' + cookieCrumb
+            cookie: 'crumb=' + crumb
           }
         };
 
         server.inject(opts, function(resp) {
           expect(resp.statusCode).to.equal(200);
           var source = resp.request.response.source;
-          expect(source).to.be.an.object();
-          expect(source.to).to.include('security@npmjs.com')
+          expect(source.template).to.equal('company/contact');
+          assertEmail(opts, 'security <security@npmjs.com>');
           done();
         });
       });
     });
+  });
 
-    it('sends an email to npm if it\'s a general inquiry', function(done) {
+  it('sends an email to npm if it\'s a general inquiry', function(done) {
+
+    server.inject({
+      url: '/contact'
+    }, function(resp) {
+      var header = resp.headers['set-cookie'];
+      expect(header.length).to.equal(1);
+
+      var cookieCrumb = header[0].match(/crumb=([^\x00-\x20\"\,\;\\\x7F]*)/)[1];
+
+      expect(resp.result).to.include('<input type="hidden" name="crumb" value="' + cookieCrumb + '"/>');
 
       generateCrumb(server, function(crumb) {
         var opts = {
@@ -214,6 +258,7 @@ describe('sending a contact email', function() {
           expect(resp.statusCode).to.equal(200);
           var source = resp.request.response.source;
           expect(source.template).to.equal('company/contact');
+          assertEmail(opts, 'npm <npm@npmjs.com>');
           done();
         });
       });

--- a/test/fixtures/enterprise.js
+++ b/test/fixtures/enterprise.js
@@ -8,7 +8,8 @@ exports.existingUser = {
   numemployees: '1-25',
   created: '2014-11-22T00:54:53.864Z',
   updated: '2015-03-13T00:09:47.632Z',
-  deleted: null
+  deleted: null,
+  verification_key: '12ab34cd-a123-4b56-789c-1de2deadbeef'
 };
 
 exports.newUser = {
@@ -18,7 +19,8 @@ exports.newUser = {
   phone: '123-456-7890',
   company: 'npm, Inc.',
   numemployees: '1-25',
-  comments: 'teehee'
+  comments: 'teehee',
+  verification_key: '12ab34cd-a123-4b56-789c-1de2deafbead'
 };
 
 exports.noLicenseUser = {
@@ -38,7 +40,7 @@ exports.licenseBrokenUser = {
 };
 
 exports.newTrial = {
-  customer_id: 'exists@bam.com',
+  customer_id: 'exists@bam.com'
 };
 
 exports.noCustomerTrial = {

--- a/test/mocks/server-methods.js
+++ b/test/mocks/server-methods.js
@@ -4,6 +4,8 @@ var crypto = require('crypto');
 var fixtures = require('../fixtures.js');
 var Promise = require('bluebird');
 var assert = require('assert');
+var sendEmail = require('../../services/email/methods/send');
+var MockTransport = require('nodemailer-mock-transport');
 
 module.exports = function(server) {
   var methods = {
@@ -68,14 +70,12 @@ module.exports = function(server) {
     email: {
       send: function(template, user, redis) {
         assert(typeof redis === 'object', 'whoops need redis');
-        return new Promise(function(resolve, reject) {
 
-          if (user.email === 'lolbad@email') {
-            return reject(new Error('no bueno yo'));
-          }
+        if (user.email === 'lolbad@email') {
+          return Promise.reject(new Error('no bueno yo'))
+        }
 
-          return resolve(null);
-        });
+        return sendEmail(template, user, redis);
       }
     },
 
@@ -188,6 +188,9 @@ module.exports = function(server) {
       setSession: require('../../services/user/methods/sessions').set
     }
   };
+
+  sendEmail.mailConfig.mailTransportModule = new MockTransport();
+  methods.email.send.mailConfig = sendEmail.mailConfig;
 
   return methods;
 };


### PR DESCRIPTION
Fixes #1710.

This is a precursor to npm/mustache-mailer#5 to guarantee that upstream dependency changes won't result in regression of email data and content sent by the app.

Note that these assertions are correct for existing functionality, even if some results are not as intended. These will be fixed after `mustache-mailer` is updated.