### PR TITLE
Add new relic fe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ config.admin.js
 static
 test/coverage.html
 *.swp
+newrelic_agent.log

--- a/adapters/bonbon.js
+++ b/adapters/bonbon.js
@@ -6,7 +6,8 @@ var bole = require('bole'),
   featureFlag = require('../lib/feature-flags.js'),
   toCommonLogFormat = require('hapi-common-log'),
   url = require('url'),
-  User = require('../agents/user');
+  User = require('../agents/user'),
+  newrelic = require('newrelic');
 
 exports.register = function(server, options, next) {
 
@@ -84,7 +85,8 @@ exports.register = function(server, options, next) {
       env: {
         NPMO_COBRAND: process.env.NPMO_COBRAND,
         CANONICAL_HOST: process.env.CANONICAL_HOST
-      }
+      },
+      nreum: newrelic.getBrowserTimingHeader()
     };
 
     if (request.response && request.response.variety && request.response.variety.match(/view|plain/)) {

--- a/adapters/bonbon.js
+++ b/adapters/bonbon.js
@@ -18,7 +18,7 @@ exports.register = function(server, options, next) {
     // Generate `request.packageName` for global and scoped package requests
     if (request.params.package || request.params.scope) {
       request.packageName = request.params.package ||
-        request.params.scope + "/" + request.params.project;
+      request.params.scope + "/" + request.params.project;
     }
 
     request.metrics = metrics;

--- a/lib/csp.js
+++ b/lib/csp.js
@@ -4,6 +4,7 @@ csp.default = {
   defaultSrc: 'self',
   scriptSrc: [
     'self',
+    'unsafe-inline',
 
     // Hubspot
     'https://forms.hubspot.com/uploads/form/v2/419727/9a2b4ac5-ef09-43e6-854a-d82c92347c9d',
@@ -49,6 +50,11 @@ csp.default = {
 
     // Marketing Assets
     'https://assets.npmjs.com',
+
+    //new relic
+    'https://js-agent.newrelic.com',
+    'https://bam.nr-data.net',
+
   ],
   styleSrc: [
     'self',

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "mousetrap": "0.0.1",
     "murmurhash": "0.0.2",
     "mustache-mailer": "^3.0.0",
+    "newrelic": "^1.25.1",
     "nib": "^1.1.0",
     "node-fetch": "^1.3.3",
     "node-uuid": "^1.4.3",

--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
 require("./lib/environment")();
+require('newrelic');
 
 var replify = require('replify');
 var bole = require('bole');

--- a/templates/layouts/default.hbs
+++ b/templates/layouts/default.hbs
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  {{{ nreum }}}
   <title>{{#if title}}{{title}}{{#if q}}{{q}}{{/if}}{{else}}npm{{#if env.NPMO_COBRAND}} ♡ {{env.NPMO_COBRAND}}{{/if}}{{/if}}</title>
 
   {{#if package}}


### PR DESCRIPTION
This PR will allow us to handle performance monitoring with New Relic for both server and browser-side monitoring.

The major caveat at this point: the change to the csp allows unsafe-inline. This could be incredibly problematic.

I would like @evilpacket to take a look at this to see if there is a way we can make this work appropriately.

Environment variables that must be set for this to work:

```
NEW_RELIC_APP_NAME
NEW_RELIC_LICENSE_KEY
NEW_RELIC_LOG_LEVEL
NEW_RELIC_NO_CONFIG_FILE
```

