### PR TITLE
Bump npm-email-templates dependency and update npmo requirements URL

### DIFF
--- a/facets/enterprise/buy-license.js
+++ b/facets/enterprise/buy-license.js
@@ -159,7 +159,7 @@ module.exports = function(request, reply) {
             var sendEmail = request.server.methods.email.send;
 
             var data = {
-              requirementsUrl: "https://docs.npmjs.com/enterprise/installation#requirements",
+              requirementsUrl: "https://docs.npmjs.com/enterprise/requirements",
               instructionsUrl: "https://docs.npmjs.com/enterprise/installation",
               name: customer.name,
               email: customer.email,

--- a/facets/enterprise/show-verification.js
+++ b/facets/enterprise/show-verification.js
@@ -53,7 +53,7 @@ module.exports = function verifyEnterpriseTrial(request, reply) {
           return;
         }
 
-        var requirementsUrl = "https://docs.npmjs.com/enterprise/installation#requirements",
+        var requirementsUrl = "https://docs.npmjs.com/enterprise/requirements",
           instructionsUrl = "https://docs.npmjs.com/enterprise/installation",
           license = licenses[0];
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "nodemailer-ses-transport": "^1.2.0",
     "normalize-license-data": "^1.0.1",
     "normalize-package-data": "^2.3.4",
-    "npm-email-templates": "^1.9.2",
+    "npm-email-templates": "^1.10.1",
     "npm-expansions": "^2.2.3",
     "npm-explicit-installs": "^2.0.0",
     "npm-humans": "^2.13.1",

--- a/test/enterprise/buy-license.js
+++ b/test/enterprise/buy-license.js
@@ -92,7 +92,7 @@ function assertEmail () {
   var expectedFrom = 'website@npmjs.com'; // fix with npm/mustache-mailer#5
   var expectedLicenseKey = '0feed16c-0f28-4911-90f4-dfe49f7bfb41';
   var expectedSupportEmail = 'support@npmjs.com';
-  var expectedRequirementsUrl = 'https://docs.npmjs.com/enterprise/installation#requirements';
+  var expectedRequirementsUrl = 'https://docs.npmjs.com/enterprise/requirements';
   var expectedInstructionsUrl = 'https://docs.npmjs.com/enterprise/installation';
 
   var msg = emailMock.sentMail[0];


### PR DESCRIPTION
Explicitly bump `npm-email-templates` to version `1.10.1` in order to pick up the latest [npmo welcome email](https://github.com/npm/email-templates/pull/21) (which is still not in staging or production for some reason).

Also update the URL we use for npmo installation requirements, which has its own page with updated content.