### PR TITLE
This fixes a possible viewing of the context' json

### DIFF
--- a/adapters/bonbon.js
+++ b/adapters/bonbon.js
@@ -114,7 +114,7 @@ exports.register = function(server, options, next) {
     // by adding a `?json` query parameter to the URL
     if ('json' in request.query &&
       Hoek.reach(request, 'response.source.context') &&
-      (process.env.NODE_ENV === "dev" || Hoek.reach(request, "loggedInUser.name") in humans)
+      (process.env.NODE_ENV === "dev" || humans.hasOwnProperty(Hoek.reach(request, "loggedInUser.name")))
     ) {
       if (request.query.json.length > 1) {
         // deep reference: ?json=profile.packages

--- a/test/adapters/bonbon.js
+++ b/test/adapters/bonbon.js
@@ -29,6 +29,8 @@ before(function(done) {
     .reply(200, fixtures.users.bob)
     .get('/user/seldo').times(3)
     .reply(200, fixtures.users.npmEmployee)
+    .get('/user/constructor')
+    .reply(200, fixtures.users.propName)
     .get('/user/bob/package?format=mini&per_page=100&page=0').times(10)
     .reply(200, fixtures.users.packages)
     .get('/user/bob/stars?format=detailed').times(10)
@@ -230,6 +232,22 @@ describe("bonbon", function() {
     });
   });
 
+  it('does not allow logged-in non-employees with obj prop names to request the view context', function(done) {
+
+    var options = {
+      url: '/~' + username1 + '?json',
+      credentials: fixtures.users.propName
+    };
+
+    expect(process.env.NODE_ENV).to.equal("production");
+    server.inject(options, function(resp) {
+      expect(resp.statusCode).to.equal(200);
+      expect(resp.headers['content-type']).to.match(/html/);
+      expect(resp.result).to.be.a.string();
+      done();
+    });
+  });
+
   it('does not allow anonymous fixtures.users to request the view context', function(done) {
 
     var options = {
@@ -245,6 +263,7 @@ describe("bonbon", function() {
       done();
     });
   });
+
 
   it('allows anyone to request the view context if NODE_ENV is `dev`', function(done) {
     process.env.NODE_ENV = "dev";

--- a/test/fixtures/users.js
+++ b/test/fixtures/users.js
@@ -214,6 +214,16 @@ exports.npmEmployee = {
   deleted: null
 };
 
+exports.propName = {
+  name: 'constructor',
+  email: 'proto@proto.com',
+  email_verified: null,
+  verification_key: '12345',
+  created: '2014-11-21T20:05:05.423Z',
+  updated: '2015-01-24T00:08:41.269Z',
+  deleted: null
+};
+
 exports.changePass = {
   current: '12345',
   new: 'abcde',


### PR DESCRIPTION
Users with names that are properties (lower-case only) on Object would
pass this test and be able to see the json we pass to the context. Using
`hasOwnProperty` instead of `in` fixes this