### PR TITLE
Adding rejection obj to catch promise-based errors

### DIFF
--- a/test/agents/team.js
+++ b/test/agents/team.js
@@ -3,13 +3,36 @@ var Code = require('code'),
   lab = exports.lab = Lab.script(),
   describe = lab.experiment,
   it = lab.test,
+  afterEach = lab.afterEach,
   expect = Code.expect,
   nock = require('nock'),
   fixtures = require('../fixtures');
 
 var Team = require('../../agents/team');
 
+var rejectionMap = {};
+
+process.on('unhandledRejection', function(reason, promise) {
+  rejectionMap[promise] = reason;
+});
+
+process.on('rejectionHandled', function(promise) {
+  delete rejectionMap[promise]
+  ;
+});
+
 describe('Team', function() {
+  afterEach(function(done) {
+    while (process.domain) {
+      process.domain.exit();
+    }
+    for (var xs in rejectionMap) {
+      if (rejectionMap.hasOwnProperty(xs)) {
+        throw rejectionMap[xs];
+      }
+    }
+    done();
+  });
   it('throws if no bearer is passed', function(done) {
     expect(function() {
       return Team();


### PR DESCRIPTION
These changes came about because there was a failing test, but it wasn't failing when we ran the tests, despite a "failing" print out.

This happens when a test fails inside of a catch block.

Let's make sure this doesn't happen again. Now tests that fail in the catch blocks will stop the test runner

The problem with change three is that it's a global change. We should talk about where that goes.