### PR TITLE
update to hapi 12.1.0 and attendant modules

### DIFF
--- a/adapters/plugins.js
+++ b/adapters/plugins.js
@@ -10,6 +10,7 @@ module.exports = [
   require('scooter'),
   require('inert'),
   require('vision'),
+  require('./qs'),
   {
     register: require('blankie'),
     options: require('../lib/csp').default

--- a/adapters/qs.js
+++ b/adapters/qs.js
@@ -1,0 +1,25 @@
+const Qs = require('qs');
+
+exports.register = function(server, options, next) {
+
+  const onPostAuth = function(request, reply) {
+
+    if (typeof request.payload === 'object' &&
+      !Buffer.isBuffer(request.payload)) {
+
+      request.payload = Qs.parse(request.payload);
+    }
+
+    return reply.continue();
+  };
+
+  server.ext('onPostAuth', onPostAuth);
+
+  next();
+
+};
+
+exports.register.attributes = {
+  name: 'qs',
+  version: '1.0.0'
+};

--- a/integration/user-to-org.js
+++ b/integration/user-to-org.js
@@ -39,7 +39,7 @@ require('./lib/sharedNemo').then(function(nemo) {
       .then(() => nemo.view.createOrg.cardExpYear().sendKeys(new Date().getFullYear() + 3))
       .then(() => t.pass("exp year entered"))
       .then(() => nemo.view.createOrg.paymentFormSubmit().click())
-      .then(() => nemo.view.createOrg.membersTabWaitVisible())
+      .then(() => nemo.view.createOrg.membersTabWaitVisible(30000))
       .then(() => t.pass("Org members page navigated to"))
       .then(() => nemo.view.createOrg.membersTab().click())
       .then(() => nemo.view.createOrg.orgInfoFirstUsernameWaitVisible())

--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
     "blankie": "^1.1.0",
     "bluebird": "^2.10.2",
     "bole": "~2.0.0",
-    "boom": "^2.9.0",
+    "boom": "^3.1.2",
     "catbox-redis": "^1.0.6",
     "chunk": "0.0.2",
-    "crumb": "^4.0.4",
+    "crumb": "^6.0.0",
     "debuglog": "^1.0.1",
     "dotenv": "^1.2.0",
     "elasticsearch": "~9.0.0",
@@ -50,7 +50,7 @@
     "gravatar": "^1.3.1",
     "handlebars": "^2.0.0",
     "handlebars-helper-pluralize": "^1.0.3",
-    "hapi": "^11.1.2",
+    "hapi": "^12.1.0",
     "hapi-auth-cookie": "2.0.0",
     "hapi-common-log": "^1.1.0",
     "hapi-stateless-notifications": "^2.1.0",
@@ -108,7 +108,7 @@
     "truncate": "^1.0.4",
     "validate-npm-package-name": "^2.2.0",
     "verror": "^1.6.1",
-    "vision": "^3.0.0"
+    "vision": "^4.0.1"
   },
   "devDependencies": {
     "bistre": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "nodemailer-ses-transport": "^1.2.0",
     "normalize-license-data": "^1.0.1",
     "normalize-package-data": "^2.3.4",
+    "npm": "^3.6.0",
     "npm-email-templates": "^1.10.1",
     "npm-expansions": "^2.2.3",
     "npm-explicit-installs": "^3.1.1",


### PR DESCRIPTION
Breaking changes are:
- move to ES6 in `vision` and `boom`
- stop using `qs` to parse URL parameters in hapi (we don't use any extended form parameters)
- change how `crumb` interacts with CORS, but we don't enable CORS at all