### PR TITLE
Adds a tiny Snyk vuln integration

### DIFF
--- a/assets/scripts/snyk.js
+++ b/assets/scripts/snyk.js
@@ -1,0 +1,76 @@
+var snyk = module.exports = function () {
+  $(snyk.init);
+  return snyk;
+};
+
+snyk.api = 'https://snyk.io/api/v1/';
+
+snyk.init = function() {
+  snyk.element = $('#snyk_vulns');
+
+  // check that the element includes everything we need to perform the XHR
+  // request for vulnerabilities
+  if (!snyk.element.length) {
+    return;
+  }
+
+  var data = snyk.element.data();
+
+  if (!data.name) {
+    return;
+  }
+
+  // kick off XHR requests
+  snyk.getVulnerabilities(data.name);
+};
+
+snyk.getVulnerabilities = function (pkg) {
+  var root = snyk.api + 'vuln/npm';
+
+  return $.getJSON(root + '/' + pkg).done(function (res) {
+    var vulns = {
+      vulns: 0,
+      directVulns: 0,
+      depVulns: 0
+    };
+
+    if (!res.ok) {
+      // I wanted to use .reduce here, but wasn't sure about target support
+      // and couldn't find any other use of reduce in the asset/scripts dir
+      // so using .forEach (also appears in star.js).
+      res.vulnerabilities.forEach(function (curr) {
+        vulns.vulns++;
+
+        if (curr.from.length === 1) {
+          vulns.directVulns++;
+        } else {
+          vulns.depVulns++;
+        }
+
+        return vulns;
+      });
+    }
+
+    var label = vulns.depVulns + ' vulnerable ' + pl('dependency', vulns.depVulns);
+    if (vulns.vulns === 0) {
+      label = 'No known vulnerabilities';
+    } else if (vulns.directVulns) {
+      label = vulns.directVulns + ' known ' + pl('vulnerability', vulns.directVulns);
+    }
+
+    // double check in case we've been called directly
+    if (snyk.element.length) {
+      snyk.element.find('span').show();
+      snyk.element.find('a').text(label);
+    } else {
+      return label;
+    }
+  });
+};
+
+function pl(word, count) {
+  if (count > 1) {
+    return word.slice(0, -1) + 'ies';
+  }
+  return word;
+}

--- a/assets/scripts/snyk.js
+++ b/assets/scripts/snyk.js
@@ -16,18 +16,20 @@ snyk.init = function() {
 
   var data = snyk.element.data();
 
-  if (!data.name) {
+  if (!data.name || !data.version) {
     return;
   }
 
   // kick off XHR requests
-  snyk.getVulnerabilities(data.name);
+  snyk.getVulnerabilities(data);
 };
 
 snyk.getVulnerabilities = function (pkg) {
   var root = snyk.api + 'vuln/npm';
+  var name = pkg.name;
+  var version = pkg.version;
 
-  return $.getJSON(root + '/' + pkg).done(function (res) {
+  return $.getJSON(root + '/' + name + '/' + version).done(function (res) {
     var vulns = {
       vulns: 0,
       directVulns: 0,

--- a/lib/csp.js
+++ b/lib/csp.js
@@ -62,6 +62,7 @@ csp.default = {
     'https://typeahead.npmjs.com/',
     'https://partners.npmjs.com/',
     'https://checkout.stripe.com/api/outer/manhattan',
+    'https://snyk.io/api/v1/vuln/npm',
     'https://api.github.com',
     'https://ac.cnstrc.com',
     'https://*.log.optimizely.com',

--- a/templates/package/show.hbs
+++ b/templates/package/show.hbs
@@ -177,8 +177,8 @@
       {{/if}}
 
       {{#unless private}}
-      <li id="snyk_vulns" data-name="{{name}}">
-        <a href="https://snyk.io/test/npm/{{name}}">Test for vulnerabilities</a> <span style="display:none">found</span> with Snyk
+      <li id="snyk_vulns" data-name="{{name}}" data-version="{{version}}">
+        <a href="https://snyk.io/test/npm/{{name}}/{{version}}">Test for vulnerabilities</a> <span style="display:none">found</span> with Snyk
       </li>
       {{/if}}
     </ul>

--- a/templates/package/show.hbs
+++ b/templates/package/show.hbs
@@ -176,6 +176,11 @@
         </li>
       {{/if}}
 
+      {{#unless private}}
+      <li id="snyk_vulns" data-name="{{name}}">
+        <a href="https://snyk.io/test/npm/{{name}}">Test for vulnerabilities</a> <span style="display:none">found</span> with Snyk
+      </li>
+      {{/if}}
     </ul>
   {{/if}}
 


### PR DESCRIPTION
For context: @guypod had spoken ahead of time to @seldo about and suggesting that Snyk send in a PR that adds vulnerability reporting alongside npm packages, so here it is.

Also, I know from @stubbornella over Twitter that there's a refactor going on in the code, and I'm more than happy to bring this code inline with any updates.

---

This mimics the github code fairly closely: has a (working link) placeholder to check for vulns for the specific package, then if JS is available, it'll make an XHR request to Snyk's API and update with any vulns in the package.

The link has a number of states (bracket denote a link):

- [Test for vulnerabilities] with Snyk (non JS state)
- [No known vulnerabilities] found with Snyk
- [1 vulnerable dependency] found with Snyk (package has vulns in dependencies)
- [4 vulnerable dependencies] found with Snyk
- [1 known vulnerability] found with Snyk (package *is* vulnerable)
- [5 known vulnerabilities] found with Snyk

In all cases, the URL will link to `https://snyk.io/test/npm/{{name}}` - i.e. this is the URL that I've included screenshots for https://snyk.io/test/npm/snyk-demo-app

This change also updates the csp to include snyk.io's specific npm API endpoint in the `connectSrc` list.

Note that scoped packages also work as expected. 

#### Screenshots

##### Pre-JavaScript

![snyk-npm](https://cloud.githubusercontent.com/assets/13700/13893676/7e9332ca-ed58-11e5-94c1-8a409405c065.png)

##### Vulns in dependencies

<img width="377" alt="screen shot 2016-03-18 at 15 22 02" src="https://cloud.githubusercontent.com/assets/13700/13886307/465c3a98-ed2e-11e5-89a7-c60e708b3f03.png">

##### Vulns found directly in package

<img width="393" alt="screen shot 2016-03-18 at 15 27 14" src="https://cloud.githubusercontent.com/assets/13700/13886318/53ca6b0a-ed2e-11e5-8768-a3c4d99a568b.png">

##### No vulns found

<img width="376" alt="screen shot 2016-03-18 at 15 24 06" src="https://cloud.githubusercontent.com/assets/13700/13886338/5abe7ac8-ed2e-11e5-9a51-2656019a45fd.png">

#### A note about tests

I'm more than happy to add tests, but I couldn't find anything to use as a starting point. I found the integration tests, but these focus around user actions (understandably) like logout, org creation etc. I'm also not sure if the integration tests actually have a package URL that works (i.e. if it's being tested with browserstack). Certainly when I clone the repo I knew that I wouldn't be able to fully see the package pages (I tested live in the browser - not ideal, but doable).

I'll take any advice or direction on tests if there is any.