### PR TITLE
removes email service from plugins

### DIFF
--- a/adapters/plugins.js
+++ b/adapters/plugins.js
@@ -16,7 +16,6 @@ module.exports = [
   },
   require('../services/user'),
   require('../services/corporate'),
-  require('../services/email'),
   require('../services/npme'),
   {
     register: require('./bonbon'),


### PR DESCRIPTION
totally forgot to remove the email service from the plugins file (which is not tested via unit tests - another good thing about this transition away from non-hapi-based plugins).

whoops :-(