### PR TITLE
Bump mustache-mailer dependency and update email test assertions

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "month": "^1.0.0",
     "mousetrap": "0.0.1",
     "murmurhash": "0.0.2",
-    "mustache-mailer": "^2.1.2",
+    "mustache-mailer": "^3.0.0",
     "nib": "^1.1.0",
     "node-fetch": "^1.3.3",
     "node-uuid": "^1.4.3",

--- a/test/company/contact-support.js
+++ b/test/company/contact-support.js
@@ -31,7 +31,7 @@ after(function(done) {
 });
 
 function assertEmail (opts, expectedTo) {
-  var expectedFrom = 'website@npmjs.com';
+  var expectedFrom = '"npm, Inc. Support" <support@npmjs.com>';
   var expectedText = opts.payload.message;
   var expectedSubject = opts.payload.subject + ' - FROM: "' +
     opts.payload.name + '" <' + opts.payload.email + '>';

--- a/test/enterprise/buy-license.js
+++ b/test/enterprise/buy-license.js
@@ -89,7 +89,7 @@ function assertEmail () {
   var expectedName = 'Boom Bam';
   var expectedEmail = 'exists@bam.com';
   var expectedTo = '"' + expectedName + '" <' + expectedEmail + '>';
-  var expectedFrom = 'website@npmjs.com'; // fix with npm/mustache-mailer#5
+  var expectedFrom = '"npm, Inc." <website@npmjs.com>';
   var expectedLicenseKey = '0feed16c-0f28-4911-90f4-dfe49f7bfb41';
   var expectedSupportEmail = 'support@npmjs.com';
   var expectedRequirementsUrl = 'https://docs.npmjs.com/enterprise/requirements';

--- a/test/enterprise/find-license.js
+++ b/test/enterprise/find-license.js
@@ -35,7 +35,7 @@ after(function(done) {
 
 function assertEmail (expectedEmail, expectedVerificationKey) {
   var expectedTo = '"' + expectedEmail + '" <' + expectedEmail + '>';
-  var expectedFrom = 'website@npmjs.com';
+  var expectedFrom = '"npm, Inc." <website@npmjs.com>';
   var expectedSupportEmail = 'support@npmjs.com';
 
   var msg = emailMock.sentMail[0];

--- a/test/enterprise/trial-signup.js
+++ b/test/enterprise/trial-signup.js
@@ -36,7 +36,7 @@ function assertEmail () {
   var expectedName = 'Boom Bam';
   var expectedEmail = 'exists@bam.com';
   var expectedTo = '"' + expectedName + '" <' + expectedEmail + '>';
-  var expectedFrom = 'website@npmjs.com';
+  var expectedFrom = '"npm, Inc." <website@npmjs.com>';
   var expectedVerificationKey = '12ab34cd-a123-4b56-789c-1de2deadbeef';
   var expectedSupportEmail = 'support@npmjs.com';
 

--- a/test/enterprise/verification.js
+++ b/test/enterprise/verification.js
@@ -35,7 +35,7 @@ function assertEmail () {
   var expectedName = 'Boom Bam';
   var expectedEmail = 'exists@bam.com';
   var expectedTo = '"' + expectedName + '" <' + expectedEmail + '>';
-  var expectedFrom = 'website@npmjs.com'; // fix with npm/mustache-mailer#5
+  var expectedFrom = '"npm, Inc." <website@npmjs.com>';
   var expectedLicenseKey = '0feed16c-0f28-4911-90f4-dfe49f7bfb41';
   var expectedSupportEmail = 'support@npmjs.com';
 

--- a/test/handlers/user/email-edit.js
+++ b/test/handlers/user/email-edit.js
@@ -73,38 +73,40 @@ function assertEmail () {
   var expectedName = 'bob';
   var expectedEmailOld = 'bob@boom.me';
   var expectedEmailNew = 'new@boom.me';
-  var chgExpectedTo = '"' + expectedName + '" <' + expectedEmailOld + '>';
-  var newExpectedTo = '"' + expectedName + '" <' + expectedEmailNew + '>';
+  var expectedToRevert = '"' + expectedName + '" <' + expectedEmailOld + '>';
+  var expectedToConfirm = '"' + expectedName + '" <' + expectedEmailNew + '>';
   var expectedFrom = 'website@npmjs.com';
+  var expectedFromRevert = '"npm, Inc. support" <' + expectedFrom + '>';
+  var expectedFromConfirm = '"npm, Inc." <' + expectedFrom + '>';
   var expectedSupportEmail = 'support@npmjs.com';
 
-  var msgChange = emailMock.sentMail[0];
-  expect(msgChange.data.to).to.equal(chgExpectedTo);
-  expect(msgChange.message._headers.find(function (header) {
+  var msgRevert = emailMock.sentMail[0];
+  expect(msgRevert.data.to).to.equal(expectedToRevert);
+  expect(msgRevert.message._headers.find(function (header) {
     return header.key === 'To';
-  }).value).to.equal(chgExpectedTo);
-  expect(msgChange.data.from).to.equal(expectedFrom);
-  expect(msgChange.message._headers.find(function (header) {
+  }).value).to.equal(expectedToRevert);
+  expect(msgRevert.data.from).to.equal(expectedFromRevert);
+  expect(msgRevert.message._headers.find(function (header) {
     return header.key === 'From';
-  }).value).to.equal(expectedFrom);
-  expect(msgChange.message.content).to.match(new RegExp(expectedName));
-  expect(msgChange.message.content).to.match(new RegExp(expectedEmailOld));
-  expect(msgChange.message.content).to.match(new RegExp(expectedEmailNew));
-  expect(msgChange.message.content).to.match(new RegExp(expectedSupportEmail));
+  }).value).to.equal(expectedFromRevert);
+  expect(msgRevert.message.content).to.match(new RegExp(expectedName));
+  expect(msgRevert.message.content).to.match(new RegExp(expectedEmailOld));
+  expect(msgRevert.message.content).to.match(new RegExp(expectedEmailNew));
+  expect(msgRevert.message.content).to.match(new RegExp(expectedSupportEmail));
 
-  var msgNew = emailMock.sentMail[1];
-  expect(msgNew.data.to).to.equal(newExpectedTo);
-  expect(msgNew.message._headers.find(function (header) {
+  var msgConfirm = emailMock.sentMail[1];
+  expect(msgConfirm.data.to).to.equal(expectedToConfirm);
+  expect(msgConfirm.message._headers.find(function (header) {
     return header.key === 'To';
-  }).value).to.equal(newExpectedTo);
-  expect(msgNew.data.from).to.equal(expectedFrom);
-  expect(msgNew.message._headers.find(function (header) {
+  }).value).to.equal(expectedToConfirm);
+  expect(msgConfirm.data.from).to.equal(expectedFromConfirm);
+  expect(msgConfirm.message._headers.find(function (header) {
     return header.key === 'From';
-  }).value).to.equal(expectedFrom);
-  expect(msgNew.message.content).to.match(new RegExp(expectedName));
-  expect(msgNew.message.content).to.match(new RegExp(expectedEmailOld));
-  expect(msgNew.message.content).to.match(new RegExp(expectedEmailNew));
-  expect(msgNew.message.content).to.match(new RegExp(expectedSupportEmail));
+  }).value).to.equal(expectedFromConfirm);
+  expect(msgConfirm.message.content).to.match(new RegExp(expectedName));
+  expect(msgConfirm.message.content).to.match(new RegExp(expectedEmailOld));
+  expect(msgConfirm.message.content).to.match(new RegExp(expectedEmailNew));
+  expect(msgConfirm.message.content).to.match(new RegExp(expectedSupportEmail));
 }
 
 describe('Accessing the email-edit page', function() {

--- a/test/handlers/user/forgot-password.js
+++ b/test/handlers/user/forgot-password.js
@@ -52,7 +52,7 @@ function assertEmail () {
   var expectedName = 'bob';
   var expectedEmail = 'bob@boom.me';
   var expectedTo = '"' + expectedName + '" <' + expectedEmail + '>';
-  var expectedFrom = 'website@npmjs.com';
+  var expectedFrom = '"npm, Inc. support" <website@npmjs.com>';
   var expectedSupportEmail = 'support@npmjs.com';
 
   var msg = emailMock.sentMail[0];

--- a/test/handlers/user/resend-email-confirmation.js
+++ b/test/handlers/user/resend-email-confirmation.js
@@ -31,7 +31,7 @@ function assertEmail () {
   var expectedName = 'bob';
   var expectedEmail = 'bob@boom.me';
   var expectedTo = '"' + expectedName + '" <' + expectedEmail + '>';
-  var expectedFrom = 'website@npmjs.com';
+  var expectedFrom = '"npm, Inc." <website@npmjs.com>';
   var expectedSupportEmail = 'support@npmjs.com';
 
   var msg = emailMock.sentMail[0];

--- a/test/handlers/user/signup.js
+++ b/test/handlers/user/signup.js
@@ -49,7 +49,7 @@ function assertEmail () {
   var expectedName = 'mikeal';
   var expectedEmail = 'mikeal@president-of-javascript.com';
   var expectedTo = '"' + expectedName + '" <' + expectedEmail + '>';
-  var expectedFrom = 'website@npmjs.com';
+  var expectedFrom = '"npm, Inc." <website@npmjs.com>';
   var expectedSupportEmail = 'support@npmjs.com';
 
   var msg = emailMock.sentMail[0];


### PR DESCRIPTION
This is the final step in a long, drawn-out process to finally squash the `from: website@npmjs.com` problem with emails sent from newww (as described in npm/email-templates#18)! \o/

Previous steps leading to this point:
- [x] [add unit tests](https://github.com/npm/email-templates/pull/20) to npm/email-templates
- [x] [augment unit tests](https://github.com/npm/newww/pull/1761) in newww to assert on generated email content
- [x] [update mustache-mailer](https://github.com/npm/mustache-mailer/pull/5) to let meta template take precedence for data property naming collisions, like `from: "npm, Inc" <{{from}}>`
- [x] [test and fix](https://github.com/npm/email-templates/pull/25) any possible regressions introduced by the mustache-mailer update (before incorporating the update)
- [x] [bump npm-email-templates dep](https://github.com/npm/newww/pull/1798) in newww to avoid regressions
- [ ] finally bump mustache-mailer dep to fix the bug <-- this PR

Phew! I'll be glad when this is done :wink: