### PR TITLE
Fix drifting code bg when in overflowing pre

### DIFF
--- a/assets/styles/typography.styl
+++ b/assets/styles/typography.styl
@@ -173,7 +173,8 @@ code
 pre
   overflow-x auto
   code
-    display block
+    display inline-block
+    min-width 100%
     margin 0 0 15px 0
     padding 8px
     border-radius 2px


### PR DESCRIPTION
I'm not sure if this has been raised separately, but it's been bugging me for some time and I wanted to send a PR to fix it.

When there's an overflowing `pre` tag with `code` inside, the grey background drifts with the scroll, as per:

![before mp4](https://cloud.githubusercontent.com/assets/13700/12423353/fac94754-bec2-11e5-8ea9-244a3b8c2fa7.gif)

This change fixes the `code` element with a change to `display: inline-block` and `min-width: 100%` to ensure it stretches across both the width of the entire page (to emulate the `block` style) and the width of the overflowing `pre`, as per:

![after mp4](https://cloud.githubusercontent.com/assets/13700/12423383/1e922a70-bec3-11e5-9e87-7bad43f46dcf.gif)

Note that I took care to keep the scrollbar in it's position (with the white background), otherwise I think the CSS could be simplified (maybe).

Anyway... keep on doing the great stuff :heart: 

