### PR TITLE
switch to new async npm-explicit-installs

### DIFF
--- a/handlers/homepage.js
+++ b/handlers/homepage.js
@@ -2,11 +2,8 @@ var P = require('bluebird');
 
 var feature = require('../lib/feature-flags.js');
 var PackageAgent = require('../agents/package');
-<<<<<<< HEAD
 var DownloadAgent = require('../agents/download');
-=======
 var ExplicitInstalls = require("npm-explicit-installs")
->>>>>>> update to async/up-to-date version of npm-explicit-installs
 
 var MINUTE = 60; // seconds
 var MODIFIED_TTL = 1 * MINUTE;

--- a/handlers/homepage.js
+++ b/handlers/homepage.js
@@ -2,7 +2,11 @@ var P = require('bluebird');
 
 var feature = require('../lib/feature-flags.js');
 var PackageAgent = require('../agents/package');
+<<<<<<< HEAD
 var DownloadAgent = require('../agents/download');
+=======
+var ExplicitInstalls = require("npm-explicit-installs")
+>>>>>>> update to async/up-to-date version of npm-explicit-installs
 
 var MINUTE = 60; // seconds
 var MODIFIED_TTL = 1 * MINUTE;
@@ -11,10 +15,7 @@ var DEPENDENTS_TTL = 30 * MINUTE;
 module.exports = function(request, reply) {
   var Package = new PackageAgent(request.loggedInUser);
   var Download = new DownloadAgent();
-  var context = {
-    explicit: require("npm-explicit-installs")
-  };
-
+  var context = {};
   var actions = {};
 
   actions.modified = Package.list({
@@ -25,6 +26,7 @@ module.exports = function(request, reply) {
     sort: "dependents",
     count: 12
   }, DEPENDENTS_TTL);
+  actions.explicit = ExplicitInstalls();
 
   if (!feature('npmo')) {
     actions.downloads = Download.getAll();
@@ -35,6 +37,7 @@ module.exports = function(request, reply) {
   }
 
   P.props(actions).then(function(results) {
+    context.explicit = results.explicit
     context.modified = results.modified;
     context.dependents = results.dependents;
     context.downloads = results.downloads;

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "normalize-package-data": "^2.3.4",
     "npm-email-templates": "^1.10.1",
     "npm-expansions": "^2.2.3",
-    "npm-explicit-installs": "^2.0.0",
+    "npm-explicit-installs": "^3.0.0",
     "npm-humans": "^2.13.1",
     "npm-marketing-sidebar-blob": "^1.1.0",
     "npm-package-arg": "^3.1.1",


### PR DESCRIPTION
This switches us to the new async version of `npm-explicit-installs`, this has some benefits:

* it now shows the actual publication dates/versions.
* it makes it easier to swap in a component fed by another data-source.