### PR TITLE
Revert "Use handlebars {{ instead of {{{ to escape html on package description"

### DIFF
--- a/templates/package/access.hbs
+++ b/templates/package/access.hbs
@@ -2,7 +2,7 @@
   <h1 class="package-name centered">
     <a href="/package/{{name}}">{{name}}</a>
   </h1>
-  <p class="package-description centered">{{description}}</p>
+  <p class="package-description centered">{{{description}}}</p>
 {{/with}}
 
 {{> package-header package}}

--- a/templates/package/show.hbs
+++ b/templates/package/show.hbs
@@ -10,7 +10,7 @@
       <i class="icon-public"></i>
     {{/if}}
   </h1>
-  <p class="package-description">{{description}}</p>
+  <p class="package-description">{{{description}}}</p>
 
   <form class="star">
     <input type="hidden" name="name" value="{{name}}">


### PR DESCRIPTION
Reverts #1731 to fix #1789

Reasoning is pretty much [here](https://github.com/npm/newww/issues/1789#issuecomment-223802559). TL;DR: That change broke about 1 % of package descriptions *and* didn’t even make the package description which was supposed to be fixed by #1731 render correctly (i.e. as intended by the author).