### PR TITLE
Move OSI logo before package license links

### DIFF
--- a/templates/package/show.hbs
+++ b/templates/package/show.hbs
@@ -93,14 +93,14 @@
 
     {{#if license}}
       <li>
+        {{#if license.osi}}
+          <img class="osi" alt="Licensed on OSI-approved terms" src="/static/images/osi.svg">®
+        {{/if}}
         {{#if license.links}}
           {{{license.links}}}
         {{/if}}
         {{#if license.string}}
           {{license.string}}
-        {{/if}}
-        {{#if license.osi}}
-          <img class="osi" alt="Licensed on OSI-approved terms" src="/static/images/osi.svg">®
         {{/if}}
       </li>
     {{/if}}


### PR DESCRIPTION
Following on from #1879.

This tiny PR moves the OSI logo on package pages _before_ links to license terms.

Visually, this is more in-line with the tiny avatars for publishers and the download icon before `npm install $thepackage`.