### PR TITLE
Show OSI logo on open source package pages

### DIFF
--- a/assets/images/osi.svg
+++ b/assets/images/osi.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="582.55762"
+   height="563.99841"
+   id="svg3290">
+  <defs
+     id="defs3292" />
+  <metadata
+     id="metadata3295">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-91.239607,-108.24463)"
+     id="layer1">
+    <g
+       transform="matrix(3.1607572,0,0,3.1607572,1289.8039,2829.9529)"
+       id="g3879"
+       style="display:inline">
+      <path
+         d="m -287.05192,-768.95371 m 11.01179,28.68474 a 30.724865,30.724865 0 1 0 -22.02358,0 l -20.69627,53.92828 a 88.487611,88.487611 0 1 1 63.41612,0 z"
+         id="path3773"
+         style="text-anchor:middle;fill:#3fa652;stroke:#21552a;stroke-width:7.37396765;stroke-linejoin:round" />
+    </g>
+  </g>
+</svg>

--- a/assets/styles/typography.styl
+++ b/assets/styles/typography.styl
@@ -234,3 +234,8 @@ pre
 
 pre.shell:before
   content "$ "
+
+.osi
+  display: inline-block
+  img
+    height: 16px

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "require-tree": "^1.1.0",
     "schemeless": "^1.1.1",
     "scooter": "^2.0.1",
+    "spdx-is-osi": "^0.1.2",
     "spdx-to-html": "^0.3.1",
     "steeltoe": "^1.0.1",
     "stripe": "^2.9.0",

--- a/presenters/package.js
+++ b/presenters/package.js
@@ -4,6 +4,7 @@ var _ = require('lodash'),
   gh = require('github-url-to-object'),
   marky = require('marky-markdown'),
   metrics = require('../adapters/metrics')(),
+  osiApproved = require('spdx-is-osi'),
   P = require('bluebird'),
   presentCollaborator = require("./collaborator"),
   presentUser = require("./user"),
@@ -31,7 +32,16 @@ module.exports = function(pkg) {
       delete pkg.license;
     } else {
       if (valid.spdx) {
-        pkg.license = {links: spdxToHTML(pkg.license)};
+        var osi
+        try {
+          osi = osiApproved(pkg.license);
+        } catch (e) {
+          osi = false;
+        }
+        pkg.license = {
+          links: spdxToHTML(pkg.license),
+          osi: osi
+        };
       } else if (valid.inFile) {
         pkg.license = {string: 'See license in ' + valid.inFile};
       } else {

--- a/templates/package/show.hbs
+++ b/templates/package/show.hbs
@@ -99,6 +99,12 @@
         {{#if license.string}}
           {{license.string}}
         {{/if}}
+        {{#if license.osi}}
+          <span class="osi">
+            <img alt="Licensed on OSI-approved terms"
+                 src="/static/images/osi.svg"/>®
+          </span>
+        {{/if}}
       </li>
     {{/if}}
   </ul>


### PR DESCRIPTION
This relatively small PR attempts to add a small green OSI circle logo (and accompanying trademark symbol) beside the license information of packages that are licensed on OSI-approved ("open source") terms.

I am not sure that I went about the presentation side of things correctly, and will add a few line comments here and there. I'm flying blind without a full test env, but think I've at least got kinda-sorta close to something presentable.

Thanks to all!