### PR TITLE
Allow for keywords to be links, just like in other keyword lists

### DIFF
--- a/templates/registry/search.hbs
+++ b/templates/registry/search.hbs
@@ -34,11 +34,7 @@
               <p class="keywords">
                 <i class="icon-tag"></i>
                 {{#each keywords}}
-                  {{#if @last}}
-                    {{this}}
-                  {{else}}
-                    {{this}},&nbsp;
-                  {{/if}}
+                  <a href="/browse/keyword/{{this}}" title="{{this}}">{{this}}</a>{{#unless @last}},&nbsp;{{/if}}
                 {{/each}}
               </p>
             {{/if}}


### PR DESCRIPTION
See: https://github.com/npm/newww/blob/master/templates/helpers/packageKeywords.js#L10-L15

Not quite sure on the hbs syntax, honestly.