### PR TITLE
Update nock

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "lab": "^5.18.1",
     "nemo": "^1.0.6",
     "nemo-view": "^1.2.0",
-    "nock": "^3.6.0",
+    "nock": "^7.0.2",
     "nodemailer-mock-transport": "^1.2.0",
     "once": "^1.3.0",
     "redis-mock": "^0.4.9",


### PR DESCRIPTION
Nock was 4 major versions behind. This updates that. Updates to the tests can come as we create new tests.