### PR TITLE
get a job => get hired

### DIFF
--- a/templates/homepage.hbs
+++ b/templates/homepage.hbs
@@ -75,7 +75,7 @@
 
   {{#unless features.npmo}}
     <li>
-      <h3><a href="/whoshiring">get a job</a></h3>
+      <h3><a href="/whoshiring">get hired</a></h3>
       <div class="hiring-container" data-template="vanilla"></div>
     </li>
   {{/unless}}


### PR DESCRIPTION
At least in Australia, "get a job" is quite insulting... it is only ever used to imply someone is a homeless bum that is draining the economy... especially as the presupposition of it is that you don't have a job, so such connotations are reasonably expected... "get hired" is a good alternative that doesn't imply such a thing, as the presupposition is just you want to be hired, rather than you are missing anything.