### PR TITLE
Break long package names

### DIFF
--- a/assets/styles/typography.styl
+++ b/assets/styles/typography.styl
@@ -182,6 +182,7 @@ pre
 &.package-name
   padding-bottom 0
   padding-right 25px
+  word-break: break-word;
   a
     color text-color
     text-decoration none


### PR DESCRIPTION
Break long package names so they won't extend past the viewport.

Example: https://www.npmjs.com/package/ifyouwanttogetthesumoftwonumberswherethosetwonumbersarechosenbyfindingthelargestoftwooutofthreenumbersandsquaringthemwhichismultiplyingthembyitselfthenyoushouldinputthreenumbersintothisfunctionanditwilldothatforyou