### PR TITLE
upgrade to new version of npm-explicit-installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "normalize-package-data": "^2.3.4",
     "npm-email-templates": "^1.10.1",
     "npm-expansions": "^2.2.3",
-    "npm-explicit-installs": "^3.0.0",
+    "npm-explicit-installs": "^3.1.0",
     "npm-humans": "^2.13.1",
     "npm-marketing-sidebar-blob": "^1.1.10",
     "npm-package-arg": "^3.1.1",

--- a/templates/homepage.hbs
+++ b/templates/homepage.hbs
@@ -41,7 +41,7 @@
 </h2>
 <ul class="columnar">
   {{#each explicit}}
-    <li>{{> package-widget}}</li>
+    <li>{{> package-widget npmo='{{../features.npmo}}'}}</li>
   {{/each}}
 </ul>
 

--- a/templates/homepage.hbs
+++ b/templates/homepage.hbs
@@ -87,7 +87,11 @@
 </h2>
 <ul class="columnar">
   {{#each modified.results}}
-    <li>{{> package-widget}}</li>
+    {{#if ../features.npmo}}
+      <li>{{> package-widget npmo='true' }}</li>
+    {{else}}
+      <li>{{> package-widget }}</li>
+    {{/if}}
   {{/each}}
 </ul>
 
@@ -96,7 +100,11 @@
 </h2>
 <ul class="columnar packages">
   {{#each dependents.results}}
-    <li>{{> package-widget}}</li>
+    {{#if ../features.npmo}}
+      <li>{{> package-widget npmo='true' }}</li>
+    {{else}}
+      <li>{{> package-widget }}</li>
+    {{/if}}
   {{/each}}
 </ul>
 

--- a/templates/homepage.hbs
+++ b/templates/homepage.hbs
@@ -41,7 +41,11 @@
 </h2>
 <ul class="columnar">
   {{#each explicit}}
-    <li>{{> package-widget npmo='{{../features.npmo}}'}}</li>
+    {{#if ../features.npmo}}
+      <li>{{> package-widget npmo='true' }}</li>
+    {{else}}
+      <li>{{> package-widget }}</li>
+    {{/if}}
   {{/each}}
 </ul>
 

--- a/templates/layouts/default.hbs
+++ b/templates/layouts/default.hbs
@@ -74,7 +74,7 @@
 
       <nav>
         <a href="https://docs.npmjs.com">docs</a>
-        <a href="/support">support</a>
+        <a href="mailto:support@npmjs.com">support</a>
       </nav>
 
     {{else}}

--- a/templates/partials/package-widget.hbs
+++ b/templates/partials/package-widget.hbs
@@ -26,11 +26,11 @@
         published
         <span data-date="{{lastPublishedAt}}" data-date-format="relative">{{lastPublishedAt}}</span>
         by
-        {{#unless npmo}}
-          <a href="/~{{publisher.name}}">{{publisher.name}}</a>
-        {{else}}
+        {{#if npmo}}
           <a href="/package/{{name}}">{{publisher.name}}</a>
-        {{/unless}}
+        {{else}}
+          <a href="/~{{publisher.name}}">{{publisher.name}}</a>
+        {{/if}}
       {{/if}} {{/if}}
 
     </p>

--- a/templates/partials/package-widget.hbs
+++ b/templates/partials/package-widget.hbs
@@ -26,7 +26,11 @@
         published
         <span data-date="{{lastPublishedAt}}" data-date-format="relative">{{lastPublishedAt}}</span>
         by
-        <a href="/~{{publisher.name}}">{{publisher.name}}</a>
+        {{#unless npmo}}
+          <a href="/~{{publisher.name}}">{{publisher.name}}</a>
+        {{else}}
+          <a href="/package/{{name}}">{{publisher.name}}</a>
+        {{/unless}}
       {{/if}} {{/if}}
 
     </p>

--- a/templates/partials/package-widget.hbs
+++ b/templates/partials/package-widget.hbs
@@ -27,7 +27,7 @@
         <span data-date="{{lastPublishedAt}}" data-date-format="relative">{{lastPublishedAt}}</span>
         by
         {{#if npmo}}
-          <a href="/package/{{name}}">{{publisher.name}}</a>
+          {{publisher.name}}
         {{else}}
           <a href="/~{{publisher.name}}">{{publisher.name}}</a>
         {{/if}}


### PR DESCRIPTION
I've upgraded to the newest version of `npm-explicit-installs`, this version:

* supports proxies (which is important for big companies).
* has a bin for editing the packages on the home-page (this is only important for `npmo`).
* I also fixed a display bug I noticed: npmo has no user pages, but we still linked to user-pages.