### PR TITLE
Fix broken links in tutorial

### DIFF
--- a/templates/package/tutorial.hbs
+++ b/templates/package/tutorial.hbs
@@ -25,7 +25,7 @@
  		{{#if private}}
 	 		<h2>Installing {{package.name}}</h2>
 	 		<p>{{package.name}} is a private module. To add {{package.name}} to your local machine, check out this handy walk-through of private modules <a href="https://www.npmjs.com/private-modules">here</a></p>
-	 		<p>If you're having trouble installing packages, check out the helpful docs at <a>https://docs.npmjs.com/getting-started/installing-npm-packages-locally</a></p>
+			<p>If you're having trouble installing packages, check out the helpful docs for <a href="https://docs.npmjs.com/getting-started/installing-npm-packages-locally">installing npm packages locally</a></p>
  		{{/if}}
 
 		{{#unless private}} 		
@@ -34,7 +34,7 @@
 	 			<pre class='shell'>{{installCommand}}</pre>
 			{{/with}}
 			<p>To add this npm package to your local machine, type the above into your command line. You’ll notice a node_modules directory appear in your root where the package is now installed.<p>
-			<p>If you're having trouble installing packages, check out the helpful docs at <a>https://docs.npmjs.com/getting-started/installing-npm-packages-locally</a>
+			<p>If you're having trouble installing packages, check out the helpful docs for <a href="https://docs.npmjs.com/getting-started/installing-npm-packages-locally">installing npm packages locally</a></p>
 		{{/unless}}
 		
 		<h2>Other Nifty Commands</h2>


### PR DESCRIPTION
I found a link in the tutorial on `https://www.npmjs.com/package/{package}/tutorial` which wasn’t clickable. I also changed the text inside the link from being a URL to a more helpful human readable text. If you’d rather like a different text I’m ok with changing it :)

<img width="637" alt="issue" src="https://cloud.githubusercontent.com/assets/944406/12529784/44fa0908-c1c5-11e5-87e1-9a37db4452b6.png">

P.S. I found some weird mixture of spaces and tabs used for indentation which I didn’t change, but it might be worthwhile to look into.