### PR TITLE
Make code blocks the same font-size

### DIFF
--- a/assets/styles/typography.styl
+++ b/assets/styles/typography.styl
@@ -160,6 +160,7 @@ p
 strong
   &.code
     code-font()
+    font-size .9em
 
 blockquote
   padding 0 15px
@@ -169,6 +170,7 @@ blockquote
 code
   code-font()
   background-color #F5F5F5
+  font-size .9em
 
 pre
   overflow-x auto
@@ -178,6 +180,7 @@ pre
     margin 0 0 15px 0
     padding 8px
     border-radius 2px
+    font-size .9em
 
 &.package-name
   padding-bottom 0


### PR DESCRIPTION
This is my first PR to a public project, so apologies if I'm doing this wrong!

### Summary
**Issue**: When `code` blocks are inserted in `p` blocks, the difference in x-height make it look odd.
**Proposal**: Make `code` blocks slightly smaller to visually match the x-height of its siblings.

### Screenshots
#### Before
![screen shot 2016-02-29 at 12 06 40 pm](https://cloud.githubusercontent.com/assets/748504/13407677/8fccce76-dede-11e5-83f0-05ed2cdb5bc1.png)

#### After
![screen shot 2016-02-29 at 12 06 31 pm](https://cloud.githubusercontent.com/assets/748504/13407678/9226c758-dede-11e5-8ef4-4cf6f69d1c6d.png)